### PR TITLE
[Spec 0013][Phase 1] RDS IAM-auth connection adapter

### DIFF
--- a/lavandula/common/db.py
+++ b/lavandula/common/db.py
@@ -1,0 +1,174 @@
+"""RDS Postgres connection adapter with IAM DB auth.
+
+Implements the password-as-function / per-connection-token-injection
+architecture from `@elationfactory/database-access` (JS), condensed to
+the SQLAlchemy idiom. The engine and its pool are created once at
+startup; each physical connection opened by the pool receives a fresh
+IAM auth token via the `do_connect` event. Tokens are cached with an
+8-minute TTL (AWS issues 15-minute tokens).
+
+Usage
+-----
+    from lavandula.common.db import make_app_engine
+    engine = make_app_engine()
+    with engine.connect() as conn:
+        conn.execute(text("SELECT 1"))
+
+Production SSM keys (flat-hyphenated, under
+`/cloud2.lavandulagroup.com/`):
+
+    rds-endpoint, rds-port, rds-database, rds-schema,
+    rds-app-user, rds-ro-user
+"""
+from __future__ import annotations
+
+import threading
+import time
+from typing import Any
+
+from sqlalchemy import create_engine, event
+from sqlalchemy.engine import Engine
+
+
+_REGION = "us-east-1"
+
+
+class IAMTokenManager:
+    """Thread-safe cache for RDS IAM DB auth tokens (8-minute TTL).
+
+    The AWS token is valid for 15 minutes. We refresh at 8 minutes to
+    leave headroom for long-running connections. The cache is shared
+    across threads behind a single lock; the token-generation call is
+    fast (local SigV4 signing) so serialising it is acceptable.
+    """
+
+    _REFRESH_AFTER_SEC = 8 * 60  # 8 minutes
+
+    def __init__(
+        self,
+        *,
+        region: str,
+        host: str,
+        port: int,
+        user: str,
+        rds_client: Any | None = None,
+        clock: Any = time.time,
+    ) -> None:
+        if rds_client is None:
+            import boto3
+            rds_client = boto3.client("rds", region_name=region)
+        self._rds = rds_client
+        self._region = region
+        self._host = host
+        self._port = port
+        self._user = user
+        self._clock = clock
+        self._token: str | None = None
+        self._expires_at: float = 0.0
+        self._lock = threading.Lock()
+
+    def token(self) -> str:
+        with self._lock:
+            now = self._clock()
+            if self._token is not None and now < self._expires_at:
+                return self._token
+            self._token = self._rds.generate_db_auth_token(
+                DBHostname=self._host,
+                Port=self._port,
+                DBUsername=self._user,
+                Region=self._region,
+            )
+            self._expires_at = now + self._REFRESH_AFTER_SEC
+            return self._token
+
+
+def make_engine(
+    *,
+    host: str,
+    port: int,
+    database: str,
+    user: str,
+    region: str = _REGION,
+    schema: str | None = None,
+    pool_size: int = 5,
+    max_overflow: int = 10,
+    token_manager: IAMTokenManager | None = None,
+) -> Engine:
+    """Build a SQLAlchemy engine that authenticates via RDS IAM tokens.
+
+    The returned engine holds a single long-lived connection pool. A
+    `do_connect` event listener injects a fresh IAM token as the
+    password each time the pool opens a new physical connection.
+    `pool_pre_ping=True` handles mid-connection token expiry: if a
+    pooled connection has been idle long enough for its session to
+    drop, the pre-ping fails, the pool discards it, and a new
+    connection opens with a current token.
+
+    Parameters
+    ----------
+    host, port, database, user : connection target.
+    region : AWS region for IAM token generation.
+    schema : optional Postgres `search_path` applied on connect.
+    pool_size, max_overflow : SQLAlchemy pool sizing.
+    token_manager : injection point for tests.
+    """
+    mgr = token_manager or IAMTokenManager(
+        region=region, host=host, port=port, user=user,
+    )
+
+    url = (
+        f"postgresql+psycopg2://{user}@{host}:{port}/{database}"
+        f"?sslmode=require"
+    )
+    engine = create_engine(
+        url,
+        pool_size=pool_size,
+        max_overflow=max_overflow,
+        pool_pre_ping=True,
+        pool_recycle=8 * 60,
+    )
+
+    @event.listens_for(engine, "do_connect")
+    def _inject_iam_token(dialect, conn_rec, cargs, cparams):
+        cparams["password"] = mgr.token()
+
+    if schema:
+        @event.listens_for(engine, "connect")
+        def _set_search_path(dbapi_conn, conn_rec):
+            cur = dbapi_conn.cursor()
+            try:
+                cur.execute(f'SET search_path TO "{schema}"')
+            finally:
+                cur.close()
+
+    return engine
+
+
+def _engine_from_ssm(user_key: str) -> Engine:
+    from .secrets import get_secret
+    return make_engine(
+        host=get_secret("rds-endpoint"),
+        port=int(get_secret("rds-port")),
+        database=get_secret("rds-database"),
+        user=get_secret(user_key),
+        region=_REGION,
+        schema=get_secret("rds-schema"),
+    )
+
+
+def make_app_engine() -> Engine:
+    """Production engine for the app role (CRUD on `lava_impact`)."""
+    return _engine_from_ssm("rds-app-user")
+
+
+def make_ro_engine() -> Engine:
+    """Production engine for the read-only role (SELECT only)."""
+    return _engine_from_ssm("rds-ro-user")
+
+
+__all__ = [
+    "IAMTokenManager",
+    "make_engine",
+    "make_app_engine",
+    "make_ro_engine",
+]

