### PR TITLE
[Spec 0013][Phase 2] SQLite -> RDS backfill tool

### DIFF
--- a/lavandula/common/tests/unit/test_backfill_rds_0013.py
+++ b/lavandula/common/tests/unit/test_backfill_rds_0013.py
@@ -27,10 +27,16 @@ class FakePgCursor:
     def __init__(self, pg: "FakePgConn") -> None:
         self.pg = pg
         self._result: list[tuple] = []
+        self.rowcount: int = -1
 
     def execute(self, sql: str, params: Any = None) -> None:
         self.pg.queries.append((sql, params))
         norm = " ".join(sql.split())
+        # Savepoint commands are no-ops for the fake; leave rowcount alone.
+        if norm.startswith(("SAVEPOINT ", "RELEASE SAVEPOINT ",
+                            "ROLLBACK TO SAVEPOINT ")):
+            self._result = []
+            return
         if norm.startswith("SELECT column_name FROM information_schema.columns"):
             _schema, table = params
             cols = self.pg.columns_by_table.get(table, [])
@@ -123,13 +129,16 @@ class FakeEngine:
 
 def _make_execute_values_recorder(
     *, fail_predicate: Callable[[str, list], bool] | None = None,
+    rowcount_for: Callable[[str, list], int] | None = None,
     track_counts: dict[str, int] | None = None,
 ) -> tuple[Callable, list[dict]]:
     """Return a fake `execute_values` + a call log.
 
     `fail_predicate(sql, rows)` returns True to raise, simulating a row
-    or batch failure. `track_counts` is a dict from table name to the
-    running count; each successful call bumps it by len(rows).
+    or batch failure. `rowcount_for(sql, rows)` overrides cur.rowcount
+    (default: len(rows)) — use it to simulate ON CONFLICT DO NOTHING
+    returning fewer (or zero) actual inserts. `track_counts` bumps a
+    running dict of dest counts by the inserted amount.
     """
     calls: list[dict] = []
 
@@ -142,10 +151,16 @@ def _make_execute_values_recorder(
         })
         if fail_predicate and fail_predicate(sql, rows):
             raise RuntimeError("simulated execute_values failure")
+        inserted = (
+            rowcount_for(sql, rows) if rowcount_for is not None else len(rows)
+        )
+        cur.rowcount = inserted
         if track_counts is not None:
             for name in list(track_counts):
                 if f'"{name}"' in sql:
-                    track_counts[name] = track_counts.get(name, 0) + len(rows)
+                    track_counts[name] = (
+                        track_counts.get(name, 0) + inserted
+                    )
                     break
         return None
 
@@ -502,7 +517,13 @@ def test_per_row_error_continues_batch(sqlite_path):
     assert rc == 3  # per-row errors > 0
     # 1 batch call + 3 row-by-row calls = 4
     assert len(calls) == 4
-    assert pg.rollbacks >= 2  # failed batch + failed row
+    # Savepoint rollbacks, not full-transaction rollbacks.
+    rollback_sp_calls = [
+        q for q, _ in pg.queries
+        if q.startswith("ROLLBACK TO SAVEPOINT ")
+    ]
+    assert len(rollback_sp_calls) >= 2  # failed batch + failed row
+    assert pg.rollbacks == 0  # whole-table rollback NOT triggered
     assert pg.commits >= 1
 
 
@@ -594,6 +615,128 @@ def test_unknown_table_name_rejected():
 # ---------------------------------------------------------------------------
 # Factory plumbing
 # ---------------------------------------------------------------------------
+
+
+# ---------------------------------------------------------------------------
+# Review-round-1 regression tests
+# ---------------------------------------------------------------------------
+
+
+def test_multi_batch_failure_preserves_earlier_batches(tmp_path):
+    """A failing batch must unwind ONLY itself; earlier batches stay.
+
+    Three batches of 1 row each (batch_size=1). Batch 2 fails hard (no
+    row-level retry saves it either). Assert batches 1 and 3 were
+    committed: each issued SAVEPOINT + RELEASE SAVEPOINT, and the final
+    commit() fires — no whole-table rollback.
+    """
+    p = tmp_path / "src.db"
+    conn = sqlite3.connect(p)
+    conn.executescript(_SEED_DDL)
+    conn.executemany(
+        "INSERT INTO nonprofits_seed (ein, name, state, extra_source_only) "
+        "VALUES (?,?,?,?)",
+        [
+            ("A01", "One",   "NY", "x"),
+            ("BAD", "Two",   "TX", "x"),
+            ("A03", "Three", "CA", "x"),
+        ],
+    )
+    conn.commit()
+    conn.close()
+
+    pg = _default_pg()
+
+    def fail_pred(sql, rows):
+        # Fail on any batch that contains the BAD pk. Covers both the
+        # initial 1-row batch attempt and the row-by-row retry for it.
+        return any(r[0] == "BAD" for r in rows)
+
+    ev, calls = _make_execute_values_recorder(
+        fail_predicate=fail_pred,
+        track_counts={"nonprofits_seed": 0},
+    )
+
+    rc = bf.run(
+        source_sqlite=str(p),
+        tables=["nonprofits_seed"],
+        batch_size=1,
+        schema="lava_impact",
+        dry_run=False,
+        apply_duplicates_ok=False,
+        engine_factory=lambda: FakeEngine(pg),
+        execute_values=ev,
+    )
+
+    # 3 batch attempts + 1 row retry for the failing singleton = 4 calls
+    assert len(calls) == 4
+    # Exit code 3 (per-row error), not 2 (table error).
+    assert rc == 3
+    # Commits fired once at end of table (not per-batch); prior batches
+    # are preserved because only their savepoints were released.
+    assert pg.commits == 1
+    assert pg.rollbacks == 0
+    # Validate the sequence of savepoint ops.
+    ops = [q for q, _ in pg.queries]
+    sp_count = sum(1 for q in ops if q.startswith("SAVEPOINT "))
+    release_count = sum(1 for q in ops if q.startswith("RELEASE SAVEPOINT "))
+    rollback_sp_count = sum(
+        1 for q in ops if q.startswith("ROLLBACK TO SAVEPOINT ")
+    )
+    # Two successful savepoints (A01 + A03) + one failing batch savepoint
+    # + one failing row savepoint = 4 SAVEPOINT; 2 RELEASE; 2 ROLLBACK TO.
+    assert sp_count == 4
+    assert release_count == 2
+    assert rollback_sp_count == 2
+
+
+def test_idempotent_rerun_reports_zero_inserted(sqlite_path, capsys):
+    """When ON CONFLICT DO NOTHING discards every row, `inserted` must
+    reflect actual inserts (0), not rows attempted."""
+    pg = _default_pg(seed_count=3)
+    # Simulate all duplicates: server reports rowcount=0.
+    ev, _calls = _make_execute_values_recorder(
+        rowcount_for=lambda sql, rows: 0,
+        track_counts={"nonprofits_seed": 3},
+    )
+
+    rc = bf.run(
+        source_sqlite=sqlite_path,
+        tables=["nonprofits_seed"],
+        batch_size=100,
+        schema="lava_impact",
+        dry_run=False,
+        apply_duplicates_ok=False,
+        engine_factory=lambda: FakeEngine(pg),
+        execute_values=ev,
+    )
+    assert rc == 0
+    out = capsys.readouterr().out
+    # Expect `inserted: 0` even though 3 rows were attempted.
+    assert "inserted:         0" in out
+
+
+def test_dry_run_auto_id_reports_skip(sqlite_path, capsys):
+    """Dry-run must mirror apply: if dest auto-id table already has rows,
+    report SKIPPED, not 'would insert N'."""
+    pg = _default_pg(fetch_log_count=7)
+    ev, calls = _make_execute_values_recorder()
+
+    rc = bf.run(
+        source_sqlite=sqlite_path,
+        tables=["fetch_log"],
+        batch_size=100,
+        schema="lava_impact",
+        dry_run=True,
+        apply_duplicates_ok=False,
+        engine_factory=lambda: FakeEngine(pg),
+        execute_values=ev,
+    )
+    assert rc == 0
+    assert calls == []
+    out = capsys.readouterr().out
+    assert "SKIPPED" in out
+    assert "would insert" not in out
 
 
 def test_uses_app_engine_by_default(monkeypatch, sqlite_path):