--- a/lavandula/common/db.py
+++ b/lavandula/common/db.py
@@ -22,6 +22,7 @@ Production SSM keys (flat-hyphenated, under
 """
 from __future__ import annotations
 
+import re
 import threading
 import time
 from typing import Any
@@ -31,6 +32,7 @@ from sqlalchemy.engine import Engine
 
 
 _REGION = "us-east-1"
+_SCHEMA_NAME_RE = re.compile(r"^[a-z_][a-z0-9_]{0,63}$")
 
 
 class IAMTokenManager:
@@ -112,6 +114,12 @@ def make_engine(
     pool_size, max_overflow : SQLAlchemy pool sizing.
     token_manager : injection point for tests.
     """
+    if schema is not None and not _SCHEMA_NAME_RE.match(schema):
+        raise ValueError(
+            f"invalid schema name {schema!r}: must match "
+            f"{_SCHEMA_NAME_RE.pattern}"
+        )
+
     mgr = token_manager or IAMTokenManager(
         region=region, host=host, port=port, user=user,
     )

--- a/lavandula/common/requirements.in
+++ b/lavandula/common/requirements.in
@@ -1,0 +1,3 @@
+boto3>=1.34
+sqlalchemy>=2.0
+psycopg2-binary>=2.9

--- a/lavandula/common/tests/unit/test_db_adapter_0013.py
+++ b/lavandula/common/tests/unit/test_db_adapter_0013.py
@@ -1,0 +1,278 @@
+"""Unit tests for lavandula.common.db (Spec 0013 Phase 1).
+
+Covers AC5-AC9 without touching real RDS. The tests exercise the
+IAM token manager directly and inspect the SQLAlchemy engine's event
+machinery; they do not actually connect to Postgres.
+
+A live-RDS smoke test lives at the bottom, gated behind
+LAVANDULA_LIVE_RDS=1 — run it manually after deployment.
+"""
+from __future__ import annotations
+
+import os
+import threading
+from unittest.mock import MagicMock
+
+import pytest
+
+from lavandula.common.db import (
+    IAMTokenManager,
+    make_app_engine,
+    make_engine,
+    make_ro_engine,
+)
+
+
+# ------------------------- IAMTokenManager ---------------------------
+
+
+def _make_mgr(clock, tokens=("tok-1", "tok-2", "tok-3")):
+    rds = MagicMock()
+    rds.generate_db_auth_token.side_effect = list(tokens)
+    mgr = IAMTokenManager(
+        region="us-east-1",
+        host="db.example",
+        port=5432,
+        user="app_user1",
+        rds_client=rds,
+        clock=clock,
+    )
+    return mgr, rds
+
+
+def test_token_cached_within_ttl():
+    """Successive calls within 8 minutes reuse the same token."""
+    now = [1000.0]
+    mgr, rds = _make_mgr(clock=lambda: now[0])
+
+    t1 = mgr.token()
+    now[0] += 60  # 1 min later
+    t2 = mgr.token()
+    now[0] += 400  # ~7 min 40 s after the first fetch, still < 8 min
+    t3 = mgr.token()
+
+    assert t1 == t2 == t3 == "tok-1"
+    assert rds.generate_db_auth_token.call_count == 1
+
+
+def test_token_refreshes_after_8_minutes():
+    """AC6: after 8 min of simulated time, a new token is fetched."""
+    now = [1000.0]
+    mgr, rds = _make_mgr(clock=lambda: now[0])
+
+    assert mgr.token() == "tok-1"
+    now[0] += 8 * 60 + 1  # past the refresh threshold
+    assert mgr.token() == "tok-2"
+    assert rds.generate_db_auth_token.call_count == 2
+
+
+def test_token_generate_call_arguments():
+    """Generated tokens target the right host/port/user/region."""
+    now = [0.0]
+    mgr, rds = _make_mgr(clock=lambda: now[0])
+    mgr.token()
+    rds.generate_db_auth_token.assert_called_once_with(
+        DBHostname="db.example",
+        Port=5432,
+        DBUsername="app_user1",
+        Region="us-east-1",
+    )
+
+
+def test_token_manager_is_thread_safe():
+    """Concurrent calls serialise through the lock; one token fetched."""
+    now = [1000.0]
+    mgr, rds = _make_mgr(clock=lambda: now[0])
+
+    # Make the underlying call slow to force thread contention.
+    original = rds.generate_db_auth_token.side_effect
+
+    def slow(*a, **kw):
+        import time as _t
+        _t.sleep(0.01)
+        if callable(original):
+            return original(*a, **kw)
+        # side_effect is a list iterator — take next value
+        return next(iter(original))
+
+    rds.generate_db_auth_token.side_effect = lambda **kw: "tok-shared"
+
+    results = []
+
+    def worker():
+        results.append(mgr.token())
+
+    threads = [threading.Thread(target=worker) for _ in range(16)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert all(r == "tok-shared" for r in results)
+    assert rds.generate_db_auth_token.call_count == 1
+
+
+# --------------------------- make_engine -----------------------------
+
+
+def test_engine_url_has_no_password_and_requires_ssl():
+    """AC8: no password in the URL; TLS is mandatory."""
+    mgr = MagicMock(spec=IAMTokenManager)
+    mgr.token.return_value = "tok"
+
+    engine = make_engine(
+        host="db.example",
+        port=5432,
+        database="lava_prod1",
+        user="app_user1",
+        token_manager=mgr,
+    )
+    url = str(engine.url)
+    assert "app_user1@db.example:5432/lava_prod1" in url
+    # SQLAlchemy masks passwords; assert the render-with-password is empty
+    assert engine.url.password is None
+    assert engine.url.query.get("sslmode") == "require"
+
+
+def test_engine_pool_config():
+    """pool_pre_ping enabled, pool_recycle ≥ 8 min (AC7 + trap #3)."""
+    mgr = MagicMock(spec=IAMTokenManager)
+    engine = make_engine(
+        host="h", port=5432, database="d", user="u", token_manager=mgr,
+    )
+    assert engine.pool._pre_ping is True
+    assert engine.pool._recycle >= 8 * 60
+
+
+def test_do_connect_injects_token_as_password():
+    """AC8: the do_connect event populates cparams['password']."""
+    mgr = MagicMock(spec=IAMTokenManager)
+    mgr.token.return_value = "fresh-token-abc"
+
+    engine = make_engine(
+        host="h", port=5432, database="d", user="u", token_manager=mgr,
+    )
+
+    # Dispatch do_connect directly with a mutable cparams dict; the
+    # registered listener should mutate it in place.
+    cparams: dict = {}
+    engine.dialect.dispatch.do_connect(engine.dialect, None, (), cparams)
+    assert cparams["password"] == "fresh-token-abc"
+    mgr.token.assert_called()
+
+
+def test_ssm_based_factory_wiring(monkeypatch):
+    """AC5: make_app_engine wires SSM values into make_engine.
+
+    We monkeypatch get_secret and make_engine to verify the call path
+    without actually building an engine (no psycopg2 connection, no
+    boto3 rds client).
+    """
+    from lavandula.common import db as dbmod
+    from lavandula.common import secrets as secretsmod
+
+    values = {
+        "rds-endpoint": "db.prod.example",
+        "rds-port": "5432",
+        "rds-database": "lava_prod1",
+        "rds-schema": "lava_impact",
+        "rds-app-user": "app_user1",
+        "rds-ro-user": "ro_user1",
+    }
+    secretsmod.clear_cache()
+    monkeypatch.setattr(
+        secretsmod, "get_secret", lambda name, **kw: values[name],
+    )
+
+    captured = {}
+
+    def fake_make_engine(**kw):
+        captured.update(kw)
+        return "ENGINE"
+
+    monkeypatch.setattr(dbmod, "make_engine", fake_make_engine)
+
+    assert dbmod.make_app_engine() == "ENGINE"
+    assert captured["user"] == "app_user1"
+    assert captured["host"] == "db.prod.example"
+    assert captured["port"] == 5432
+    assert captured["database"] == "lava_prod1"
+    assert captured["schema"] == "lava_impact"
+    assert captured["region"] == "us-east-1"
+
+    captured.clear()
+    assert dbmod.make_ro_engine() == "ENGINE"
+    assert captured["user"] == "ro_user1"
+
+
+def test_ro_engine_uses_ro_user(monkeypatch):
+    """AC9 (wiring portion): make_ro_engine reads rds-ro-user from SSM.
+
+    The database-level negative test (INSERT denied) is covered by the
+    live-RDS smoke test below; the unit layer only verifies that the
+    ro factory targets the ro-user SSM key.
+    """
+    from lavandula.common import db as dbmod
+    from lavandula.common import secrets as secretsmod
+
+    asked = []
+    monkeypatch.setattr(
+        secretsmod,
+        "get_secret",
+        lambda name, **kw: (asked.append(name) or {
+            "rds-endpoint": "h",
+            "rds-port": "5432",
+            "rds-database": "d",
+            "rds-schema": "s",
+            "rds-ro-user": "ro_user1",
+            "rds-app-user": "app_user1",
+        }[name]),
+    )
+    monkeypatch.setattr(dbmod, "make_engine", lambda **kw: kw)
+
+    kw = dbmod.make_ro_engine()
+    assert kw["user"] == "ro_user1"
+    assert "rds-ro-user" in asked
+    assert "rds-app-user" not in asked
+
+
+# ----------------------- live-RDS smoke tests ------------------------
+
+
+@pytest.mark.skipif(
+    os.environ.get("LAVANDULA_LIVE_RDS") != "1",
+    reason="set LAVANDULA_LIVE_RDS=1 to run live-RDS integration test",
+)
+def test_live_rds_app_engine_select_1():
+    """AC5: real make_app_engine() connects and runs SELECT 1.
+
+    Requires the EC2 IAM role to have rds-db:connect for app_user1 and
+    the SSM parameters to be populated. Run manually after deployment.
+    """
+    from sqlalchemy import text
+
+    engine = make_app_engine()
+    with engine.connect() as conn:
+        result = conn.execute(text("SELECT 1")).scalar()
+    assert result == 1
+
+
+@pytest.mark.skipif(
+    os.environ.get("LAVANDULA_LIVE_RDS") != "1",
+    reason="set LAVANDULA_LIVE_RDS=1 to run live-RDS integration test",
+)
+def test_live_rds_ro_engine_cannot_insert():
+    """AC9: make_ro_engine() is denied INSERT (DB-level check)."""
+    from sqlalchemy import text
+    from sqlalchemy.exc import DBAPIError
+
+    engine = make_ro_engine()
+    with engine.connect() as conn:
+        assert conn.execute(text("SELECT 1")).scalar() == 1
+        with pytest.raises(DBAPIError):
+            conn.execute(
+                text(
+                    "INSERT INTO lava_impact.schema_version (version, note) "
+                    "VALUES (-1, 'ro-user insert probe')"
+                )
+            )

--- a/lavandula/common/tests/unit/test_db_adapter_0013.py
+++ b/lavandula/common/tests/unit/test_db_adapter_0013.py
@@ -161,6 +161,38 @@ def test_do_connect_injects_token_as_password():
     mgr.token.assert_called()
 
 
+@pytest.mark.parametrize(
+    "bad",
+    [
+        'lava"; DROP SCHEMA public; --',
+        "lava_impact; SELECT 1",
+        "Lava_Impact",           # uppercase not allowed
+        "1lava",                 # leading digit
+        "lava-impact",           # hyphen
+        "a" * 65,                # too long
+        "",                      # empty
+        "lava impact",           # space
+    ],
+)
+def test_make_engine_rejects_malformed_schema(bad):
+    """Schema is interpolated into SET search_path; reject non-identifiers."""
+    mgr = MagicMock(spec=IAMTokenManager)
+    with pytest.raises(ValueError):
+        make_engine(
+            host="h", port=5432, database="d", user="u",
+            schema=bad, token_manager=mgr,
+        )
+
+
+def test_make_engine_accepts_valid_schema():
+    mgr = MagicMock(spec=IAMTokenManager)
+    engine = make_engine(
+        host="h", port=5432, database="d", user="u",
+        schema="lava_impact", token_manager=mgr,
+    )
+    assert engine is not None
+
+
 def test_ssm_based_factory_wiring(monkeypatch):
     """AC5: make_app_engine wires SSM values into make_engine.
 

--- a/lavandula/migrations/rds/001_initial_schema.sql
+++ b/lavandula/migrations/rds/001_initial_schema.sql
@@ -1,0 +1,264 @@
+-- Migration: 001_initial_schema
+-- Date: 2026-04-22
+-- Target: PostgreSQL (RDS lava_prod1), schema lava_impact
+-- Mirrors current SQLite schema from:
+--   lavandula/reports/schema.py
+--   lavandula/nonprofits/tools/seed_enumerate.py (nonprofits_seed + runs + migrations)
+--
+-- Run as master user (postgres) from pgAdmin or psql.
+
+BEGIN;
+
+SET search_path TO lava_impact, public;
+
+-- =========================================================================
+-- schema_version — tracks which migrations have been applied
+-- =========================================================================
+CREATE TABLE IF NOT EXISTS schema_version (
+  version     INTEGER PRIMARY KEY,
+  name        TEXT NOT NULL,
+  applied_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  applied_by  TEXT NOT NULL DEFAULT CURRENT_USER
+);
+
+-- =========================================================================
+-- Default privileges — makes every table created by postgres auto-grant
+-- CRUD to app_user1 and SELECT to ro_user1. Must be set BEFORE CREATE TABLE
+-- so the newly-created objects inherit the grants.
+-- =========================================================================
+ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA lava_impact
+  GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO app_user1;
+ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA lava_impact
+  GRANT SELECT ON TABLES TO ro_user1;
+ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA lava_impact
+  GRANT USAGE, SELECT ON SEQUENCES TO app_user1;
+ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA lava_impact
+  GRANT SELECT ON SEQUENCES TO ro_user1;
+
+-- =========================================================================
+-- nonprofits_seed — seed list of nonprofit orgs with resolver output
+-- =========================================================================
+CREATE TABLE IF NOT EXISTS nonprofits_seed (
+  ein                     TEXT PRIMARY KEY,
+  name                    TEXT,
+  address                 TEXT,
+  city                    TEXT,
+  state                   TEXT,
+  zipcode                 TEXT,
+  ntee_code               TEXT,
+  revenue                 BIGINT,
+  subsection_code         INTEGER,
+  activity_codes          TEXT,
+  classification_codes    TEXT,
+  foundation_code         INTEGER,
+  ruling_date             TEXT,
+  accounting_period       INTEGER,
+  website_url             TEXT,
+  website_candidates_json TEXT,
+  resolver_status         TEXT,
+  resolver_confidence     DOUBLE PRECISION,
+  resolver_method         TEXT,
+  resolver_reason         TEXT,
+  notes                   TEXT,
+  discovered_at           TEXT,
+  run_id                  TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_seed_state        ON nonprofits_seed(state);
+CREATE INDEX IF NOT EXISTS idx_seed_website_null ON nonprofits_seed(ein) WHERE website_url IS NULL;
+
+-- Convenience view used by the crawler selection path
+CREATE OR REPLACE VIEW nonprofits AS
+  SELECT ein, website_url, resolver_status FROM nonprofits_seed;
+
+-- =========================================================================
+-- runs — seed-enumeration audit log
+-- =========================================================================
+CREATE TABLE IF NOT EXISTS runs (
+  run_id             TEXT PRIMARY KEY,
+  started_at         TEXT,
+  finished_at        TEXT,
+  filters_json       TEXT,
+  found_count        INTEGER,
+  website_hit_count  INTEGER,
+  last_page_scanned  TEXT,
+  exit_reason        TEXT
+);
+
+-- =========================================================================
+-- reports — PDF metadata, classification, provenance
+-- =========================================================================
+CREATE TABLE IF NOT EXISTS reports (
+  content_sha256       TEXT PRIMARY KEY,
+
+  source_url_redacted         TEXT NOT NULL,
+  referring_page_url_redacted TEXT,
+  redirect_chain_json         TEXT,
+  source_org_ein              TEXT NOT NULL,
+  discovered_via              TEXT NOT NULL,
+  hosting_platform            TEXT,
+
+  attribution_confidence TEXT NOT NULL,
+
+  archived_at     TEXT NOT NULL,
+  content_type    TEXT NOT NULL,
+  file_size_bytes BIGINT NOT NULL,
+  page_count      INTEGER,
+
+  first_page_text   TEXT,
+  pdf_creator       TEXT,
+  pdf_producer      TEXT,
+  pdf_creation_date TEXT,
+
+  pdf_has_javascript  SMALLINT NOT NULL DEFAULT 0,
+  pdf_has_launch      SMALLINT NOT NULL DEFAULT 0,
+  pdf_has_embedded    SMALLINT NOT NULL DEFAULT 0,
+  pdf_has_uri_actions SMALLINT NOT NULL DEFAULT 0,
+
+  classification            TEXT,
+  classification_confidence DOUBLE PRECISION,
+  classifier_model          TEXT NOT NULL,
+  classifier_version        INTEGER NOT NULL DEFAULT 1,
+  classified_at             TEXT,
+
+  report_year        INTEGER,
+  report_year_source TEXT,
+
+  extractor_version INTEGER NOT NULL DEFAULT 1,
+
+  CONSTRAINT reports_sha_len_chk CHECK (length(content_sha256) = 64),
+  CONSTRAINT reports_size_chk    CHECK (file_size_bytes > 0),
+  CONSTRAINT reports_ct_chk      CHECK (content_type = 'application/pdf'),
+  CONSTRAINT reports_disc_chk    CHECK (discovered_via IN
+                                         ('sitemap','homepage-link','subpage-link','hosting-platform')),
+  CONSTRAINT reports_platform_chk CHECK (hosting_platform IS NULL OR hosting_platform IN
+                                         ('issuu','flipsnack','canva','own-domain','own-cms')),
+  CONSTRAINT reports_class_chk   CHECK (classification IS NULL OR classification IN
+                                         ('annual','impact','hybrid','other','not_a_report')),
+  CONSTRAINT reports_conf_chk    CHECK (classification_confidence IS NULL OR
+                                         (classification_confidence >= 0
+                                          AND classification_confidence <= 1)),
+  CONSTRAINT reports_attr_chk    CHECK (attribution_confidence IN
+                                         ('own_domain','platform_verified','platform_unverified')),
+  CONSTRAINT reports_redirect_chk CHECK (redirect_chain_json IS NULL
+                                          OR length(redirect_chain_json) <= 2048),
+  CONSTRAINT reports_js_chk      CHECK (pdf_has_javascript IN (0,1)),
+  CONSTRAINT reports_launch_chk  CHECK (pdf_has_launch IN (0,1)),
+  CONSTRAINT reports_embed_chk   CHECK (pdf_has_embedded IN (0,1)),
+  CONSTRAINT reports_uri_chk     CHECK (pdf_has_uri_actions IN (0,1)),
+  CONSTRAINT reports_fpt_len_chk CHECK (first_page_text IS NULL
+                                         OR length(first_page_text) <= 4096),
+  CONSTRAINT reports_creator_chk CHECK (pdf_creator IS NULL OR length(pdf_creator) <= 200),
+  CONSTRAINT reports_producer_chk CHECK (pdf_producer IS NULL OR length(pdf_producer) <= 200),
+  CONSTRAINT reports_year_src_chk CHECK (report_year_source IS NULL OR report_year_source IN
+                                          ('url','filename','first-page','pdf-creation-date'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_reports_ein            ON reports(source_org_ein);
+CREATE INDEX IF NOT EXISTS idx_reports_classification ON reports(classification);
+CREATE INDEX IF NOT EXISTS idx_reports_year           ON reports(report_year);
+CREATE INDEX IF NOT EXISTS idx_reports_platform       ON reports(hosting_platform);
+
+-- reports_public view — mirrors SQLite; tests grep the WHERE clause
+CREATE OR REPLACE VIEW reports_public AS
+  SELECT content_sha256, source_org_ein, hosting_platform,
+         attribution_confidence,
+         archived_at, file_size_bytes, page_count,
+         classification, classification_confidence,
+         report_year, report_year_source,
+         pdf_has_javascript, pdf_has_launch, pdf_has_embedded
+  FROM reports
+  WHERE attribution_confidence IN ('own_domain','platform_verified')
+    AND classification IS NOT NULL
+    AND classification != 'not_a_report'
+    AND classification_confidence >= 0.8
+    AND pdf_has_javascript = 0
+    AND pdf_has_launch = 0
+    AND pdf_has_embedded = 0;
+
+-- =========================================================================
+-- fetch_log — every HTTP / classifier event, for audit + debugging
+-- =========================================================================
+CREATE TABLE IF NOT EXISTS fetch_log (
+  id             BIGSERIAL PRIMARY KEY,
+  ein            TEXT,
+  url_redacted   TEXT NOT NULL,
+  kind           TEXT NOT NULL,
+  fetch_status   TEXT NOT NULL,
+  status_code    INTEGER,
+  fetched_at     TEXT NOT NULL,
+  elapsed_ms     INTEGER,
+  notes          TEXT,
+  CONSTRAINT fetch_log_kind_chk CHECK (kind IN
+    ('robots','sitemap','homepage','subpage','pdf-head','pdf-get',
+     'extract','classify')),
+  CONSTRAINT fetch_log_status_chk CHECK (fetch_status IN
+    ('ok','not_found','rate_limited','forbidden','server_error',
+     'network_error','size_capped','blocked_content_type',
+     'blocked_scheme','blocked_ssrf','cross_origin_blocked',
+     'blocked_robots','classifier_error'))
+);
+CREATE INDEX IF NOT EXISTS idx_fetch_log_ein ON fetch_log(ein);
+
+-- =========================================================================
+-- crawled_orgs — per-org crawl rollup
+-- =========================================================================
+CREATE TABLE IF NOT EXISTS crawled_orgs (
+  ein                    TEXT PRIMARY KEY,
+  first_crawled_at       TEXT NOT NULL,
+  last_crawled_at        TEXT NOT NULL,
+  candidate_count        INTEGER NOT NULL DEFAULT 0,
+  fetched_count          INTEGER NOT NULL DEFAULT 0,
+  confirmed_report_count INTEGER NOT NULL DEFAULT 0
+);
+
+-- =========================================================================
+-- deletion_log — audit of deleted reports
+-- =========================================================================
+CREATE TABLE IF NOT EXISTS deletion_log (
+  id              BIGSERIAL PRIMARY KEY,
+  content_sha256  TEXT NOT NULL,
+  deleted_at      TEXT NOT NULL,
+  reason          TEXT,
+  operator        TEXT,
+  pdf_unlinked    SMALLINT NOT NULL,
+  CONSTRAINT deletion_log_unlinked_chk CHECK (pdf_unlinked IN (0,1))
+);
+
+-- =========================================================================
+-- budget_ledger — classifier spend accounting
+-- =========================================================================
+CREATE TABLE IF NOT EXISTS budget_ledger (
+  id                BIGSERIAL PRIMARY KEY,
+  at_timestamp      TEXT NOT NULL,
+  classifier_model  TEXT NOT NULL,
+  sha256_classified TEXT NOT NULL,
+  input_tokens      INTEGER NOT NULL,
+  output_tokens     INTEGER NOT NULL,
+  cents_spent       INTEGER NOT NULL,
+  notes             TEXT,
+  CONSTRAINT budget_cents_chk      CHECK (cents_spent >= 0),
+  CONSTRAINT budget_input_chk      CHECK (input_tokens >= 0),
+  CONSTRAINT budget_output_chk     CHECK (output_tokens >= 0),
+  CONSTRAINT budget_sha_chk        CHECK (length(sha256_classified) = 64
+                                           OR sha256_classified = 'preflight')
+);
+CREATE INDEX IF NOT EXISTS idx_budget_ledger_at ON budget_ledger(at_timestamp);
+
+-- =========================================================================
+-- Explicit grants on existing objects (defensive; default privileges above
+-- handle NEW objects, these cover tables just created in this transaction).
+-- =========================================================================
+GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA lava_impact TO app_user1;
+GRANT SELECT ON ALL TABLES IN SCHEMA lava_impact TO ro_user1;
+GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA lava_impact TO app_user1;
+GRANT SELECT ON ALL SEQUENCES IN SCHEMA lava_impact TO ro_user1;
+
+-- =========================================================================
+-- Record this migration
+-- =========================================================================
+INSERT INTO schema_version (version, name)
+  VALUES (1, 'initial_schema')
+  ON CONFLICT (version) DO NOTHING;
+
+COMMIT;

--- a/locard/projectlist.md
+++ b/locard/projectlist.md
@@ -268,7 +268,7 @@ projects:
   - id: "0013"
     title: "SQLite → PostgreSQL (RDS) Dual-Write Migration"
     summary: "Staged migration to managed Postgres RDS. Deploys RDS alongside existing SQLite with clean Alembic-managed schema, adds dual-write mode to db_writer so every write hits both backends, one-time backfills existing SQLite rows to RDS, then flips reads to RDS once dual-write is proven stable. Avoids a clean-cutoff pause because corpus build is continuous. Uses SQLAlchemy (already committed for 0006/0008) so the code change is minimal."
-    status: conceived
+    status: implementing
     priority: high
     files:
       spec: locard/specs/0013-rds-postgres-migration.md

--- a/locard/projectlist.md
+++ b/locard/projectlist.md
@@ -203,15 +203,15 @@ projects:
   - id: "0008"
     title: "Agent Batch Runner"
     summary: "Orchestrate Claude Code WebSearch sub-agents for URL resolution at scale. Takes an EIN list → splits into N-org chunks → spawns K agents in parallel → waits → ingests results back into seeds.db. Resumable (agents append to results file as they go), skip-already-resolved by default."
-    status: conceived
+    status: implementing
     priority: high
     files:
       spec: locard/specs/0008-agent-batch-runner.md
-      plan: null
+      plan: locard/plans/0008-agent-batch-runner.md
       review: null
     dependencies: ["0001"]
     tags: [resolver, orchestration, agents, haiku]
-    notes: "Replaces manual JSON-file shuffling observed in 2026-04-21 TX 100 validation. Critical for weekly batch workflow at 1K-5K orgs per week."
+    notes: "Spec + plan approved 2026-04-22 (red-team APPROVE, 0 CRITICAL, 0 HIGH). 25 ACs. Key security: agents run with WebSearch+WebFetch only (no Bash/Read/Write), per-agent subprocess timeout, 2MB output cap, json.dumps() for input generation."
 
   - id: "0009"
     title: "Address Verification Pass"

--- a/locard/specs/0013-rds-postgres-migration.md
+++ b/locard/specs/0013-rds-postgres-migration.md
@@ -82,15 +82,36 @@ Five phases, gated explicitly:
 
 | Phase | What changes | Rollback |
 |-------|-------------|----------|
-| 0. **Provision** | RDS instance, DB, schema, roles, SG, SSM keys | Terminate RDS |
+| 0. **Provision** ✅ DONE 2026-04-22 | RDS `lava-1`, DB `lava_prod1`, schema `lava_impact`, roles `app_user1`/`ro_user1`, IAM auth, 8 tables + 2 views | Drop schema |
 | 1. **Connect** | Python adapter (`lavandula.common.db`) with SQLAlchemy + IAM token manager | Remove adapter import |
-| 2. **Backfill** | One-time copy of current SQLite rows into RDS | Truncate RDS tables |
+| 2. **Backfill** | One-time copy of current SQLite rows into RDS | TRUNCATE RDS tables |
 | 3. **Dual-write** | `db_writer` writes to both SQLite and RDS | Flag off, drop RDS queue |
 | 4. **Read flip** | Reads come from RDS; SQLite reads retained behind a fallback flag | Flip reads back to SQLite |
 
 Each phase is independently mergeable and reversible. Phase order is
 strict: cannot dual-write before backfill; cannot flip reads before
 dual-write is validated.
+
+### Phase 0 actual state (as completed 2026-04-22)
+
+- Database: `lava_prod1` (existing; shared with future Amazon order data)
+- Schema: `lava_impact` (research data scope)
+- Tables (8): `schema_version`, `nonprofits_seed`, `runs`, `reports`,
+  `fetch_log`, `crawled_orgs`, `deletion_log`, `budget_ledger`
+- Views (2): `nonprofits`, `reports_public`
+- Roles (IAM auth via `rds_iam` group):
+  - `app_user1` — CRUD + CREATE on `lava_impact`
+  - `ro_user1` — SELECT only on `lava_impact`
+  - `postgres` (master) — DDL; NOT `rds_iam` (password auth only for
+    future manual migrations; placeholder password stored temporarily
+    in SSM during initial DDL and deleted after)
+- IAM policy on `cloud2_lavandulagroup` EC2 role includes
+  `rds-db:connect` for both user ARNs
+- SSM connection params at `/cloud2.lavandulagroup.com/rds-*`:
+  `endpoint`, `port`, `database`, `schema`, `app-user`, `ro-user`
+- Migration file committed at
+  `lavandula/migrations/rds/001_initial_schema.sql` — plain SQL run
+  via pgAdmin/psql as master. NO Alembic.
 
 ### Phase 0 — RDS provisioning
 
@@ -272,10 +293,10 @@ def make_app_engine() -> Engine:
     """Production app-role engine. Reads connection params from SSM."""
     from .secrets import get_secret  # existing helper
     return make_engine(
-        host=get_secret("rds/endpoint"),
-        port=int(get_secret("rds/port")),
-        database=get_secret("rds/database"),
-        user=get_secret("rds/app_user"),
+        host=get_secret("rds-endpoint"),
+        port=int(get_secret("rds-port")),
+        database=get_secret("rds-database"),
+        user=get_secret("rds-app-user"),
         region="us-east-1",
         role="app",
     )
@@ -285,14 +306,19 @@ def make_ro_engine() -> Engine:
     """Read-only engine for extraction/gallery future apps."""
     from .secrets import get_secret
     return make_engine(
-        host=get_secret("rds/endpoint"),
-        port=int(get_secret("rds/port")),
-        database=get_secret("rds/database"),
-        user=get_secret("rds/ro_user"),
+        host=get_secret("rds-endpoint"),
+        port=int(get_secret("rds-port")),
+        database=get_secret("rds-database"),
+        user=get_secret("rds-ro-user"),
         region="us-east-1",
         role="ro",
     )
 ```
+
+SSM keys use the flat-hyphenated naming convention (`rds-endpoint`,
+etc.), matching the project-wide standard in `secrets.py`. Schema name
+(`lava_impact`) is applied via `search_path` in connection setup or
+via fully-qualified table names in SQL — not in the URL.
 
 #### Why not port the JS helper wholesale?
 

--- a/locard/specs/0013-rds-postgres-migration.md
+++ b/locard/specs/0013-rds-postgres-migration.md
@@ -1,0 +1,571 @@
+# Spec 0013 — SQLite → PostgreSQL (RDS) Dual-Write Migration
+
+**Status**: draft  
+**Protocol**: SPIDER  
+**Priority**: high (start in parallel with 0006 Dashboard)  
+**Date**: 2026-04-22  
+**Depends on**: Spec 0004 (crawler), Spec 0007 (S3 archive)
+
+---
+
+## Problem
+
+The pipeline currently stores all metadata in local SQLite files:
+
+- `seeds.db` / `seeds-eastcoast.db` — nonprofit seed list + resolver output
+- `reports.db` — PDF metadata, classifications, fetch_log, budget_ledger
+
+SQLite served well through bootstrap and the TX 88-org validation, but
+the near-term roadmap has three forcing functions for Postgres on RDS:
+
+1. **Multi-user / multi-host access** — the dashboard (0006) will
+   eventually be accessed from outside the EC2 host, and the future
+   gallery app (0015) is inherently multi-user read-only. SQLite over
+   NFS is not viable for either.
+
+2. **Data protection** — EBS is a single point of failure. RDS
+   automated backups + PITR + cross-AZ replicas give real durability
+   guarantees.
+
+3. **Downstream apps overlap with ongoing corpus build** — the
+   extraction pipeline (0014) and gallery (0015) start before corpus
+   build is "done" (there is no clean cutoff — corpus builds
+   continuously). Neither can wait for a stop-the-world migration.
+
+Option A (dual-write, staged) was chosen 2026-04-22 over clean-cutover
+and sync-job alternatives. This spec implements it.
+
+---
+
+## Goals
+
+1. Deploy a managed Postgres RDS instance with a clean schema that
+   mirrors the current SQLite tables plus room to grow.
+2. Add a dual-write mode to the DB-writer layer: every write hits
+   SQLite (as today) AND RDS (async-queued, best-effort).
+3. One-time backfill of existing SQLite rows into RDS at deploy time.
+4. Once dual-write is stable (~2-4 weeks), flip reads to RDS. SQLite
+   writes remain as a local cache for performance during active
+   crawls; eventual retirement is out of scope here.
+5. Use AWS IAM database authentication with 8-minute token refresh
+   (matching the pattern in the elationfactory JS helper module).
+6. Zero code downtime during any phase. Rollback = revert the read
+   flip; SQLite still has full state.
+
+---
+
+## Non-Goals
+
+- **Retiring SQLite entirely.** Post-flip, SQLite remains the primary
+  write path for crawler hot loops; the migration stops at "reads
+  live on RDS." A future spec can retire SQLite once multi-host
+  writes are a real requirement.
+- **Porting the JS IAM helper module.** We implement the core
+  token-refresh pattern natively in Python using SQLAlchemy events
+  — the architectural precedent is adopted; the JS code is not.
+- **Schema-level feature expansion.** The RDS schema mirrors current
+  SQLite columns 1:1 with Postgres-native types. JSONB, GIN indexes,
+  partitioning, materialized views — all deferred.
+- **Changing query access patterns in app code.** The crawler and
+  classifier use the same SQLAlchemy session whether SQLite or
+  Postgres is the backend. No per-call branching.
+- **Multi-region or read-replica setup.** Single RDS instance until
+  we actually have a use case.
+
+---
+
+## Design
+
+### Phase model
+
+Five phases, gated explicitly:
+
+| Phase | What changes | Rollback |
+|-------|-------------|----------|
+| 0. **Provision** | RDS instance, DB, schema, roles, SG, SSM keys | Terminate RDS |
+| 1. **Connect** | Python adapter (`lavandula.common.db`) with SQLAlchemy + IAM token manager | Remove adapter import |
+| 2. **Backfill** | One-time copy of current SQLite rows into RDS | Truncate RDS tables |
+| 3. **Dual-write** | `db_writer` writes to both SQLite and RDS | Flag off, drop RDS queue |
+| 4. **Read flip** | Reads come from RDS; SQLite reads retained behind a fallback flag | Flip reads back to SQLite |
+
+Each phase is independently mergeable and reversible. Phase order is
+strict: cannot dual-write before backfill; cannot flip reads before
+dual-write is validated.
+
+### Phase 0 — RDS provisioning
+
+**Target configuration** (recommended defaults; override at
+provisioning time if needed):
+
+| Setting | Value |
+|---------|-------|
+| Engine | Postgres 16.x |
+| Instance class | `db.t4g.small` (2 vCPU, 2 GB RAM) |
+| Storage | 20 GB gp3 SSD, auto-scale to 100 GB |
+| Multi-AZ | No (single-AZ; research workload) |
+| Backup retention | 7 days |
+| Network | Same VPC as EC2, private subnet, no public access |
+| AZ | us-east-1b (operator's choice; cross-AZ EC2↔RDS is acceptable) |
+| IAM database auth | **Enabled** — this is the primary auth path |
+| TLS | Required for all connections |
+| Parameter group | Default `default.postgres16`; adjust if needed |
+| Deletion protection | On |
+
+**Database and role layout** (created once by admin, via psql after
+first provisioning):
+
+```sql
+CREATE DATABASE lavandula
+    WITH ENCODING = 'UTF8' LC_COLLATE = 'en_US.UTF-8';
+
+-- Roles
+CREATE ROLE lavandula_admin LOGIN;   -- DDL + migrations + backups
+CREATE ROLE lavandula_app   LOGIN;   -- CRUD on app tables (crawler, dashboard)
+CREATE ROLE lavandula_ro    LOGIN;   -- SELECT only (extraction, gallery)
+
+-- IAM authentication: RDS-provided role that IAM-authenticated users inherit
+GRANT rds_iam TO lavandula_app;
+GRANT rds_iam TO lavandula_ro;
+-- lavandula_admin keeps password auth (offline DDL); can optionally also have rds_iam
+
+-- Schemas
+\c lavandula
+CREATE SCHEMA lavandula AUTHORIZATION lavandula_admin;
+GRANT USAGE ON SCHEMA lavandula TO lavandula_app, lavandula_ro;
+ALTER DEFAULT PRIVILEGES FOR ROLE lavandula_admin IN SCHEMA lavandula
+    GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO lavandula_app;
+ALTER DEFAULT PRIVILEGES FOR ROLE lavandula_admin IN SCHEMA lavandula
+    GRANT SELECT ON TABLES TO lavandula_ro;
+```
+
+This gives us three clean roles with least-privilege separation:
+`admin` runs migrations, `app` is the runtime role for the crawler
+and other write paths, `ro` is for future extraction/gallery readers.
+
+**Connection parameters stored in SSM**:
+
+```
+/cloud2.lavandulagroup.com/lavandula/rds/endpoint   → dbhost.us-east-1.rds.amazonaws.com
+/cloud2.lavandulagroup.com/lavandula/rds/port       → 5432
+/cloud2.lavandulagroup.com/lavandula/rds/database   → lavandula
+/cloud2.lavandulagroup.com/lavandula/rds/app_user   → lavandula_app
+/cloud2.lavandulagroup.com/lavandula/rds/ro_user    → lavandula_ro
+```
+
+Credentials for `lavandula_admin` (password auth for DDL work) live in
+`/cloud2.lavandulagroup.com/lavandula/rds/admin_password` as
+SecureString. `app` and `ro` roles use IAM auth — no password stored.
+
+### Phase 1 — Python connection adapter
+
+New module: `lavandula/common/db.py`.
+
+Implements the IAM-token-as-password pattern from the JS helper
+module (`@elationfactory/database-access`), condensed to the
+SQLAlchemy idiom. ~40 LOC of substance; tests under 200 LOC.
+
+#### Architecture (from JS helper precedent)
+
+The JS helper module solved three specific anti-patterns:
+
+1. **Pool-storm on token refresh** — naive code recreates the
+   connection pool every 15 minutes when the IAM token expires. Our
+   adapter avoids this by making `password` a *function* that's
+   called per new connection, not per session.
+2. **Mid-connection expiry** — the JS code uses `pool_pre_ping`
+   equivalent to detect dead connections and open a fresh one with
+   a current token. SQLAlchemy's `pool_pre_ping=True` handles this.
+3. **Thread-safe token cache** — one fetch every ~8 minutes, shared
+   across all threads. The Python equivalent uses a `threading.Lock`
+   around the 8-min-TTL cache.
+
+Token lifetime: AWS-issued tokens are valid 15 minutes. We refresh
+at 8 minutes to give headroom. Same numbers as the JS helper.
+
+#### Adapter API
+
+```python
+# lavandula/common/db.py
+
+from sqlalchemy import create_engine, event
+from sqlalchemy.engine import Engine
+import boto3, threading, time
+
+class IAMTokenManager:
+    """Thread-safe IAM DB auth token cache with 8-min TTL.
+
+    Mirrors the architecture of @elationfactory/database-access
+    (JS). The pool is created once; connections get fresh tokens
+    as they're established via the 'do_connect' SQLAlchemy event.
+    """
+
+    _REFRESH_AFTER_SEC = 8 * 60  # 8 min; AWS token lifetime is 15 min
+
+    def __init__(self, *, region: str, host: str, port: int, user: str):
+        self._rds = boto3.client("rds", region_name=region)
+        self._region, self._host, self._port, self._user = (
+            region, host, port, user
+        )
+        self._token: str | None = None
+        self._expires_at: float = 0.0
+        self._lock = threading.Lock()
+
+    def token(self) -> str:
+        with self._lock:
+            if time.time() < self._expires_at and self._token:
+                return self._token
+            self._token = self._rds.generate_db_auth_token(
+                DBHostname=self._host,
+                Port=self._port,
+                DBUsername=self._user,
+                Region=self._region,
+            )
+            self._expires_at = time.time() + self._REFRESH_AFTER_SEC
+            return self._token
+
+
+def make_engine(
+    *,
+    host: str,
+    port: int,
+    database: str,
+    user: str,
+    region: str,
+    role: str = "app",  # "app" or "ro"
+    pool_size: int = 5,
+    max_overflow: int = 10,
+) -> Engine:
+    """Create a SQLAlchemy engine that authenticates via IAM DB auth.
+
+    Connection flow:
+    1. Engine + pool created once at startup. Pool lives forever.
+    2. When a new physical connection is opened, the 'do_connect'
+       event fires and injects a fresh IAM token as the password.
+    3. Existing connections keep their original token until they
+       close or fail a pre-ping, at which point they get a new one.
+
+    No password is stored in env, config, or logs.
+    """
+    mgr = IAMTokenManager(region=region, host=host, port=port, user=user)
+
+    # Build URL without password; injected per-connection below.
+    url = (
+        f"postgresql+psycopg2://{user}@{host}:{port}/{database}"
+        f"?sslmode=require"
+    )
+    engine = create_engine(
+        url,
+        pool_size=pool_size,
+        max_overflow=max_overflow,
+        pool_pre_ping=True,        # handles mid-connection token expiry
+        pool_recycle=8 * 60,       # force recycle at 8 min
+    )
+
+    @event.listens_for(engine, "do_connect")
+    def _inject_iam_token(dialect, conn_rec, cargs, cparams):
+        cparams["password"] = mgr.token()
+
+    return engine
+
+
+def make_app_engine() -> Engine:
+    """Production app-role engine. Reads connection params from SSM."""
+    from .secrets import get_secret  # existing helper
+    return make_engine(
+        host=get_secret("rds/endpoint"),
+        port=int(get_secret("rds/port")),
+        database=get_secret("rds/database"),
+        user=get_secret("rds/app_user"),
+        region="us-east-1",
+        role="app",
+    )
+
+
+def make_ro_engine() -> Engine:
+    """Read-only engine for extraction/gallery future apps."""
+    from .secrets import get_secret
+    return make_engine(
+        host=get_secret("rds/endpoint"),
+        port=int(get_secret("rds/port")),
+        database=get_secret("rds/database"),
+        user=get_secret("rds/ro_user"),
+        region="us-east-1",
+        role="ro",
+    )
+```
+
+#### Why not port the JS helper wholesale?
+
+The JS helper is ~2000 LOC solving IAM auth + domain collections
+(users/sessions/themes) + a CLI REPL + debug introspection. The
+Python ecosystem already has most of that:
+
+- IAM token generation: `boto3.rds.generate_db_auth_token()` (1 call,
+  no need to reimplement SigV4)
+- Pool management: SQLAlchemy built-in
+- Pre-ping / recycle: SQLAlchemy config flags
+- Debug REPL: `pgcli` (Python) or `psql` with the IAM token
+- Query introspection: SQLAlchemy `inspect()`
+- Domain collections: out of scope for this codebase
+
+What remains unique to our case is ~40 LOC of token-cache glue.
+Porting the whole module would be 50x the code for no additional
+functionality. We adopt the *architecture* the JS helper defines
+(password-as-function, per-connection token injection, 8-min cache,
+pre-ping), not its implementation.
+
+### Phase 2 — Schema + backfill
+
+Alembic manages the schema. Initial migration mirrors current SQLite
+tables exactly — same columns, same types (adjusted for Postgres
+idioms: `INTEGER` → `BIGINT` where appropriate, `TEXT` → `TEXT`,
+`BLOB` → `BYTEA` if any).
+
+Tables in scope (copied from current SQLite):
+
+- `nonprofits_seed`
+- `reports`
+- `fetch_log`
+- `crawled_orgs`
+- `budget_ledger`
+- `runs` (seed enumeration audit)
+- `deletion_log`
+
+Constraints and indexes are carried over. `reports_public` view is
+recreated in Postgres.
+
+**Backfill tool**: `lavandula/common/tools/backfill_rds.py`.
+
+Reads each SQLite DB in the project's `data/` directory, COPIES rows
+to RDS via `psycopg2.extras.execute_values()` (fast bulk inserts).
+Uses `ON CONFLICT DO NOTHING` per table so re-runs are idempotent.
+
+Runs in two modes:
+- `--dry-run`: counts rows that would be inserted; writes nothing.
+- `--apply`: performs the inserts.
+
+Per-table progress printed; per-row errors logged but don't abort
+the run. Exit code 0 on success, 2 on hard error.
+
+### Phase 3 — Dual-write
+
+A new wrapper layer, `lavandula.reports.db_writer_dual`, wraps both
+the existing SQLite DBWriter and a new RDS writer. Same public
+interface; writes go to SQLite first (synchronous, fast), then
+queued to RDS (async, best-effort).
+
+RDS write failures are logged but do NOT fail the SQLite write.
+This keeps the crawler hot path fast and resilient to RDS outages
+during the stabilization period.
+
+Feature flag `LAVANDULA_DUAL_WRITE` (env var, default off). When
+off, behavior is pre-0013 identical. When on, RDS writes happen in
+parallel with SQLite writes.
+
+A background reconciler process runs periodically (manual for now,
+cron later) to compare row counts between SQLite and RDS and flag
+drift:
+
+```
+python -m lavandula.common.tools.verify_dual_write \
+    --sqlite data/seeds.db \
+    --rds-table nonprofits_seed
+```
+
+### Phase 4 — Read flip
+
+After ~2-4 weeks of stable dual-write with minimal drift, flip
+reads. Strategy:
+
+1. Add `LAVANDULA_READ_BACKEND` env var (values: `sqlite` | `rds`;
+   default `sqlite`).
+2. All read paths (crawler seed selection, classifier fetch, future
+   dashboard) consult this flag and use the appropriate engine.
+3. Default stays `sqlite` during the dual-write stabilization.
+4. To flip: set `LAVANDULA_READ_BACKEND=rds` in the environment
+   where the crawler runs.
+5. Rollback: unset the var. SQLite still has full state.
+
+---
+
+## Acceptance Criteria
+
+### Phase 0 — Provision
+
+**AC1** — RDS instance `lavandula-rds-prod` exists in us-east-1,
+Postgres 16.x, IAM auth enabled, deletion protection on.
+
+**AC2** — Security group allows ingress only from the EC2 instance
+role's security group on port 5432.
+
+**AC3** — Database `lavandula` exists with schema `lavandula`.
+Three roles (`lavandula_admin`, `lavandula_app`, `lavandula_ro`)
+exist with the permission grants specified in Design.
+
+**AC4** — SSM parameters populated for endpoint/port/database/users.
+`admin_password` is SecureString.
+
+### Phase 1 — Connect
+
+**AC5** — `lavandula.common.db.make_app_engine()` returns a working
+SQLAlchemy engine that can SELECT against the `lavandula` database.
+Verified via a smoke test that issues `SELECT 1`.
+
+**AC6** — Token refresh works: after 8 minutes of idle time, a new
+connection opens with a fresh IAM token (verified by monkey-patching
+the clock in tests).
+
+**AC7** — `pool_pre_ping=True` handles mid-connection token expiry:
+a connection whose token has expired triggers a reconnect on next
+use, not an exception.
+
+**AC8** — The `do_connect` event correctly injects password from
+the token manager; no password is passed via the URL or env.
+
+**AC9** — `make_ro_engine()` connects as `lavandula_ro` and is
+denied INSERT on any table (verified by a negative test).
+
+### Phase 2 — Backfill
+
+**AC10** — `backfill_rds.py --dry-run` counts rows without writing.
+**AC11** — `backfill_rds.py --apply` copies rows with per-table progress.
+**AC12** — Re-running `--apply` doesn't duplicate rows (`ON CONFLICT
+DO NOTHING`).
+**AC13** — Post-backfill row counts match between SQLite and RDS for
+each table, verified by the `verify_dual_write` tool.
+
+### Phase 3 — Dual-write
+
+**AC14** — With `LAVANDULA_DUAL_WRITE=1`, a crawler run writes to
+both SQLite and RDS; row counts stay in sync (±small backlog).
+**AC15** — RDS write failure does NOT fail the SQLite write. The
+crawler keeps running; the failure is logged with structured detail.
+**AC16** — With the flag off, behavior is byte-identical to pre-0013.
+
+### Phase 4 — Read flip
+
+**AC17** — With `LAVANDULA_READ_BACKEND=rds`, crawler reads seeds
+from RDS; query results match SQLite for the same filter.
+**AC18** — Unsetting the flag reverts to SQLite reads.
+
+---
+
+## Traps to Avoid
+
+1. **Don't read AWS credentials from env in the adapter.** boto3's
+   default credential chain handles this via IMDS on EC2.
+
+2. **Don't pass the IAM token via URL query string.** The password
+   must go through `do_connect` kwargs so SQLAlchemy can apply it
+   per-connection.
+
+3. **Don't use `pool_recycle < 8*60`.** Recycling more often than the
+   token-refresh cadence wastes connections without benefit.
+
+4. **Don't disable `sslmode=require`.** IAM auth requires TLS.
+
+5. **Don't assume RDS is always reachable during dual-write.** Failures
+   must be non-fatal for the SQLite path. A temporary RDS outage
+   should not stop the crawler.
+
+6. **Don't grant `lavandula_ro` any INSERT/UPDATE/DELETE.** The whole
+   point of the role is that it's *provably* read-only at the DB
+   layer, not just by convention.
+
+7. **Don't skip deletion protection on the RDS instance.** A
+   developer-accidentally-running-Terraform-destroy scenario is the
+   kind of thing we absolutely need to prevent.
+
+8. **Don't store the admin password in git or env.** SSM SecureString
+   only; fetched on-demand for DDL work.
+
+9. **Don't run the backfill without a recent snapshot of SQLite.**
+   Copy each `*.db` file to `*.db.pre-backfill.bak` first. The
+   backfill is idempotent but the safeguard costs nothing.
+
+10. **Don't skip the Phase 3 → Phase 4 stabilization period.** Flipping
+    reads immediately after dual-write starts would miss drift
+    signals. Wait ~2-4 weeks or until the reconciler reports zero
+    drift over multiple crawl cycles.
+
+---
+
+## Security Considerations
+
+### Threat model
+
+- **Assets**: RDS credentials (IAM tokens + admin password), database
+  contents (currently same as SQLite contents — not sensitive), the
+  EC2 IAM role that issues tokens.
+- **Actors**: Compromised EC2 host (could extract IAM role credentials
+  and connect as `lavandula_app`); misconfigured security group
+  (could expose RDS to the internet).
+
+### Mitigations
+
+1. **IAM auth, not passwords** for the app and ro roles. Tokens
+   expire in 15 minutes; stolen tokens have bounded lifetime.
+2. **No public RDS access**. Security group allows only the EC2
+   role's SG. Private subnet.
+3. **Least-privilege roles**: `app` gets DML on the `lavandula`
+   schema only; `ro` gets SELECT only; `admin` is human-access for
+   DDL (password, not used by applications).
+4. **SSL required**: all connections use `sslmode=require`. Not
+   `verify-full` for now (certificate rotation overhead); revisit
+   if threat model tightens.
+5. **Deletion protection**: on. `terraform destroy` / `aws rds
+   delete-db-instance` require an explicit operator step to remove.
+6. **Backup retention**: 7 days of automated PITR. Sufficient for
+   operational recovery; not a compliance-grade retention window.
+
+### Residual risks
+
+- **EC2 host compromise** → attacker connects as `lavandula_app`, can
+  read/write all app tables. Mitigations: the existing EC2 hardening
+  + short-lived IAM tokens + RDS doesn't contain user PII.
+- **Admin password leak** → DDL-level compromise. Mitigations:
+  SecureString in SSM, scoped access, only used for manual migrations.
+- **Schema migration drift** → Alembic must stay in sync with the
+  Python models. Tests (part of Phase 2 builder work) verify this.
+
+---
+
+## Files Changed / Added
+
+| Path | Status |
+|------|--------|
+| `lavandula/common/db.py` | NEW — IAM token manager + engine factories |
+| `lavandula/common/tools/backfill_rds.py` | NEW — one-time SQLite→RDS copy |
+| `lavandula/common/tools/verify_dual_write.py` | NEW — drift detection |
+| `lavandula/reports/db_writer_dual.py` | NEW — dual-write wrapper |
+| `lavandula/reports/db_writer.py` | EXTEND — accept optional RDS writer |
+| `lavandula/alembic/` | NEW — migration environment + initial schema |
+| `lavandula/common/tests/unit/test_db_adapter_0013.py` | NEW |
+| `lavandula/common/tests/unit/test_backfill_0013.py` | NEW |
+| `lavandula/reports/tests/unit/test_dual_write_0013.py` | NEW |
+
+---
+
+## Open Questions
+
+1. **Admin IAM policy scope**: the admin policy needed for RDS
+   provisioning (`rds:CreateDBInstance`, `rds:ModifyDBInstance`, etc.)
+   is broader than the runtime policy. Attach temporarily, detach
+   after provisioning — same pattern as the S3 bucket work.
+
+2. **Connection pooling across crawler threads**: the crawler uses
+   `ThreadPoolExecutor(max_workers=8)` (TICK-002). With `pool_size=5,
+   max_overflow=10`, we have up to 15 concurrent connections from
+   one crawler — comfortably under the `db.t4g.small` default of
+   ~100. If we scale parallelism, revisit.
+
+3. **Whether to adopt `psycopg` (v3) vs `psycopg2`**: psycopg v3 is
+   the modern driver with async support, but SQLAlchemy's defaults
+   and ecosystem compatibility favor psycopg2 for now. Recommend
+   staying on psycopg2 through Phase 4; revisit for Phase 5+.
+
+4. **Future retirement of SQLite** — out of scope for this spec but
+   worth flagging: once extraction/gallery apps rely on RDS as the
+   only source of truth, the SQLite layer becomes redundant. A
+   future spec retires the dual-write, makes RDS primary, and keeps
+   SQLite only for dev/CI.


### PR DESCRIPTION
## Summary
Implements Spec 0013 **Phase 1 only** — the Python connection adapter for the new RDS Postgres instance (`lava_prod1.lava_impact`). Phases 2–4 (backfill, dual-write, read-flip) are out of scope for this PR.

- `lavandula/common/db.py` — `IAMTokenManager` (thread-safe, 8-min TTL, injectable clock/rds client) + `make_engine` (no password in URL, `sslmode=require`, `pool_pre_ping=True`, `pool_recycle=480`, `do_connect` event injects token, optional `search_path`) + `make_app_engine` / `make_ro_engine` reading flat SSM keys (`rds-endpoint`, `rds-port`, `rds-database`, `rds-schema`, `rds-app-user`, `rds-ro-user`).
- `lavandula/common/tests/unit/test_db_adapter_0013.py` — 9 unit tests covering AC5–AC9 with mocked boto3 and monkey-patched clock (including the 8-min refresh test and thread-safety check); 2 live-RDS smoke tests gated on `LAVANDULA_LIVE_RDS=1`.
- `lavandula/common/requirements.in` — declares sqlalchemy, psycopg2-binary, boto3.

## Test plan
- [x] Unit tests pass locally: 9 passed, 2 skipped (live-RDS)
- [ ] Run `LAVANDULA_LIVE_RDS=1 pytest lavandula/common/tests/unit/test_db_adapter_0013.py` on the EC2 host with the `cloud2_lavandulagroup` role to verify AC5 (app_user1 SELECT 1) and AC9 (ro_user1 INSERT denied) against the live `lava_prod1` database.

🤖 Generated with [Claude Code](https://claude.com/claude-code)