--- a/lavandula/common/tests/unit/test_backfill_rds_0013.py
+++ b/lavandula/common/tests/unit/test_backfill_rds_0013.py
@@ -1,0 +1,626 @@
+"""Unit tests for `lavandula.common.tools.backfill_rds` (Spec 0013 Phase 2).
+
+All DB I/O is mocked. A real tempfile SQLite is used for the source side
+(`sqlite3` is stdlib and fast); the Postgres side is a FakePgConn that
+records calls and serves canned information_schema / COUNT results.
+`execute_values` is likewise injected.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import sqlite3
+import tempfile
+from typing import Any, Callable
+
+import pytest
+
+from lavandula.common.tools import backfill_rds as bf
+
+
+# ---------------------------------------------------------------------------
+# Test doubles
+# ---------------------------------------------------------------------------
+
+
+class FakePgCursor:
+    def __init__(self, pg: "FakePgConn") -> None:
+        self.pg = pg
+        self._result: list[tuple] = []
+
+    def execute(self, sql: str, params: Any = None) -> None:
+        self.pg.queries.append((sql, params))
+        norm = " ".join(sql.split())
+        if norm.startswith("SELECT column_name FROM information_schema.columns"):
+            _schema, table = params
+            cols = self.pg.columns_by_table.get(table, [])
+            self._result = [(c,) for c in cols]
+            return
+        if "COUNT(*)" in norm:
+            matched = False
+            for tname, cnt in self.pg.counts.items():
+                if f'"{tname}"' in sql:
+                    self._result = [(cnt,)]
+                    matched = True
+                    break
+            if not matched:
+                self._result = [(0,)]
+            return
+        self._result = []
+
+    def fetchall(self) -> list[tuple]:
+        return list(self._result)
+
+    def fetchone(self):
+        return self._result[0] if self._result else None
+
+    def __enter__(self) -> "FakePgCursor":
+        return self
+
+    def __exit__(self, *_exc) -> bool:
+        return False
+
+
+class FakePgConn:
+    def __init__(
+        self,
+        *,
+        columns_by_table: dict[str, list[str]] | None = None,
+        counts: dict[str, int] | None = None,
+        fail_on_count_for: set[str] | None = None,
+    ) -> None:
+        self.columns_by_table = columns_by_table or {}
+        self.counts = counts or {}
+        self.fail_on_count_for = fail_on_count_for or set()
+        self.queries: list[tuple[str, Any]] = []
+        self.commits = 0
+        self.rollbacks = 0
+        self.autocommit = True
+
+    def cursor(self) -> FakePgCursor:
+        cur = FakePgCursor(self)
+        # Allow forced failures for specific tables' COUNT queries
+        if self.fail_on_count_for:
+            orig_execute = cur.execute
+
+            def patched_execute(sql: str, params: Any = None) -> None:
+                if "COUNT(*)" in sql:
+                    for t in self.fail_on_count_for:
+                        if f'"{t}"' in sql:
+                            raise RuntimeError(
+                                f"forced count failure for {t}"
+                            )
+                orig_execute(sql, params)
+
+            cur.execute = patched_execute  # type: ignore[method-assign]
+        return cur
+
+    def commit(self) -> None:
+        self.commits += 1
+
+    def rollback(self) -> None:
+        self.rollbacks += 1
+
+
+class FakeSAConn:
+    def __init__(self, pg: FakePgConn) -> None:
+        self.connection = pg
+
+    def __enter__(self) -> "FakeSAConn":
+        return self
+
+    def __exit__(self, *_exc) -> bool:
+        return False
+
+
+class FakeEngine:
+    def __init__(self, pg: FakePgConn) -> None:
+        self._pg = pg
+
+    def connect(self) -> FakeSAConn:
+        return FakeSAConn(self._pg)
+
+
+def _make_execute_values_recorder(
+    *, fail_predicate: Callable[[str, list], bool] | None = None,
+    track_counts: dict[str, int] | None = None,
+) -> tuple[Callable, list[dict]]:
+    """Return a fake `execute_values` + a call log.
+
+    `fail_predicate(sql, rows)` returns True to raise, simulating a row
+    or batch failure. `track_counts` is a dict from table name to the
+    running count; each successful call bumps it by len(rows).
+    """
+    calls: list[dict] = []
+
+    def _ev(cur, sql, rows, page_size=None, template=None):
+        rows = list(rows)
+        calls.append({
+            "sql": sql,
+            "rows": rows,
+            "page_size": page_size,
+        })
+        if fail_predicate and fail_predicate(sql, rows):
+            raise RuntimeError("simulated execute_values failure")
+        if track_counts is not None:
+            for name in list(track_counts):
+                if f'"{name}"' in sql:
+                    track_counts[name] = track_counts.get(name, 0) + len(rows)
+                    break
+        return None
+
+    return _ev, calls
+
+
+# ---------------------------------------------------------------------------
+# Fixtures: source sqlite with known tables
+# ---------------------------------------------------------------------------
+
+_SEED_DDL = """
+CREATE TABLE nonprofits_seed (
+    ein TEXT PRIMARY KEY,
+    name TEXT,
+    state TEXT,
+    extra_source_only TEXT
+);
+"""
+
+_FETCH_LOG_DDL = """
+CREATE TABLE fetch_log (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    ein TEXT,
+    url_redacted TEXT,
+    kind TEXT,
+    fetch_status TEXT,
+    fetched_at TEXT
+);
+"""
+
+
+@pytest.fixture()
+def sqlite_path(tmp_path):
+    p = tmp_path / "src.db"
+    conn = sqlite3.connect(p)
+    conn.executescript(_SEED_DDL + _FETCH_LOG_DDL)
+    conn.executemany(
+        "INSERT INTO nonprofits_seed (ein, name, state, extra_source_only) "
+        "VALUES (?,?,?,?)",
+        [
+            ("001", "Alpha", "NY", "s1"),
+            ("002", "Beta",  "TX", "s2"),
+            ("003", "Gamma", "CA", "s3"),
+        ],
+    )
+    conn.executemany(
+        "INSERT INTO fetch_log (ein, url_redacted, kind, fetch_status, "
+        "fetched_at) VALUES (?,?,?,?,?)",
+        [
+            ("001", "https://a", "homepage", "ok", "2026-01-01T00:00:00Z"),
+            ("002", "https://b", "homepage", "ok", "2026-01-01T00:00:00Z"),
+        ],
+    )
+    conn.commit()
+    conn.close()
+    return str(p)
+
+
+def _default_pg(
+    *,
+    seed_count: int = 0,
+    fetch_log_count: int = 0,
+    target_only_extra: bool = True,
+) -> FakePgConn:
+    seed_cols = ["ein", "name", "state"]
+    if target_only_extra:
+        seed_cols.append("target_only_col")
+    return FakePgConn(
+        columns_by_table={
+            "nonprofits_seed": seed_cols,
+            "fetch_log": [
+                "id", "ein", "url_redacted", "kind",
+                "fetch_status", "fetched_at",
+            ],
+        },
+        counts={
+            "nonprofits_seed": seed_count,
+            "fetch_log": fetch_log_count,
+        },
+    )
+
+
+# ---------------------------------------------------------------------------
+# CLI arg parsing
+# ---------------------------------------------------------------------------
+
+
+def test_argv_requires_exactly_one_of_dry_run_or_apply():
+    with pytest.raises(SystemExit):
+        bf._parse_args(["--source-sqlite", "x.db"])
+    with pytest.raises(SystemExit):
+        bf._parse_args([
+            "--source-sqlite", "x.db", "--dry-run", "--apply",
+        ])
+
+
+def test_argv_source_sqlite_required():
+    with pytest.raises(SystemExit):
+        bf._parse_args(["--dry-run"])
+
+
+def test_argv_accepts_repeated_table_flag():
+    ns = bf._parse_args([
+        "--source-sqlite", "x.db",
+        "--table", "nonprofits_seed",
+        "--table", "reports",
+        "--dry-run",
+    ])
+    assert ns.table == ["nonprofits_seed", "reports"]
+
+
+# ---------------------------------------------------------------------------
+# Column intersection + alignment
+# ---------------------------------------------------------------------------
+
+
+def test_column_intersection_skips_missing_sides(sqlite_path, caplog):
+    caplog.set_level(logging.INFO, logger=bf.log.name)
+    pg = _default_pg()
+    ev, calls = _make_execute_values_recorder(track_counts={
+        "nonprofits_seed": 0,
+    })
+
+    rc = bf.run(
+        source_sqlite=sqlite_path,
+        tables=["nonprofits_seed"],
+        batch_size=100,
+        schema="lava_impact",
+        dry_run=False,
+        apply_duplicates_ok=False,
+        engine_factory=lambda: FakeEngine(pg),
+        execute_values=ev,
+    )
+    assert rc == 0
+    assert len(calls) == 1
+    sql = calls[0]["sql"]
+    # Only the intersection columns appear.
+    assert '"ein"' in sql and '"name"' in sql and '"state"' in sql
+    assert "extra_source_only" not in sql
+    assert "target_only_col" not in sql
+    # Logging at INFO notes both sides.
+    msgs = [r.getMessage() for r in caplog.records]
+    assert any("source-only columns" in m and "extra_source_only" in m
+               for m in msgs)
+    assert any("target-only columns" in m and "target_only_col" in m
+               for m in msgs)
+
+
+def test_mismatched_table_logs_info(sqlite_path, caplog):
+    caplog.set_level(logging.INFO, logger=bf.log.name)
+    pg = _default_pg()
+    ev, _calls = _make_execute_values_recorder(track_counts={
+        "nonprofits_seed": 0,
+    })
+    bf.run(
+        source_sqlite=sqlite_path,
+        tables=["nonprofits_seed"],
+        batch_size=100,
+        schema="lava_impact",
+        dry_run=False,
+        apply_duplicates_ok=False,
+        engine_factory=lambda: FakeEngine(pg),
+        execute_values=ev,
+    )
+    joined = "\n".join(r.getMessage() for r in caplog.records)
+    assert "extra_source_only" in joined
+
+
+# ---------------------------------------------------------------------------
+# Dry-run
+# ---------------------------------------------------------------------------
+
+
+def test_dry_run_counts_rows_no_writes(sqlite_path, capsys):
+    pg = _default_pg(seed_count=1)
+    ev, calls = _make_execute_values_recorder()
+
+    rc = bf.run(
+        source_sqlite=sqlite_path,
+        tables=["nonprofits_seed"],
+        batch_size=100,
+        schema="lava_impact",
+        dry_run=True,
+        apply_duplicates_ok=False,
+        engine_factory=lambda: FakeEngine(pg),
+        execute_values=ev,
+    )
+    assert rc == 0
+    assert calls == []  # no writes
+    out = capsys.readouterr().out
+    assert "would insert" in out
+    assert pg.commits == 0
+
+
+# ---------------------------------------------------------------------------
+# Apply path
+# ---------------------------------------------------------------------------
+
+
+def test_apply_inserts_rows_via_execute_values(sqlite_path):
+    pg = _default_pg()
+    ev, calls = _make_execute_values_recorder(track_counts={
+        "nonprofits_seed": 0,
+    })
+
+    rc = bf.run(
+        source_sqlite=sqlite_path,
+        tables=["nonprofits_seed"],
+        batch_size=100,
+        schema="lava_impact",
+        dry_run=False,
+        apply_duplicates_ok=False,
+        engine_factory=lambda: FakeEngine(pg),
+        execute_values=ev,
+    )
+    assert rc == 0
+    assert len(calls) == 1
+    rows = calls[0]["rows"]
+    assert len(rows) == 3
+    # Rows come in as tuples from sqlite; values preserved in col order.
+    assert set(tuple(r) for r in rows) == {
+        ("001", "Alpha", "NY"),
+        ("002", "Beta", "TX"),
+        ("003", "Gamma", "CA"),
+    }
+    assert pg.commits >= 1
+
+
+def test_on_conflict_skips_existing_rows(sqlite_path):
+    pg = _default_pg()
+    ev, calls = _make_execute_values_recorder(track_counts={
+        "nonprofits_seed": 0,
+    })
+    bf.run(
+        source_sqlite=sqlite_path,
+        tables=["nonprofits_seed"],
+        batch_size=100,
+        schema="lava_impact",
+        dry_run=False,
+        apply_duplicates_ok=False,
+        engine_factory=lambda: FakeEngine(pg),
+        execute_values=ev,
+    )
+    sql = calls[0]["sql"]
+    assert 'ON CONFLICT ("ein") DO NOTHING' in sql
+
+
+# ---------------------------------------------------------------------------
+# Auto-id tables
+# ---------------------------------------------------------------------------
+
+
+def test_auto_id_tables_omit_id_column(sqlite_path):
+    pg = _default_pg()
+    ev, calls = _make_execute_values_recorder(track_counts={
+        "fetch_log": 0,
+    })
+
+    rc = bf.run(
+        source_sqlite=sqlite_path,
+        tables=["fetch_log"],
+        batch_size=100,
+        schema="lava_impact",
+        dry_run=False,
+        apply_duplicates_ok=False,
+        engine_factory=lambda: FakeEngine(pg),
+        execute_values=ev,
+    )
+    assert rc == 0
+    assert len(calls) == 1
+    sql = calls[0]["sql"]
+    # id column must NOT appear in the column list — quoted or bare.
+    assert '"id"' not in sql
+    # No ON CONFLICT for auto-id tables.
+    assert "ON CONFLICT" not in sql
+    # Each row must have one fewer value than the full source column set.
+    assert all(len(r) == 5 for r in calls[0]["rows"])  # 5 non-id cols
+
+
+def test_auto_id_skip_when_dest_has_rows(sqlite_path, caplog):
+    caplog.set_level(logging.WARNING, logger=bf.log.name)
+    pg = _default_pg(fetch_log_count=7)
+    ev, calls = _make_execute_values_recorder()
+
+    rc = bf.run(
+        source_sqlite=sqlite_path,
+        tables=["fetch_log"],
+        batch_size=100,
+        schema="lava_impact",
+        dry_run=False,
+        apply_duplicates_ok=False,
+        engine_factory=lambda: FakeEngine(pg),
+        execute_values=ev,
+    )
+    assert rc == 0
+    assert calls == []  # no insertion
+    joined = "\n".join(r.getMessage() for r in caplog.records)
+    assert "auto-id" in joined
+    assert "skipping" in joined
+
+
+def test_auto_id_apply_duplicates_ok_forces_insert(sqlite_path):
+    pg = _default_pg(fetch_log_count=7)
+    ev, calls = _make_execute_values_recorder(track_counts={
+        "fetch_log": 7,
+    })
+
+    rc = bf.run(
+        source_sqlite=sqlite_path,
+        tables=["fetch_log"],
+        batch_size=100,
+        schema="lava_impact",
+        dry_run=False,
+        apply_duplicates_ok=True,
+        engine_factory=lambda: FakeEngine(pg),
+        execute_values=ev,
+    )
+    assert rc == 0
+    assert len(calls) == 1
+    assert len(calls[0]["rows"]) == 2
+
+
+# ---------------------------------------------------------------------------
+# Error handling
+# ---------------------------------------------------------------------------
+
+
+def test_per_row_error_continues_batch(sqlite_path):
+    """A batch failure triggers row-by-row retry; one bad row yields exit 3."""
+    pg = _default_pg()
+    # Simulate: batch (len > 1) fails; within row-by-row retry, the row
+    # whose ein='002' fails; others succeed.
+    def fail_pred(sql, rows):
+        if len(rows) > 1:
+            return True
+        row = rows[0]
+        return row[0] == "002"
+
+    ev, calls = _make_execute_values_recorder(
+        fail_predicate=fail_pred,
+        track_counts={"nonprofits_seed": 0},
+    )
+
+    rc = bf.run(
+        source_sqlite=sqlite_path,
+        tables=["nonprofits_seed"],
+        batch_size=100,
+        schema="lava_impact",
+        dry_run=False,
+        apply_duplicates_ok=False,
+        engine_factory=lambda: FakeEngine(pg),
+        execute_values=ev,
+    )
+    assert rc == 3  # per-row errors > 0
+    # 1 batch call + 3 row-by-row calls = 4
+    assert len(calls) == 4
+    assert pg.rollbacks >= 2  # failed batch + failed row
+    assert pg.commits >= 1
+
+
+def test_per_table_error_moves_to_next(sqlite_path):
+    """If nonprofits_seed's Postgres COUNT errors out, we proceed to
+    fetch_log and the run reports exit 2."""
+    pg = FakePgConn(
+        columns_by_table={
+            "nonprofits_seed": ["ein", "name", "state"],
+            "fetch_log": [
+                "id", "ein", "url_redacted", "kind",
+                "fetch_status", "fetched_at",
+            ],
+        },
+        counts={"nonprofits_seed": 0, "fetch_log": 0},
+        fail_on_count_for={"nonprofits_seed"},
+    )
+    ev, calls = _make_execute_values_recorder(track_counts={
+        "fetch_log": 0,
+    })
+
+    rc = bf.run(
+        source_sqlite=sqlite_path,
+        tables=["nonprofits_seed", "fetch_log"],
+        batch_size=100,
+        schema="lava_impact",
+        dry_run=False,
+        apply_duplicates_ok=False,
+        engine_factory=lambda: FakeEngine(pg),
+        execute_values=ev,
+    )
+    assert rc == 2
+    # fetch_log still got its insert call.
+    assert len(calls) == 1
+    assert '"fetch_log"' in calls[0]["sql"]
+
+
+# ---------------------------------------------------------------------------
+# Batch size
+# ---------------------------------------------------------------------------
+
+
+def test_batch_size_honored(sqlite_path):
+    pg = _default_pg()
+    ev, calls = _make_execute_values_recorder(track_counts={
+        "nonprofits_seed": 0,
+    })
+
+    rc = bf.run(
+        source_sqlite=sqlite_path,
+        tables=["nonprofits_seed"],
+        batch_size=2,
+        schema="lava_impact",
+        dry_run=False,
+        apply_duplicates_ok=False,
+        engine_factory=lambda: FakeEngine(pg),
+        execute_values=ev,
+    )
+    assert rc == 0
+    # 3 rows with batch_size=2 → two batches (2 + 1).
+    assert [len(c["rows"]) for c in calls] == [2, 1]
+    assert all(c["page_size"] == 2 for c in calls)
+
+
+# ---------------------------------------------------------------------------
+# Identifier safety
+# ---------------------------------------------------------------------------
+
+
+def test_unsafe_schema_rejected(sqlite_path):
+    with pytest.raises(ValueError):
+        bf.run(
+            source_sqlite=sqlite_path,
+            tables=["nonprofits_seed"],
+            batch_size=100,
+            schema="bad; DROP TABLE",
+            dry_run=True,
+            apply_duplicates_ok=False,
+            engine_factory=lambda: FakeEngine(_default_pg()),
+            execute_values=lambda *a, **k: None,
+        )
+
+
+def test_unknown_table_name_rejected():
+    with pytest.raises(SystemExit):
+        bf._resolve_table_specs(["no_such_table"])
+
+
+# ---------------------------------------------------------------------------
+# Factory plumbing
+# ---------------------------------------------------------------------------
+
+
+def test_uses_app_engine_by_default(monkeypatch, sqlite_path):
+    """`run(engine_factory=None)` must call `make_app_engine`, not
+    anything master-level."""
+    called = {"n": 0}
+    pg = _default_pg()
+
+    def fake_app_engine():
+        called["n"] += 1
+        return FakeEngine(pg)
+
+    monkeypatch.setattr(
+        "lavandula.common.db.make_app_engine", fake_app_engine, raising=True,
+    )
+    ev, _calls = _make_execute_values_recorder(track_counts={
+        "nonprofits_seed": 0,
+    })
+    rc = bf.run(
+        source_sqlite=sqlite_path,
+        tables=["nonprofits_seed"],
+        batch_size=100,
+        schema="lava_impact",
+        dry_run=True,
+        apply_duplicates_ok=False,
+        engine_factory=None,  # triggers default resolution
+        execute_values=ev,
+    )
+    assert rc == 0
+    assert called["n"] == 1

--- a/lavandula/common/tools/backfill_rds.py
+++ b/lavandula/common/tools/backfill_rds.py
@@ -1,0 +1,538 @@
+"""One-time SQLite → RDS Postgres backfill (Spec 0013 Phase 2).
+
+Copies rows from a source SQLite DB file into the configured RDS
+Postgres instance (schema `lava_impact`) using fast batched inserts.
+Runs under the runtime IAM-auth path via
+`lavandula.common.db.make_app_engine` — no master credentials are
+ever read.
+
+Seven tables are known. Four have explicit primary keys and use
+`ON CONFLICT (pk) DO NOTHING` so re-runs are idempotent. Three are
+auto-increment log tables; the source `id` column is dropped and
+Postgres assigns fresh sequence values. A safeguard prevents
+accidental duplicate log floods on re-run: when the destination
+already has rows in an auto-id table, the table is skipped unless
+`--apply-duplicates-ok` is passed.
+
+Usage
+-----
+    python -m lavandula.common.tools.backfill_rds \\
+        --source-sqlite /path/to/seeds.db \\
+        [--table TABLE]... \\
+        [--batch-size 1000] \\
+        [--schema lava_impact] \\
+        (--dry-run | --apply) \\
+        [--apply-duplicates-ok]
+
+Exit codes
+----------
+  0  success, no errors
+  2  connection-level or per-table failure
+  3  partial success (>=1 per-row error)
+"""
+from __future__ import annotations
+
+import argparse
+import logging
+import sqlite3
+import sys
+import time
+from dataclasses import dataclass, field
+from typing import Any, Iterable, Sequence
+
+log = logging.getLogger("lavandula.common.tools.backfill_rds")
+
+
+# ---------------------------------------------------------------------------
+# Table registry
+# ---------------------------------------------------------------------------
+
+@dataclass(frozen=True)
+class TableSpec:
+    name: str
+    pk: str | None  # None for auto-id tables
+    auto_id: bool = False
+
+
+TABLES: tuple[TableSpec, ...] = (
+    TableSpec("nonprofits_seed", pk="ein"),
+    TableSpec("reports",         pk="content_sha256"),
+    TableSpec("crawled_orgs",    pk="ein"),
+    TableSpec("runs",            pk="run_id"),
+    TableSpec("fetch_log",       pk=None, auto_id=True),
+    TableSpec("deletion_log",    pk=None, auto_id=True),
+    TableSpec("budget_ledger",   pk=None, auto_id=True),
+)
+
+TABLE_BY_NAME: dict[str, TableSpec] = {t.name: t for t in TABLES}
+
+
+# ---------------------------------------------------------------------------
+# Identifier validation — we build some SQL with f-strings since psycopg2
+# can't parameterize table / column / schema names. Strict whitelist.
+# ---------------------------------------------------------------------------
+
+import re
+_IDENT_RE = re.compile(r"^[a-z_][a-z0-9_]{0,62}$")
+
+
+def _safe_ident(name: str) -> str:
+    if not _IDENT_RE.match(name):
+        raise ValueError(f"unsafe SQL identifier: {name!r}")
+    return name
+
+
+# ---------------------------------------------------------------------------
+# Column discovery
+# ---------------------------------------------------------------------------
+
+def _sqlite_columns(conn: sqlite3.Connection, table: str) -> list[str]:
+    """Return column names for `table` in insert order (PRAGMA cid ORDER)."""
+    cur = conn.execute(f"PRAGMA table_info({_safe_ident(table)})")
+    rows = cur.fetchall()
+    # PRAGMA returns (cid, name, type, notnull, dflt_value, pk). Sort by cid.
+    rows = sorted(rows, key=lambda r: r[0])
+    return [r[1] for r in rows]
+
+
+def _postgres_columns(pg_cur, schema: str, table: str) -> list[str]:
+    pg_cur.execute(
+        "SELECT column_name "
+        "FROM information_schema.columns "
+        "WHERE table_schema = %s AND table_name = %s "
+        "ORDER BY ordinal_position",
+        (schema, table),
+    )
+    return [r[0] for r in pg_cur.fetchall()]
+
+
+# ---------------------------------------------------------------------------
+# Counts
+# ---------------------------------------------------------------------------
+
+def _sqlite_count(conn: sqlite3.Connection, table: str) -> int:
+    cur = conn.execute(f"SELECT COUNT(*) FROM {_safe_ident(table)}")
+    return int(cur.fetchone()[0])
+
+
+def _postgres_count(pg_cur, schema: str, table: str) -> int:
+    pg_cur.execute(
+        f'SELECT COUNT(*) FROM "{_safe_ident(schema)}"."{_safe_ident(table)}"'
+    )
+    return int(pg_cur.fetchone()[0])
+
+
+# ---------------------------------------------------------------------------
+# Batch insert
+# ---------------------------------------------------------------------------
+
+def _build_insert_sql(
+    schema: str, table: str, cols: Sequence[str], pk: str | None
+) -> str:
+    schema = _safe_ident(schema)
+    table = _safe_ident(table)
+    col_list = ", ".join(f'"{_safe_ident(c)}"' for c in cols)
+    sql = (
+        f'INSERT INTO "{schema}"."{table}" ({col_list}) '
+        "VALUES %s"
+    )
+    if pk is not None:
+        sql += f' ON CONFLICT ("{_safe_ident(pk)}") DO NOTHING'
+    return sql
+
+
+def _chunked(rows: Iterable[tuple], size: int):
+    batch: list[tuple] = []
+    for r in rows:
+        batch.append(r)
+        if len(batch) >= size:
+            yield batch
+            batch = []
+    if batch:
+        yield batch
+
+
+@dataclass
+class TableResult:
+    table: str
+    source_rows: int = 0
+    target_before: int = 0
+    target_after: int = 0
+    inserted: int = 0
+    skipped_existing: bool = False
+    per_row_errors: int = 0
+    table_error: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# Per-table backfill
+# ---------------------------------------------------------------------------
+
+def backfill_table(
+    *,
+    spec: TableSpec,
+    sqlite_conn: sqlite3.Connection,
+    pg_conn,
+    schema: str,
+    batch_size: int,
+    dry_run: bool,
+    apply_duplicates_ok: bool,
+    execute_values,  # injected: psycopg2.extras.execute_values
+) -> TableResult:
+    """Backfill a single table. Returns a TableResult.
+
+    Mutates `pg_conn` by issuing BEGIN / COMMIT for --apply mode.
+    On per-table failure the Postgres transaction is rolled back.
+    """
+    res = TableResult(table=spec.name)
+
+    try:
+        src_cols = _sqlite_columns(sqlite_conn, spec.name)
+    except sqlite3.Error as exc:
+        res.table_error = f"sqlite PRAGMA failed: {exc.__class__.__name__}"
+        log.error("%s: source unavailable: %s", spec.name, res.table_error)
+        return res
+
+    if not src_cols:
+        res.table_error = "source table missing or empty schema"
+        log.error("%s: %s", spec.name, res.table_error)
+        return res
+
+    with pg_conn.cursor() as cur:
+        try:
+            dst_cols = _postgres_columns(cur, schema, spec.name)
+        except Exception as exc:  # noqa: BLE001
+            pg_conn.rollback()
+            res.table_error = (
+                f"postgres column lookup failed: {exc.__class__.__name__}"
+            )
+            log.error("%s: %s", spec.name, res.table_error)
+            return res
+
+    if not dst_cols:
+        res.table_error = "destination table not found in schema"
+        log.error("%s: %s in schema %s", spec.name, res.table_error, schema)
+        return res
+
+    # Alignment: intersection preserves source insert order.
+    src_set = set(src_cols)
+    dst_set = set(dst_cols)
+
+    only_src = [c for c in src_cols if c not in dst_set]
+    only_dst = [c for c in dst_cols if c not in src_set]
+    if only_src:
+        log.info("%s: source-only columns ignored: %s",
+                 spec.name, ", ".join(only_src))
+    if only_dst:
+        log.info("%s: target-only columns left to default/NULL: %s",
+                 spec.name, ", ".join(only_dst))
+
+    cols = [c for c in src_cols if c in dst_set]
+
+    # For auto-id tables, drop the id column even if present on both sides.
+    if spec.auto_id:
+        cols = [c for c in cols if c != "id"]
+
+    if not cols:
+        res.table_error = "no columns overlap between source and target"
+        log.error("%s: %s", spec.name, res.table_error)
+        return res
+
+    # Counts (source + target-before)
+    try:
+        res.source_rows = _sqlite_count(sqlite_conn, spec.name)
+    except sqlite3.Error as exc:
+        res.table_error = f"sqlite count failed: {exc.__class__.__name__}"
+        log.error("%s: %s", spec.name, res.table_error)
+        return res
+
+    with pg_conn.cursor() as cur:
+        try:
+            res.target_before = _postgres_count(cur, schema, spec.name)
+        except Exception as exc:  # noqa: BLE001
+            pg_conn.rollback()
+            res.table_error = (
+                f"postgres count failed: {exc.__class__.__name__}"
+            )
+            log.error("%s: %s", spec.name, res.table_error)
+            return res
+
+    # Auto-id safeguard: skip if dest has rows, unless override.
+    if spec.auto_id and res.target_before > 0 and not apply_duplicates_ok:
+        log.warning(
+            "%s: auto-id table already has %d rows; skipping "
+            "(pass --apply-duplicates-ok to force)",
+            spec.name, res.target_before,
+        )
+        res.skipped_existing = True
+        res.target_after = res.target_before
+        return res
+
+    if dry_run:
+        would = max(0, res.source_rows - res.target_before)
+        log.info(
+            "%s: dry-run source=%d target=%d would_insert=%d",
+            spec.name, res.source_rows, res.target_before, would,
+        )
+        res.target_after = res.target_before
+        res.inserted = would  # reported as "would insert"
+        return res
+
+    # --apply path.
+    sql = _build_insert_sql(schema, spec.name, cols, spec.pk)
+
+    quoted_cols = ", ".join(f'"{_safe_ident(c)}"' for c in cols)
+    select_sql = (
+        f"SELECT {quoted_cols} FROM {_safe_ident(spec.name)}"
+    )
+    src_cursor = sqlite_conn.execute(select_sql)
+
+    total_inserted = 0
+    per_row_errors = 0
+
+    try:
+        for batch in _chunked(iter(src_cursor.fetchone, None), batch_size):
+            try:
+                with pg_conn.cursor() as cur:
+                    execute_values(cur, sql, batch, page_size=batch_size)
+                total_inserted += len(batch)
+            except Exception as batch_exc:  # noqa: BLE001
+                # Rollback the failed batch and retry row-by-row so one bad
+                # row doesn't abort the whole table.
+                pg_conn.rollback()
+                log.warning(
+                    "%s: batch of %d failed (%s); falling back row-by-row",
+                    spec.name, len(batch), batch_exc.__class__.__name__,
+                )
+                for row in batch:
+                    try:
+                        with pg_conn.cursor() as cur:
+                            execute_values(cur, sql, [row], page_size=1)
+                        total_inserted += 1
+                    except Exception as row_exc:  # noqa: BLE001
+                        pg_conn.rollback()
+                        per_row_errors += 1
+                        # Log PK only; never log row contents.
+                        pk_hint = _row_pk_hint(cols, row, spec.pk)
+                        log.warning(
+                            "%s: row error pk=%s (%s)",
+                            spec.name, pk_hint, row_exc.__class__.__name__,
+                        )
+        pg_conn.commit()
+    except Exception as exc:  # noqa: BLE001
+        pg_conn.rollback()
+        res.table_error = (
+            f"insert path failed: {exc.__class__.__name__}"
+        )
+        log.error("%s: %s", spec.name, res.table_error)
+        return res
+
+    res.inserted = total_inserted
+    res.per_row_errors = per_row_errors
+
+    with pg_conn.cursor() as cur:
+        try:
+            res.target_after = _postgres_count(cur, schema, spec.name)
+        except Exception:  # noqa: BLE001
+            pg_conn.rollback()
+            res.target_after = res.target_before + total_inserted
+
+    return res
+
+
+def _row_pk_hint(cols: Sequence[str], row: Sequence[Any], pk: str | None) -> str:
+    if pk is None or pk not in cols:
+        return "<auto-id>"
+    try:
+        return str(row[cols.index(pk)])
+    except Exception:  # noqa: BLE001
+        return "<unknown>"
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def _parse_args(argv: Sequence[str]) -> argparse.Namespace:
+    ap = argparse.ArgumentParser(
+        prog="python -m lavandula.common.tools.backfill_rds",
+        description="Backfill SQLite rows into RDS Postgres (spec 0013).",
+    )
+    ap.add_argument(
+        "--source-sqlite", required=True,
+        help="Path to source SQLite DB file",
+    )
+    ap.add_argument(
+        "--table", action="append", default=[],
+        help="Specific table(s) to backfill; repeatable. "
+             "Default: all seven known tables.",
+    )
+    ap.add_argument(
+        "--batch-size", type=int, default=1000,
+        help="Rows per execute_values call (default 1000).",
+    )
+    ap.add_argument(
+        "--schema", default="lava_impact",
+        help="Target Postgres schema (default lava_impact).",
+    )
+    ap.add_argument(
+        "--apply-duplicates-ok", action="store_true",
+        help="Allow re-inserting auto-id tables that already have rows.",
+    )
+
+    mode = ap.add_mutually_exclusive_group(required=True)
+    mode.add_argument("--dry-run", action="store_true",
+                      help="Count rows; write nothing.")
+    mode.add_argument("--apply", action="store_true",
+                      help="Perform the inserts.")
+
+    return ap.parse_args(argv)
+
+
+def _resolve_table_specs(requested: Sequence[str]) -> list[TableSpec]:
+    if not requested:
+        return list(TABLES)
+    specs: list[TableSpec] = []
+    for name in requested:
+        if name not in TABLE_BY_NAME:
+            raise SystemExit(
+                f"unknown table {name!r}; known: {sorted(TABLE_BY_NAME)}"
+            )
+        specs.append(TABLE_BY_NAME[name])
+    return specs
+
+
+def _print_result(res: TableResult, dry_run: bool) -> None:
+    print(f"=== {res.table} ===")
+    if res.table_error:
+        print(f"  ERROR: {res.table_error}")
+        return
+    if res.skipped_existing:
+        print(f"  source rows:      {res.source_rows}")
+        print(f"  target rows:      {res.target_before}")
+        print(f"  SKIPPED (auto-id dest non-empty; pass "
+              f"--apply-duplicates-ok to force)")
+        return
+    if dry_run:
+        print(f"  source rows:      {res.source_rows}")
+        print(f"  target current:   {res.target_before}")
+        print(f"  would insert:     {res.inserted}  "
+              f"(delta: {res.inserted:+d})")
+        return
+    print(f"  source rows:      {res.source_rows}")
+    print(f"  target before:    {res.target_before}")
+    print(f"  inserted:         {res.inserted}")
+    print(f"  target after:     {res.target_after}")
+    if res.per_row_errors:
+        print(f"  per-row errors:   {res.per_row_errors}")
+
+
+def run(
+    *,
+    source_sqlite: str,
+    tables: Sequence[str],
+    batch_size: int,
+    schema: str,
+    dry_run: bool,
+    apply_duplicates_ok: bool,
+    engine_factory=None,
+    execute_values=None,
+) -> int:
+    """Library entry point. Returns the process exit code.
+
+    `engine_factory` and `execute_values` are injection points for tests.
+    In production they default to `make_app_engine` and
+    `psycopg2.extras.execute_values`.
+    """
+    if engine_factory is None:
+        from lavandula.common.db import make_app_engine
+        engine_factory = make_app_engine
+    if execute_values is None:
+        from psycopg2.extras import execute_values as _ev  # type: ignore
+        execute_values = _ev
+
+    specs = _resolve_table_specs(tables)
+    _safe_ident(schema)  # fail fast on bad schema name
+
+    try:
+        sqlite_conn = sqlite3.connect(source_sqlite)
+    except sqlite3.Error as exc:
+        log.error("cannot open source sqlite %s: %s", source_sqlite, exc)
+        return 2
+
+    try:
+        engine = engine_factory()
+    except Exception as exc:  # noqa: BLE001
+        log.error("cannot build RDS engine: %s", exc.__class__.__name__)
+        sqlite_conn.close()
+        return 2
+
+    results: list[TableResult] = []
+    started = time.monotonic()
+    table_failure = False
+
+    try:
+        with engine.connect() as sa_conn:
+            pg_conn = sa_conn.connection  # raw psycopg2 connection
+            # Turn off SQLAlchemy-managed BEGIN; we manage transactions
+            # per-table via commit/rollback.
+            try:
+                pg_conn.autocommit = False
+            except Exception:  # noqa: BLE001
+                pass
+            for spec in specs:
+                res = backfill_table(
+                    spec=spec,
+                    sqlite_conn=sqlite_conn,
+                    pg_conn=pg_conn,
+                    schema=schema,
+                    batch_size=batch_size,
+                    dry_run=dry_run,
+                    apply_duplicates_ok=apply_duplicates_ok,
+                    execute_values=execute_values,
+                )
+                results.append(res)
+                _print_result(res, dry_run=dry_run)
+                if res.table_error:
+                    table_failure = True
+    finally:
+        sqlite_conn.close()
+
+    elapsed = time.monotonic() - started
+    total_inserted = sum(r.inserted for r in results if not r.table_error
+                         and not r.skipped_existing)
+    total_row_errors = sum(r.per_row_errors for r in results)
+
+    print()
+    print("=== summary ===")
+    print(f"  tables:           {len(results)}")
+    print(f"  total inserted:   {total_inserted}"
+          f"{' (projected)' if dry_run else ''}")
+    print(f"  per-row errors:   {total_row_errors}")
+    print(f"  wall time:        {elapsed:.2f}s")
+
+    if table_failure:
+        return 2
+    if total_row_errors > 0:
+        return 3
+    return 0
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+    args = _parse_args(list(sys.argv[1:] if argv is None else argv))
+    return run(
+        source_sqlite=args.source_sqlite,
+        tables=args.table,
+        batch_size=args.batch_size,
+        schema=args.schema,
+        dry_run=args.dry_run,
+        apply_duplicates_ok=args.apply_duplicates_ok,
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/lavandula/common/tools/backfill_rds.py
+++ b/lavandula/common/tools/backfill_rds.py
@@ -43,6 +43,12 @@ from typing import Any, Iterable, Sequence
 log = logging.getLogger("lavandula.common.tools.backfill_rds")
 
 
+def _default_execute_values():
+    """Lazy import so unit tests never need psycopg2 installed."""
+    from psycopg2.extras import execute_values  # type: ignore
+    return execute_values
+
+
 # ---------------------------------------------------------------------------
 # Table registry
 # ---------------------------------------------------------------------------
@@ -289,17 +295,31 @@ def backfill_table(
 
     total_inserted = 0
     per_row_errors = 0
+    sp_batch = "bf_batch"
+    sp_row = "bf_row"
+
+    def _released_rowcount(cur) -> int:
+        # Under `ON CONFLICT DO NOTHING`, Postgres reports the number of
+        # actually-inserted rows in cur.rowcount. `execute_values` emits
+        # a single INSERT per call so rowcount is authoritative.
+        rc = getattr(cur, "rowcount", 0) or 0
+        return rc if rc > 0 else 0
 
     try:
         for batch in _chunked(iter(src_cursor.fetchone, None), batch_size):
+            # Per-batch savepoint: a failing batch unwinds only itself,
+            # never previously-committed batches for this table.
             try:
                 with pg_conn.cursor() as cur:
+                    cur.execute(f"SAVEPOINT {sp_batch}")
                     execute_values(cur, sql, batch, page_size=batch_size)
-                total_inserted += len(batch)
+                    inserted_in_batch = _released_rowcount(cur)
+                    cur.execute(f"RELEASE SAVEPOINT {sp_batch}")
+                total_inserted += inserted_in_batch
             except Exception as batch_exc:  # noqa: BLE001
-                # Rollback the failed batch and retry row-by-row so one bad
-                # row doesn't abort the whole table.
-                pg_conn.rollback()
+                # Undo the failing batch only; prior batches remain.
+                with pg_conn.cursor() as cur:
+                    cur.execute(f"ROLLBACK TO SAVEPOINT {sp_batch}")
                 log.warning(
                     "%s: batch of %d failed (%s); falling back row-by-row",
                     spec.name, len(batch), batch_exc.__class__.__name__,
@@ -307,10 +327,14 @@ def backfill_table(
                 for row in batch:
                     try:
                         with pg_conn.cursor() as cur:
+                            cur.execute(f"SAVEPOINT {sp_row}")
                             execute_values(cur, sql, [row], page_size=1)
-                        total_inserted += 1
+                            inserted_in_row = _released_rowcount(cur)
+                            cur.execute(f"RELEASE SAVEPOINT {sp_row}")
+                        total_inserted += inserted_in_row
                     except Exception as row_exc:  # noqa: BLE001
-                        pg_conn.rollback()
+                        with pg_conn.cursor() as cur:
+                            cur.execute(f"ROLLBACK TO SAVEPOINT {sp_row}")
                         per_row_errors += 1
                         # Log PK only; never log row contents.
                         pk_hint = _row_pk_hint(cols, row, spec.pk)
@@ -448,8 +472,7 @@ def run(
         from lavandula.common.db import make_app_engine
         engine_factory = make_app_engine
     if execute_values is None:
-        from psycopg2.extras import execute_values as _ev  # type: ignore
-        execute_values = _ev
+        execute_values = _default_execute_values()
 
     specs = _resolve_table_specs(tables)
     _safe_ident(schema)  # fail fast on bad schema name

--- a/locard/plans/0013-phase2-backfill.md
+++ b/locard/plans/0013-phase2-backfill.md
@@ -1,0 +1,338 @@
+# Plan 0013 Phase 2 — SQLite → RDS Backfill Tool
+
+**Spec**: `locard/specs/0013-rds-postgres-migration.md` Phase 2  
+**Depends on**: Phase 1 (merged PR #6) + Phase 0 schema live on `lava_prod1.lava_impact`  
+**Date**: 2026-04-22
+
+---
+
+## Scope
+
+Ship one new tool and its tests. Zero changes to crawler / classifier /
+resolver hot paths. Phase 3 (dual-write) and Phase 4 (read flip) are
+explicitly NOT in this PR.
+
+---
+
+## Deliverables
+
+| Path | Status |
+|------|--------|
+| `lavandula/common/tools/backfill_rds.py` | NEW — CLI tool |
+| `lavandula/common/tools/__init__.py` | NEW (empty) |
+| `lavandula/common/tests/unit/test_backfill_rds_0013.py` | NEW |
+
+No schema changes. No adapter changes.
+
+---
+
+## Existing code to read first
+
+1. `lavandula/common/db.py` — use `make_app_engine()` for the Postgres
+   destination. **Note**: `app_user1` has CRUD on `lava_impact`,
+   which is sufficient for INSERTs. The tool does NOT need master
+   credentials.
+2. `lavandula/reports/schema.py` — source-of-truth SQLite column
+   names for `reports`, `fetch_log`, `crawled_orgs`, `deletion_log`,
+   `budget_ledger`.
+3. `lavandula/nonprofits/tools/seed_enumerate.py` — SQLite column
+   names for `nonprofits_seed` and `runs` (plus the `_apply_migrations`
+   list of post-initial columns).
+4. `lavandula/migrations/rds/001_initial_schema.sql` — target
+   Postgres column layout (should be 1:1 with SQLite column names).
+
+---
+
+## Command-line interface
+
+```
+python -m lavandula.common.tools.backfill_rds \
+    --source-sqlite PATH \
+    [--table TABLE_NAME]... \
+    [--batch-size N] \
+    [--schema lava_impact] \
+    (--dry-run | --apply)
+```
+
+| Flag | Purpose | Default |
+|------|---------|---------|
+| `--source-sqlite` | Source SQLite DB file | required |
+| `--table` | Specific table(s) to backfill; repeatable | all known tables |
+| `--batch-size` | Rows per `execute_values` call | 1000 |
+| `--schema` | Target Postgres schema | `lava_impact` |
+| `--dry-run` | Count and compare rows; write nothing | mutually exclusive with `--apply` |
+| `--apply` | Perform the inserts | mutually exclusive with `--dry-run` |
+
+Exactly one of `--dry-run` / `--apply` is required — mirrors the
+convention from `reconcile_s3.py` (spec 0007).
+
+---
+
+## Table mappings
+
+Seven tables. Two mappings matter:
+
+### A. Explicit primary key — idempotent via `ON CONFLICT DO NOTHING`
+
+| SQLite table | PK column | Postgres DDL notes |
+|-------------|-----------|-------------------|
+| `nonprofits_seed` | `ein` | `ON CONFLICT (ein) DO NOTHING` |
+| `reports` | `content_sha256` | `ON CONFLICT (content_sha256) DO NOTHING` |
+| `crawled_orgs` | `ein` | `ON CONFLICT (ein) DO NOTHING` |
+| `runs` | `run_id` | `ON CONFLICT (run_id) DO NOTHING` |
+
+### B. Auto-increment PK — drop source IDs, let Postgres assign
+
+| SQLite table | SQLite PK | Strategy |
+|-------------|-----------|----------|
+| `fetch_log` | `id BIGSERIAL` | Skip source `id` column; insert all other columns; Postgres auto-assigns new `id` |
+| `deletion_log` | `id BIGSERIAL` | Same |
+| `budget_ledger` | `id BIGSERIAL` | Same |
+
+**Rationale**: no foreign key references these ids, so renumbering is safe. Source-id preservation would require `ALTER SEQUENCE ... SET`
+gymnastics that add complexity for no benefit.
+
+**Consequence**: re-running backfill against the same SQLite DB would
+produce duplicate log entries in Postgres. To prevent this, the tool
+emits a warning when the destination already contains rows for an
+auto-id table, and requires `--apply-duplicates-ok` to proceed anyway.
+Default behavior: skip auto-id tables if Postgres already has rows.
+
+---
+
+## Column source-of-truth
+
+For each SQLite table, the tool reads `PRAGMA table_info(<table>)` at
+runtime to get actual column names — that handles the additive
+migrations applied over time (e.g., `nonprofits_seed` has
+`resolver_status`, `address`, etc. added via `_apply_migrations`).
+
+For the destination, the tool issues `SELECT column_name FROM
+information_schema.columns WHERE table_schema = ? AND table_name = ?`
+to get the actual target columns.
+
+**Column alignment**: the tool intersects source + target columns and
+inserts only the intersection. Columns present only on one side are
+logged at INFO.
+
+---
+
+## Data-type coercion
+
+SQLite → Postgres mapping at row level:
+
+- `TEXT` → `str` (pass-through)
+- `INTEGER` stored as bool (0/1) → `int` (Postgres SMALLINT auto-coerces)
+- `INTEGER` stored as int → `int` (Postgres INTEGER/BIGINT auto-coerces)
+- `REAL` → `float`
+- `NULL` → `None`
+- All timestamps stay as `TEXT` (SQLite storage is ISO 8601 string;
+  Postgres target columns are `TEXT` in our schema, not `TIMESTAMP`)
+
+No explicit conversion needed for most columns; psycopg2's default
+type adapter handles `str`/`int`/`float`/`None` natively.
+
+---
+
+## Insert path (the performance-sensitive bit)
+
+Use `psycopg2.extras.execute_values` for batched inserts:
+
+```python
+from psycopg2.extras import execute_values
+
+sql = f"""
+INSERT INTO {schema}.{table} ({col_list})
+VALUES %s
+ON CONFLICT ({pk_col}) DO NOTHING
+"""
+# For auto-id tables, omit the ON CONFLICT clause entirely.
+
+with engine.connect() as conn:
+    raw_conn = conn.connection  # psycopg2 connection
+    with raw_conn.cursor() as cur:
+        execute_values(cur, sql, rows, page_size=batch_size)
+    conn.commit()
+```
+
+Why `execute_values` rather than `executemany` or SQLAlchemy Core
+inserts:
+- 10-50x faster on bulk loads (single round-trip per batch)
+- Native `ON CONFLICT DO NOTHING` support via template substitution
+- Small, well-understood API
+
+Why not `COPY`: COPY is fastest for cold loads but doesn't natively
+handle `ON CONFLICT DO NOTHING` (would need a staging table +
+`INSERT ... SELECT ... ON CONFLICT`). For our row counts (< 50K per
+table initially), `execute_values` is fast enough.
+
+---
+
+## Progress reporting
+
+Per-table output:
+
+```
+=== nonprofits_seed ===
+  source rows:      5000
+  target before:       0
+  inserted:         5000
+  skipped (dup):       0
+  target after:     5000
+```
+
+For `--dry-run`:
+
+```
+=== nonprofits_seed ===
+  source rows:      5000
+  target current:      0
+  would insert:     5000  (delta: +5000)
+```
+
+At end of run, summary: total rows inserted across all tables, wall
+time, exit status.
+
+---
+
+## Error handling
+
+Per-row errors (e.g., one row violates a CHECK constraint) are logged
+as `WARN` with the table, row hint (PK value), and exception class.
+The remainder of the batch continues. `--apply` tracks total error
+count; if >0, exit code is 3 (partial success) instead of 0.
+
+Per-table errors (e.g., table missing on source, or dest table
+unreachable) log `ERROR` and move to the next table. If any table
+fails entirely, final exit code is 2.
+
+Connection-level errors (e.g., RDS unreachable, IAM token expired)
+abort with exit 2.
+
+---
+
+## Tests
+
+**`lavandula/common/tests/unit/test_backfill_rds_0013.py`** — all tests
+use an in-memory Postgres via `testing.postgresql` OR a live test DB
+behind `LAVANDULA_LIVE_RDS=1`. For CI-friendly tests:
+
+- Mock out the SQLAlchemy engine + raw psycopg2 connection
+- Use a tempfile SQLite DB as source (real sqlite3)
+- Assert SQL generated matches expected `INSERT ... ON CONFLICT ... DO NOTHING` shape
+- Assert `execute_values` called with correct args
+
+Test list:
+
+| Name | Covers |
+|------|--------|
+| `test_argv_requires_exactly_one_of_dry_run_or_apply` | CLI |
+| `test_argv_source_sqlite_required` | CLI |
+| `test_column_intersection_skips_missing_sides` | alignment |
+| `test_dry_run_counts_rows_no_writes` | dry-run path |
+| `test_apply_inserts_rows_via_execute_values` | main insert path |
+| `test_on_conflict_skips_existing_rows` | idempotency |
+| `test_auto_id_tables_omit_id_column` | auto-id rule |
+| `test_auto_id_skip_when_dest_has_rows` | safeguard |
+| `test_per_row_error_continues_batch` | error resilience |
+| `test_per_table_error_moves_to_next` | error resilience |
+| `test_mismatched_table_logs_info` | alignment warning |
+| `test_batch_size_honored` | perf |
+
+Optional integration test behind `LAVANDULA_LIVE_RDS=1`:
+- Creates a tempfile SQLite with 5 seeded rows
+- Runs `--apply`
+- Connects to `lava_prod1.lava_impact` as `app_user1` and verifies
+  row count went from 0 → 5 (skipping if prior test data exists)
+- Cleans up the 5 rows at the end
+
+---
+
+## Traps to Avoid
+
+1. **Don't attempt to preserve source `id` values on auto-id tables.**
+   Would require `ALTER SEQUENCE` calls and there's no benefit.
+
+2. **Don't commit after each row.** Batch commits per-table keep the
+   transaction count low. A per-table transaction also gives a clean
+   rollback if the table fails mid-way.
+
+3. **Don't use SQLAlchemy ORM for the insert.** `execute_values` is
+   the performance tool. ORM inserts would be 10-50x slower.
+
+4. **Don't use master credentials.** `app_user1` has INSERT on
+   `lava_impact` per default privileges set by the Phase 0 migration.
+   The backfill tool runs under the runtime IAM auth path.
+
+5. **Don't skip the dry-run safety.** Real runs must be preceded by a
+   `--dry-run` in the operator's workflow. The tool doesn't enforce
+   this but the runbook (HANDOFF.md section) should.
+
+6. **Don't log row contents.** Log PKs / row counts only. Some SQLite
+   tables contain `first_page_text` or other user-content-derived
+   data that shouldn't hit logs.
+
+7. **Don't assume `PRAGMA table_info` returns columns in insert
+   order.** Use explicit ORDER BY `cid` when iterating; then match
+   against the target column list.
+
+8. **Don't hard-code the tables list.** Build it from the known
+   seven names but allow `--table` to narrow — useful for operator
+   re-runs of a single table.
+
+---
+
+## Acceptance Criteria
+
+**AC1** — `--dry-run` counts rows per table and compares to target;
+writes zero rows.
+
+**AC2** — `--apply` inserts rows via `execute_values` with
+`ON CONFLICT DO NOTHING` for explicit-PK tables.
+
+**AC3** — Re-running `--apply` against unchanged source produces
+zero duplicates and exit 0.
+
+**AC4** — Auto-id tables (`fetch_log`, `deletion_log`,
+`budget_ledger`) skip the source `id` column and let Postgres assign
+new values.
+
+**AC5** — Re-running `--apply` on auto-id tables warns and skips
+(unless `--apply-duplicates-ok`) — prevents accidental duplicate log
+flood.
+
+**AC6** — Column intersection: target columns missing in source are
+filled with default/NULL; source columns missing in target are
+logged INFO and ignored.
+
+**AC7** — Per-row errors don't abort the batch; total error count is
+surfaced in the final summary; exit code 3 if errors > 0.
+
+**AC8** — Per-table errors move on to the next table; exit code 2
+if any table fails.
+
+**AC9** — Tool uses `make_app_engine()` for destination; no master
+credentials read.
+
+**AC10** — Unit tests mock all network/DB I/O; no AWS or real
+Postgres calls in the default test suite.
+
+**AC11** — `--table X` restricts backfill to one table; repeatable
+flag allowed.
+
+**AC12** — Row-content is never logged — only PKs and counts.
+
+---
+
+## Post-merge work (architect's job)
+
+1. Run `--dry-run` against the current SQLite DBs to preview deltas:
+   ```
+   python -m lavandula.common.tools.backfill_rds \
+       --source-sqlite /home/ubuntu/research/lavandula/nonprofits/data/seeds-eastcoast.db \
+       --dry-run
+   ```
+2. If counts look right, run `--apply`.
+3. Repeat for any other SQLite DBs of operational interest.
+4. Update spec 0013 status note in `projectlist.md` to indicate Phase
+   2 complete.


### PR DESCRIPTION
## Summary

Phase 2 of spec 0013 — a one-time SQLite → RDS Postgres backfill CLI
that copies rows into `lava_prod1.lava_impact` via the Phase 1
IAM-auth engine (`app_user1`). No schema changes, no adapter
changes, no crawler/classifier touches.

## What's here

- `lavandula/common/tools/backfill_rds.py` — CLI + library entry
  point. Uses `psycopg2.extras.execute_values` for batched inserts.
  - Four explicit-PK tables (`nonprofits_seed`, `reports`,
    `crawled_orgs`, `runs`) use `ON CONFLICT (pk) DO NOTHING` for
    idempotent re-runs.
  - Three auto-id log tables (`fetch_log`, `deletion_log`,
    `budget_ledger`) drop the source `id` column and let Postgres
    assign fresh sequence values. Safeguard: warns and skips when
    the destination already has rows, unless `--apply-duplicates-ok`
    is passed.
  - `--dry-run` counts only; `--apply` writes. Mutually exclusive
    and required (mirrors `reconcile_s3.py` convention).
  - Column alignment via `PRAGMA table_info` (source) +
    `information_schema.columns` (target); intersection used; each
    side's extras logged at INFO.
  - Per-row errors retry row-by-row inside the failing batch;
    exit 3 if any row errors. Per-table errors move on; exit 2.
- `lavandula/common/tools/__init__.py` — empty package marker.
- `lavandula/common/tests/unit/test_backfill_rds_0013.py` — 17 unit
  tests, fully mocked (no AWS, no live Postgres).

## Acceptance criteria (from plan)

All 12 ACs addressed; see tests for coverage map. Identifier
safety enforced via a strict regex whitelist before any f-string
SQL is built. Row contents are never logged — only PKs + counts.

## Test plan

- [x] `python3 -m pytest lavandula/common/tests/unit/test_backfill_rds_0013.py` — 17/17 pass
- [x] `python3 -m pytest lavandula/common/tests/` — 43 pass, 2 skipped (live SSM), no regressions
- [ ] Architect post-merge: `--dry-run` against current SQLite DBs to preview deltas
- [ ] Architect post-merge: `--apply` once deltas look right

🤖 Generated with [Claude Code](https://claude.com/claude-code)