### PR TITLE
[Spec 0013][Phase 3] SQLite/RDS dual-write wrapper

### DIFF
--- a/lavandula/common/tests/unit/test_verify_dual_write_0013p3.py
+++ b/lavandula/common/tests/unit/test_verify_dual_write_0013p3.py
@@ -1,0 +1,170 @@
+"""Tests for `lavandula.common.tools.verify_dual_write` (Spec 0013 P3)."""
+from __future__ import annotations
+
+import sqlite3
+from unittest.mock import MagicMock
+
+import pytest
+
+from lavandula.common.tools import verify_dual_write as vd
+
+
+def _make_sqlite(tmp_path, rows_by_table):
+    """Create a SQLite DB with given tables and row lists.
+    rows_by_table: dict[table_name, (pk_col, [pk_values])]
+    """
+    path = tmp_path / "t.db"
+    conn = sqlite3.connect(str(path))
+    for table, (pk_col, values) in rows_by_table.items():
+        conn.execute(f"CREATE TABLE {table} ({pk_col} TEXT PRIMARY KEY)")
+        for v in values:
+            conn.execute(f"INSERT INTO {table} ({pk_col}) VALUES (?)", (v,))
+    conn.commit()
+    conn.close()
+    return str(path)
+
+
+class _FakeCursor:
+    def __init__(self, table_rows):
+        """table_rows: dict[table, list[pk]]"""
+        self._tables = table_rows
+        self._queue = []
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+    def execute(self, sql, params=()):
+        import re
+        # Count query: SELECT COUNT(*) FROM "schema"."table"
+        m = re.search(
+            r'SELECT COUNT\(\*\) FROM "[^"]+"\."([^"]+)"',
+            sql,
+        )
+        if m:
+            t = m.group(1)
+            n = len(self._tables.get(t, []))
+            self._queue = [(n,)]
+            return
+        # PK list: SELECT "<pk>" FROM "<schema>"."<table>" LIMIT %s
+        m = re.search(
+            r'SELECT "[^"]+" FROM "[^"]+"\."([^"]+)" LIMIT',
+            sql,
+        )
+        if m:
+            t = m.group(1)
+            rows = self._tables.get(t, [])
+            self._queue = [(v,) for v in rows]
+            return
+        self._queue = []
+
+    def fetchone(self):
+        return self._queue[0] if self._queue else None
+
+    def fetchall(self):
+        return list(self._queue)
+
+
+class _FakePgConn:
+    def __init__(self, table_rows):
+        self._t = table_rows
+
+    def cursor(self):
+        return _FakeCursor(self._t)
+
+
+class _FakeSA:
+    def __init__(self, conn):
+        self._conn = conn
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+    @property
+    def connection(self):
+        return self._conn
+
+
+class _FakeEngine:
+    def __init__(self, pg_conn):
+        self._pg_conn = pg_conn
+
+    def connect(self):
+        return _FakeSA(self._pg_conn)
+
+
+def test_no_drift(tmp_path, capsys):
+    sqlite_path = _make_sqlite(tmp_path, {
+        "nonprofits_seed": ("ein", ["a", "b"]),
+        "reports":         ("content_sha256", ["s1"]),
+        "crawled_orgs":    ("ein", ["a"]),
+        "runs":            ("run_id", ["r1"]),
+        "fetch_log":       ("ein", ["a", "b"]),
+        "deletion_log":    ("ein", []),
+        "budget_ledger":   ("ein", []),
+    })
+    rds_rows = {
+        "nonprofits_seed": ["a", "b"],
+        "reports":         ["s1"],
+        "crawled_orgs":    ["a"],
+        "runs":            ["r1"],
+        "fetch_log":       ["x", "y"],
+        "deletion_log":    [],
+        "budget_ledger":   [],
+    }
+    engine = _FakeEngine(_FakePgConn(rds_rows))
+    rc = vd.run(
+        sqlite_path=sqlite_path, tables=[], engine_factory=lambda: engine,
+    )
+    assert rc == 0
+
+
+def test_drift_detected(tmp_path, capsys):
+    sqlite_path = _make_sqlite(tmp_path, {
+        "nonprofits_seed": ("ein", ["a", "b", "c"]),
+    })
+    rds_rows = {"nonprofits_seed": ["a"]}  # missing b, c
+    engine = _FakeEngine(_FakePgConn(rds_rows))
+    rc = vd.run(
+        sqlite_path=sqlite_path,
+        tables=["nonprofits_seed"],
+        engine_factory=lambda: engine,
+    )
+    assert rc == 1
+    out = capsys.readouterr().out
+    assert "sqlite count:" in out
+    assert "rds count:" in out
+    # b and c missing in rds
+    assert "missing in rds" in out
+
+
+def test_unknown_table_raises(tmp_path):
+    sqlite_path = _make_sqlite(tmp_path, {})
+    with pytest.raises(SystemExit):
+        vd.run(
+            sqlite_path=sqlite_path,
+            tables=["totally_made_up"],
+            engine_factory=lambda: _FakeEngine(_FakePgConn({})),
+        )
+
+
+def test_missing_sqlite_table_is_not_drift(tmp_path, capsys):
+    """Running against reports.db which doesn't have nonprofits_seed
+    should skip (sqlite_table_absent) rather than report drift."""
+    sqlite_path = _make_sqlite(tmp_path, {
+        "reports": ("content_sha256", ["s1"]),
+    })
+    rds_rows = {"reports": ["s1"], "nonprofits_seed": ["x"]}
+    engine = _FakeEngine(_FakePgConn(rds_rows))
+    rc = vd.run(
+        sqlite_path=sqlite_path,
+        tables=["reports", "nonprofits_seed"],
+        engine_factory=lambda: engine,
+    )
+    # reports matches, nonprofits_seed absent → rc 0
+    assert rc == 0

--- a/lavandula/common/tests/unit/test_verify_dual_write_0013p3.py
+++ b/lavandula/common/tests/unit/test_verify_dual_write_0013p3.py
@@ -48,9 +48,9 @@ class _FakeCursor:
             n = len(self._tables.get(t, []))
             self._queue = [(n,)]
             return
-        # PK list: SELECT "<pk>" FROM "<schema>"."<table>" LIMIT %s
+        # PK list: SELECT "<pk>" FROM "<schema>"."<table>" ORDER BY "<pk>" LIMIT %s
         m = re.search(
-            r'SELECT "[^"]+" FROM "[^"]+"\."([^"]+)" LIMIT',
+            r'SELECT "[^"]+" FROM "[^"]+"\."([^"]+)"',
             sql,
         )
         if m:
@@ -151,6 +151,23 @@ def test_unknown_table_raises(tmp_path):
             tables=["totally_made_up"],
             engine_factory=lambda: _FakeEngine(_FakePgConn({})),
         )
+
+
+def test_hard_engine_error_returns_two(tmp_path):
+    """Docstring promises exit 2 on hard (connection-level) errors."""
+    sqlite_path = _make_sqlite(tmp_path, {
+        "reports": ("content_sha256", ["s1"]),
+    })
+
+    def _raising_factory():
+        raise RuntimeError("no engine")
+
+    rc = vd.run(
+        sqlite_path=sqlite_path,
+        tables=["reports"],
+        engine_factory=_raising_factory,
+    )
+    assert rc == 2
 
 
 def test_missing_sqlite_table_is_not_drift(tmp_path, capsys):

--- a/lavandula/common/tools/verify_dual_write.py
+++ b/lavandula/common/tools/verify_dual_write.py
@@ -100,8 +100,12 @@ def _postgres_count(pg_cur, schema: str, table: str) -> int:
 def _sqlite_pks(
     conn: sqlite3.Connection, table: str, pk: str, limit: int = 100000
 ) -> set[str]:
+    # Deterministic sampling: ORDER BY <pk> so both backends walk the
+    # same prefix of the sort order. Without this, LIMIT picks an
+    # arbitrary subset and the "missing PKs" list is meaningless.
     cur = conn.execute(
-        f"SELECT {_safe_ident(pk)} FROM {_safe_ident(table)} LIMIT ?",
+        f"SELECT {_safe_ident(pk)} FROM {_safe_ident(table)} "
+        f"ORDER BY {_safe_ident(pk)} LIMIT ?",
         (limit,),
     )
     return {str(r[0]) for r in cur.fetchall() if r[0] is not None}
@@ -111,8 +115,9 @@ def _postgres_pks(
     pg_cur, schema: str, table: str, pk: str, limit: int = 100000
 ) -> set[str]:
     pg_cur.execute(
-        f'SELECT "{_safe_ident(pk)}" FROM "{_safe_ident(schema)}"."{_safe_ident(table)}" '
-        f"LIMIT %s",
+        f'SELECT "{_safe_ident(pk)}" '
+        f'FROM "{_safe_ident(schema)}"."{_safe_ident(table)}" '
+        f'ORDER BY "{_safe_ident(pk)}" LIMIT %s',
         (limit,),
     )
     return {str(r[0]) for r in pg_cur.fetchall() if r[0] is not None}
@@ -249,7 +254,7 @@ def run(
     print(f"  drift count:     {total_drift}")
 
     if any_error:
-        return 1
+        return 2
     return 1 if total_drift else 0
 
 

--- a/lavandula/common/tools/verify_dual_write.py
+++ b/lavandula/common/tools/verify_dual_write.py
@@ -97,28 +97,22 @@ def _postgres_count(pg_cur, schema: str, table: str) -> int:
     return int(pg_cur.fetchone()[0])
 
 
-def _sqlite_pks(
-    conn: sqlite3.Connection, table: str, pk: str, limit: int = 100000
-) -> set[str]:
-    # Deterministic sampling: ORDER BY <pk> so both backends walk the
-    # same prefix of the sort order. Without this, LIMIT picks an
-    # arbitrary subset and the "missing PKs" list is meaningless.
+def _sqlite_pks(conn: sqlite3.Connection, table: str, pk: str) -> set[str]:
+    # Full set-diff (no LIMIT). Current scale (<10K rows) makes the
+    # memory cost trivial. If scale grows past ~1M, add an opt-in
+    # `--sample-size` flag — but a bounded sample would hide real
+    # drift that falls outside the sample, so the default must be
+    # exact.
     cur = conn.execute(
-        f"SELECT {_safe_ident(pk)} FROM {_safe_ident(table)} "
-        f"ORDER BY {_safe_ident(pk)} LIMIT ?",
-        (limit,),
+        f"SELECT {_safe_ident(pk)} FROM {_safe_ident(table)}"
     )
     return {str(r[0]) for r in cur.fetchall() if r[0] is not None}
 
 
-def _postgres_pks(
-    pg_cur, schema: str, table: str, pk: str, limit: int = 100000
-) -> set[str]:
+def _postgres_pks(pg_cur, schema: str, table: str, pk: str) -> set[str]:
     pg_cur.execute(
         f'SELECT "{_safe_ident(pk)}" '
-        f'FROM "{_safe_ident(schema)}"."{_safe_ident(table)}" '
-        f'ORDER BY "{_safe_ident(pk)}" LIMIT %s',
-        (limit,),
+        f'FROM "{_safe_ident(schema)}"."{_safe_ident(table)}"'
     )
     return {str(r[0]) for r in pg_cur.fetchall() if r[0] is not None}
 
@@ -131,6 +125,8 @@ def verify_table(
     schema: str,
     sample_size: int = 20,
 ) -> TableDrift:
+    """Compare one table. `sample_size` caps the number of missing
+    PKs printed in the drift report; set-diff itself is exhaustive."""
     res = TableDrift(table=spec.name)
     if not _sqlite_has_table(sqlite_conn, spec.name):
         # This SQLite file doesn't have this table; e.g. reports.db vs seeds.db.

--- a/lavandula/common/tools/verify_dual_write.py
+++ b/lavandula/common/tools/verify_dual_write.py
@@ -1,0 +1,284 @@
+"""Drift detection between SQLite and RDS dual-write (Spec 0013 Phase 3).
+
+Compares row counts and PK overlap between a local SQLite DB and the
+corresponding `lava_impact.<table>` in RDS. Intended as an operational
+check during the Phase 3 stabilization period before the Phase 4
+read flip.
+
+Usage
+-----
+    python -m lavandula.common.tools.verify_dual_write \\
+        --sqlite PATH/reports.db \\
+        [--table TABLE]...
+
+Exit codes
+----------
+  0  no drift detected (all compared tables match)
+  1  drift detected (counts differ or missing PKs in either backend)
+  2  hard error (connection-level)
+"""
+from __future__ import annotations
+
+import argparse
+import logging
+import re
+import sqlite3
+import sys
+from dataclasses import dataclass, field
+from typing import Any, Sequence
+
+log = logging.getLogger("lavandula.common.tools.verify_dual_write")
+
+_IDENT_RE = re.compile(r"^[a-z_][a-z0-9_]{0,62}$")
+
+
+def _safe_ident(name: str) -> str:
+    if not _IDENT_RE.match(name):
+        raise ValueError(f"unsafe SQL identifier: {name!r}")
+    return name
+
+
+@dataclass(frozen=True)
+class TableSpec:
+    name: str
+    pk: str | None
+
+
+TABLES: tuple[TableSpec, ...] = (
+    TableSpec("nonprofits_seed", pk="ein"),
+    TableSpec("reports",         pk="content_sha256"),
+    TableSpec("crawled_orgs",    pk="ein"),
+    TableSpec("runs",            pk="run_id"),
+    TableSpec("fetch_log",       pk=None),
+    TableSpec("deletion_log",    pk=None),
+    TableSpec("budget_ledger",   pk=None),
+)
+
+TABLE_BY_NAME: dict[str, TableSpec] = {t.name: t for t in TABLES}
+
+
+@dataclass
+class TableDrift:
+    table: str
+    sqlite_count: int = 0
+    rds_count: int = 0
+    missing_in_rds: list[str] = field(default_factory=list)
+    missing_in_sqlite: list[str] = field(default_factory=list)
+    error: str | None = None
+
+    @property
+    def has_drift(self) -> bool:
+        if self.error:
+            return True
+        if self.sqlite_count != self.rds_count:
+            return True
+        if self.missing_in_rds or self.missing_in_sqlite:
+            return True
+        return False
+
+
+def _sqlite_has_table(conn: sqlite3.Connection, table: str) -> bool:
+    cur = conn.execute(
+        "SELECT 1 FROM sqlite_master WHERE type='table' AND name = ?",
+        (table,),
+    )
+    return cur.fetchone() is not None
+
+
+def _sqlite_count(conn: sqlite3.Connection, table: str) -> int:
+    cur = conn.execute(f"SELECT COUNT(*) FROM {_safe_ident(table)}")
+    return int(cur.fetchone()[0])
+
+
+def _postgres_count(pg_cur, schema: str, table: str) -> int:
+    pg_cur.execute(
+        f'SELECT COUNT(*) FROM "{_safe_ident(schema)}"."{_safe_ident(table)}"'
+    )
+    return int(pg_cur.fetchone()[0])
+
+
+def _sqlite_pks(
+    conn: sqlite3.Connection, table: str, pk: str, limit: int = 100000
+) -> set[str]:
+    cur = conn.execute(
+        f"SELECT {_safe_ident(pk)} FROM {_safe_ident(table)} LIMIT ?",
+        (limit,),
+    )
+    return {str(r[0]) for r in cur.fetchall() if r[0] is not None}
+
+
+def _postgres_pks(
+    pg_cur, schema: str, table: str, pk: str, limit: int = 100000
+) -> set[str]:
+    pg_cur.execute(
+        f'SELECT "{_safe_ident(pk)}" FROM "{_safe_ident(schema)}"."{_safe_ident(table)}" '
+        f"LIMIT %s",
+        (limit,),
+    )
+    return {str(r[0]) for r in pg_cur.fetchall() if r[0] is not None}
+
+
+def verify_table(
+    spec: TableSpec,
+    *,
+    sqlite_conn: sqlite3.Connection,
+    pg_conn: Any,
+    schema: str,
+    sample_size: int = 20,
+) -> TableDrift:
+    res = TableDrift(table=spec.name)
+    if not _sqlite_has_table(sqlite_conn, spec.name):
+        # This SQLite file doesn't have this table; e.g. reports.db vs seeds.db.
+        res.error = "sqlite_table_absent"
+        return res
+    try:
+        res.sqlite_count = _sqlite_count(sqlite_conn, spec.name)
+    except sqlite3.Error as exc:
+        res.error = f"sqlite_error:{exc.__class__.__name__}"
+        return res
+
+    try:
+        with pg_conn.cursor() as cur:
+            res.rds_count = _postgres_count(cur, schema, spec.name)
+    except Exception as exc:  # noqa: BLE001
+        res.error = f"rds_error:{exc.__class__.__name__}"
+        return res
+
+    if spec.pk:
+        try:
+            sqlite_set = _sqlite_pks(sqlite_conn, spec.name, spec.pk)
+            with pg_conn.cursor() as cur:
+                rds_set = _postgres_pks(cur, schema, spec.name, spec.pk)
+        except Exception as exc:  # noqa: BLE001
+            res.error = f"pk_compare_error:{exc.__class__.__name__}"
+            return res
+        only_sqlite = sorted(sqlite_set - rds_set)[:sample_size]
+        only_rds = sorted(rds_set - sqlite_set)[:sample_size]
+        res.missing_in_rds = only_sqlite
+        res.missing_in_sqlite = only_rds
+    return res
+
+
+def _resolve_specs(requested: Sequence[str]) -> list[TableSpec]:
+    if not requested:
+        return list(TABLES)
+    out: list[TableSpec] = []
+    for name in requested:
+        if name not in TABLE_BY_NAME:
+            raise SystemExit(
+                f"unknown table {name!r}; known: {sorted(TABLE_BY_NAME)}"
+            )
+        out.append(TABLE_BY_NAME[name])
+    return out
+
+
+def _print_drift(d: TableDrift) -> None:
+    print(f"=== {d.table} ===")
+    if d.error:
+        print(f"  ERROR: {d.error}")
+        return
+    delta = d.rds_count - d.sqlite_count
+    sign = f"{delta:+d}"
+    print(f"  sqlite count:    {d.sqlite_count}")
+    print(f"  rds count:       {d.rds_count}   (drift: {sign})")
+    if d.missing_in_rds:
+        print(f"  missing in rds:  {', '.join(d.missing_in_rds[:10])}"
+              f"{' …' if len(d.missing_in_rds) > 10 else ''}")
+    if d.missing_in_sqlite:
+        print(f"  missing in sqlite: {', '.join(d.missing_in_sqlite[:10])}"
+              f"{' …' if len(d.missing_in_sqlite) > 10 else ''}")
+
+
+def run(
+    *,
+    sqlite_path: str,
+    tables: Sequence[str],
+    schema: str = "lava_impact",
+    engine_factory=None,
+) -> int:
+    if engine_factory is None:
+        from lavandula.common.db import make_ro_engine
+        engine_factory = make_ro_engine
+
+    _safe_ident(schema)
+    specs = _resolve_specs(tables)
+
+    try:
+        sqlite_conn = sqlite3.connect(sqlite_path)
+    except sqlite3.Error as exc:
+        log.error("cannot open sqlite %s: %s", sqlite_path, exc)
+        return 2
+
+    try:
+        engine = engine_factory()
+    except Exception as exc:  # noqa: BLE001
+        log.error("cannot build RDS engine: %s", exc.__class__.__name__)
+        sqlite_conn.close()
+        return 2
+
+    drifts: list[TableDrift] = []
+    any_error = False
+    try:
+        with engine.connect() as sa_conn:
+            pg_conn = sa_conn.connection
+            try:
+                pg_conn.autocommit = True
+            except Exception:  # noqa: BLE001
+                pass
+            for spec in specs:
+                d = verify_table(
+                    spec,
+                    sqlite_conn=sqlite_conn,
+                    pg_conn=pg_conn,
+                    schema=schema,
+                )
+                drifts.append(d)
+                _print_drift(d)
+                if d.error and d.error != "sqlite_table_absent":
+                    any_error = True
+    finally:
+        sqlite_conn.close()
+
+    total_drift = sum(
+        1 for d in drifts
+        if d.error != "sqlite_table_absent" and d.has_drift
+    )
+    print()
+    print("=== summary ===")
+    print(f"  tables compared: {len(drifts)}")
+    print(f"  drift count:     {total_drift}")
+
+    if any_error:
+        return 1
+    return 1 if total_drift else 0
+
+
+def _parse_args(argv: Sequence[str]) -> argparse.Namespace:
+    ap = argparse.ArgumentParser(
+        prog="python -m lavandula.common.tools.verify_dual_write",
+        description="Compare SQLite vs RDS row counts and PK presence.",
+    )
+    ap.add_argument("--sqlite", required=True,
+                    help="Path to source SQLite DB file")
+    ap.add_argument("--table", action="append", default=[],
+                    help="Specific table(s); repeatable. Default: all seven.")
+    ap.add_argument("--schema", default="lava_impact",
+                    help="Target Postgres schema (default lava_impact).")
+    return ap.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+    args = _parse_args(list(sys.argv[1:] if argv is None else argv))
+    return run(
+        sqlite_path=args.sqlite,
+        tables=args.table,
+        schema=args.schema,
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/lavandula/reports/budget.py
+++ b/lavandula/reports/budget.py
@@ -23,9 +23,12 @@ from __future__ import annotations
 
 import datetime
 import sqlite3
+from typing import Any
 
 from . import classify as _classify
 from . import config
+
+_RDS_SCHEMA = "lava_impact"
 
 
 class BudgetExceeded(RuntimeError):
@@ -41,6 +44,7 @@ def check_and_reserve(
     *,
     estimated_cents: int,
     classifier_model: str,
+    rds_writer: Any = None,
 ) -> int:
     """Atomic preflight reserve: returns the reservation row id.
 
@@ -63,6 +67,7 @@ def check_and_reserve(
                 f"budget cap {config.CLASSIFIER_BUDGET_CENTS}c: running {running_total}c + "
                 f"est {estimated_cents}c would exceed"
             )
+        at_iso = _now_iso()
         cur = conn.execute(
             """
             INSERT INTO budget_ledger
@@ -70,10 +75,30 @@ def check_and_reserve(
                input_tokens, output_tokens, cents_spent, notes)
             VALUES (?, ?, 'preflight', 0, 0, ?, 'reserved')
             """,
-            (_now_iso(), classifier_model, int(estimated_cents)),
+            (at_iso, classifier_model, int(estimated_cents)),
         )
         reservation_id = int(cur.lastrowid)
         conn.execute("COMMIT")
+        if rds_writer is not None:
+            # The RDS row's autoincrement id is independent of SQLite's
+            # reservation_id; encode SQLite's id into the notes field
+            # so `settle`/`release` can locate the matching RDS row.
+            rds_note = f"reserved:{reservation_id}"
+            params = (at_iso, classifier_model, int(estimated_cents), rds_note)
+
+            def _do_rds(pg_conn: Any) -> None:
+                with pg_conn.cursor() as cur_pg:
+                    cur_pg.execute(
+                        f"""
+                        INSERT INTO {_RDS_SCHEMA}.budget_ledger
+                          (at_timestamp, classifier_model, sha256_classified,
+                           input_tokens, output_tokens, cents_spent, notes)
+                        VALUES (%s, %s, 'preflight', 0, 0, %s, %s)
+                        """,
+                        params,
+                    )
+
+            rds_writer.put(_do_rds)
         return reservation_id
     except BudgetExceeded:
         raise
@@ -92,6 +117,7 @@ def settle(
     actual_input_tokens: int,
     actual_output_tokens: int,
     sha256_classified: str,
+    rds_writer: Any = None,
 ) -> None:
     """Convert a preflight reservation to an actual spend record."""
     if len(sha256_classified) != 64:
@@ -127,8 +153,33 @@ def settle(
             pass
         raise
 
+    if rds_writer is not None:
+        rds_preflight_note = f"reserved:{reservation_id}"
+        params = (
+            actual_cents, sha256_classified,
+            int(actual_input_tokens), int(actual_output_tokens),
+            rds_preflight_note,
+        )
 
-def release(conn: sqlite3.Connection, *, reservation_id: int) -> None:
+        def _do_rds(pg_conn: Any) -> None:
+            with pg_conn.cursor() as cur_pg:
+                cur_pg.execute(
+                    f"""
+                    UPDATE {_RDS_SCHEMA}.budget_ledger
+                       SET cents_spent = %s,
+                           sha256_classified = %s,
+                           input_tokens = %s,
+                           output_tokens = %s,
+                           notes = 'settled'
+                     WHERE notes = %s AND sha256_classified = 'preflight'
+                    """,
+                    params,
+                )
+
+        rds_writer.put(_do_rds)
+
+
+def release(conn: sqlite3.Connection, *, reservation_id: int, rds_writer: Any = None) -> None:
     """Delete an unsettled preflight row (call on API failure)."""
     try:
         conn.execute("BEGIN IMMEDIATE")
@@ -143,6 +194,21 @@ def release(conn: sqlite3.Connection, *, reservation_id: int) -> None:
         except sqlite3.OperationalError:
             pass
         raise
+
+    if rds_writer is not None:
+        rds_preflight_note = f"reserved:{reservation_id}"
+
+        def _do_rds(pg_conn: Any) -> None:
+            with pg_conn.cursor() as cur_pg:
+                cur_pg.execute(
+                    f"""
+                    DELETE FROM {_RDS_SCHEMA}.budget_ledger
+                     WHERE notes = %s AND sha256_classified = 'preflight'
+                    """,
+                    (rds_preflight_note,),
+                )
+
+        rds_writer.put(_do_rds)
 
 
 def reconcile_stale_reservations(conn: sqlite3.Connection) -> int:

--- a/lavandula/reports/crawler.py
+++ b/lavandula/reports/crawler.py
@@ -33,6 +33,7 @@ from . import archive as _archive
 from . import budget
 from .candidate_filter import Candidate
 from .db_queue import DBWriter, DBWriterDied
+from .rds_db_writer import RDSDBWriter
 from .discover import per_org_candidates
 from .http_client import ReportsHTTPClient, tls_self_test, TLSMisconfigured
 from .logging_utils import sanitize, setup_logging
@@ -284,6 +285,7 @@ def process_org(
     archive_dir: Path | None = None,
     run_id: str = "",
     db_queue: "DBWriter | None" = None,
+    rds_queue: "RDSDBWriter | None" = None,
     client: ReportsHTTPClient | None = None,
     conn: sqlite3.Connection | None = None,
 ) -> OrgResult:
@@ -311,7 +313,9 @@ def process_org(
         archive = _archive.LocalArchive(archive_dir)
 
     def _write_fetch(**kwargs):
-        db_writer.record_fetch(conn, db_writer=db_queue, **kwargs)
+        db_writer.record_fetch(
+            conn, db_writer=db_queue, rds_writer=rds_queue, **kwargs,
+        )
 
     result = OrgResult(ein=ein)
     seed_etld1 = etld1(urlsplit(website).hostname or "")
@@ -461,6 +465,7 @@ def process_org(
         db_writer.upsert_report(
             conn,
             db_writer=db_queue,
+            rds_writer=rds_queue,
             content_sha256=outcome.content_sha256,
             source_url_redacted=outcome.final_url_redacted or redact_url(cand.url),
             referring_page_url_redacted=redact_url(cand.referring_page_url),
@@ -511,6 +516,7 @@ def process_org(
     db_writer.upsert_crawled_org(
         conn,
         db_writer=db_queue,
+        rds_writer=rds_queue,
         ein=ein,
         candidate_count=result.candidate_count,
         fetched_count=result.fetched_count,
@@ -706,6 +712,27 @@ def run(argv: list[str] | None = None) -> int:
             # through `writer`. `max_workers=1` preserves serial behavior.
             writer = DBWriter(str(db_path))
             writer.start()
+
+            # Spec 0013 Phase 3: opt-in dual-write to RDS. When the flag
+            # is off, NO RDS engine is constructed and behavior is
+            # byte-identical to pre-0013.
+            rds_writer: RDSDBWriter | None = None
+            dual_write_flag = os.getenv("LAVANDULA_DUAL_WRITE", "").strip().lower()
+            if dual_write_flag in ("1", "true", "yes", "on"):
+                try:
+                    from lavandula.common.db import make_app_engine
+                    engine = make_app_engine()
+                    rds_writer = RDSDBWriter(engine)
+                    rds_writer.start()
+                    logger.info("LAVANDULA_DUAL_WRITE on: RDS writer started")
+                except Exception as exc:  # noqa: BLE001
+                    logger.warning(
+                        "LAVANDULA_DUAL_WRITE on but RDS engine setup "
+                        "failed (%s); continuing with SQLite only",
+                        exc.__class__.__name__,
+                    )
+                    rds_writer = None
+
             try:
                 with ThreadPoolExecutor(
                     max_workers=args.max_workers,
@@ -719,6 +746,7 @@ def run(argv: list[str] | None = None) -> int:
                             archive=archive,
                             run_id=run_id,
                             db_queue=writer,
+                            rds_queue=rds_writer,
                         ): (ein, website)
                         for ein, website in pending
                     }
@@ -737,6 +765,14 @@ def run(argv: list[str] | None = None) -> int:
                             logger.exception("ein=%s failed: %s", ein, exc)
             finally:
                 writer.stop()
+                if rds_writer is not None:
+                    try:
+                        rds_writer.stop()
+                    except Exception as exc:  # noqa: BLE001
+                        logger.warning(
+                            "rds writer stop raised (%s); ignoring",
+                            exc.__class__.__name__,
+                        )
                 _close_thread_clients()
         finally:
             conn.close()

--- a/lavandula/reports/db_writer.py
+++ b/lavandula/reports/db_writer.py
@@ -4,6 +4,11 @@ Every SQL write goes through `?` parameter binding. This module plus
 `catalogue.py` and `schema.py` are the ONLY files permitted to reference
 the `reports` table directly (AC23); everything else reads through the
 `reports_public` view.
+
+Spec 0013 Phase 3: each public function accepts an optional
+`rds_writer` kwarg. When provided, a parallel Postgres-flavored
+closure is enqueued on the RDS writer. RDS is best-effort; its
+failures never affect the SQLite write or the caller.
 """
 from __future__ import annotations
 
@@ -11,6 +16,8 @@ import datetime
 import json
 import sqlite3
 from typing import Any
+
+_RDS_SCHEMA = "lava_impact"
 
 _ATTRIBUTION_RANK = {
     "platform_unverified": 0,
@@ -100,11 +107,17 @@ def record_fetch(
     elapsed_ms: int | None = None,
     notes: str | None = None,
     db_writer: Any = None,
+    rds_writer: Any = None,
 ) -> None:
     """Append a row to fetch_log.
 
     When `db_writer` is provided (TICK-002 parallel mode), the write is
     enqueued on the single-writer thread and `conn` may be `None`.
+
+    When `rds_writer` is also provided (Spec 0013 Phase 3 dual-write),
+    a parallel Postgres-flavored closure is enqueued on the RDS
+    writer. `fetch_log` is an auto-id table; the `id` column is
+    omitted so Postgres assigns a fresh sequence value.
     """
     now_iso = _now_iso()
 
@@ -125,6 +138,24 @@ def record_fetch(
     else:
         _do(conn)
 
+    if rds_writer is not None:
+        params = (ein, url_redacted, kind, fetch_status, status_code,
+                  now_iso, elapsed_ms, notes)
+
+        def _do_rds(pg_conn: Any) -> None:
+            with pg_conn.cursor() as cur:
+                cur.execute(
+                    f"""
+                    INSERT INTO {_RDS_SCHEMA}.fetch_log
+                      (ein, url_redacted, kind, fetch_status, status_code,
+                       fetched_at, elapsed_ms, notes)
+                    VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
+                    """,
+                    params,
+                )
+
+        rds_writer.put(_do_rds)
+
 
 def upsert_crawled_org(
     conn: sqlite3.Connection | None,
@@ -134,6 +165,7 @@ def upsert_crawled_org(
     fetched_count: int,
     confirmed_report_count: int,
     db_writer: Any = None,
+    rds_writer: Any = None,
 ) -> None:
     """Track that this EIN has been processed (AC20 resume)."""
     now = _now_iso()
@@ -163,6 +195,28 @@ def upsert_crawled_org(
         db_writer.put(_do)
     else:
         _do(conn)
+
+    if rds_writer is not None:
+        params = (ein, now, now, candidate_count, fetched_count,
+                  confirmed_report_count)
+
+        def _do_rds(pg_conn: Any) -> None:
+            with pg_conn.cursor() as cur:
+                cur.execute(
+                    f"""
+                    INSERT INTO {_RDS_SCHEMA}.crawled_orgs
+                      (ein, first_crawled_at, last_crawled_at,
+                       candidate_count, fetched_count, confirmed_report_count)
+                    VALUES (%s, %s, %s, %s, %s, %s)
+                    ON CONFLICT (ein) DO UPDATE SET
+                      last_crawled_at = EXCLUDED.last_crawled_at,
+                      candidate_count = EXCLUDED.candidate_count,
+                      fetched_count = EXCLUDED.fetched_count
+                    """,
+                    params,
+                )
+
+        rds_writer.put(_do_rds)
 
 
 def upsert_report(
@@ -195,6 +249,7 @@ def upsert_report(
     report_year_source: str | None,
     extractor_version: int,
     db_writer: Any = None,
+    rds_writer: Any = None,
 ) -> None:
     """Insert or improve a fully-shaped row into reports keyed by sha."""
     chain_json = (
@@ -240,8 +295,49 @@ def upsert_report(
 
     if db_writer is not None:
         db_writer.put(_do)
-        return
-    _do(conn)
+    else:
+        _do(conn)
+
+    if rds_writer is not None:
+        # Capture the fully-resolved kwargs for the RDS closure. The
+        # Postgres side runs a parallel read-merge-write with the same
+        # attribution/confidence logic, but against lava_impact.reports.
+        rds_kwargs = dict(
+            content_sha256=content_sha256,
+            source_url_redacted=source_url_redacted,
+            referring_page_url_redacted=referring_page_url_redacted,
+            chain_json=chain_json,
+            source_org_ein=source_org_ein,
+            discovered_via=discovered_via,
+            hosting_platform=hosting_platform,
+            attribution_confidence=attribution_confidence,
+            archived_at=archived_at,
+            content_type=content_type,
+            file_size_bytes=file_size_bytes,
+            page_count=page_count,
+            first_page_text=first_page_text,
+            pdf_creator=pdf_creator,
+            pdf_producer=pdf_producer,
+            pdf_creation_date=pdf_creation_date,
+            pdf_has_javascript=pdf_has_javascript,
+            pdf_has_launch=pdf_has_launch,
+            pdf_has_embedded=pdf_has_embedded,
+            pdf_has_uri_actions=pdf_has_uri_actions,
+            classification=classification,
+            classification_confidence=classification_confidence,
+            classifier_model=classifier_model,
+            classifier_version=classifier_version,
+            classified_at=classified_at,
+            report_year=report_year,
+            report_year_source=report_year_source,
+            extractor_version=extractor_version,
+        )
+
+        def _do_rds(pg_conn: Any) -> None:
+            _upsert_report_pg_inner(pg_conn, **rds_kwargs)
+
+        rds_writer.put(_do_rds)
+    return
 
 
 def _upsert_report_inner(
@@ -391,6 +487,7 @@ def record_deletion(
     operator: str | None,
     pdf_unlinked: int,
     db_writer: Any = None,
+    rds_writer: Any = None,
 ) -> None:
     now_iso = _now_iso()
 
@@ -409,10 +506,200 @@ def record_deletion(
     else:
         _do(conn)
 
+    if rds_writer is not None:
+        params = (content_sha256, now_iso, reason, operator, pdf_unlinked)
+
+        def _do_rds(pg_conn: Any) -> None:
+            with pg_conn.cursor() as cur:
+                cur.execute(
+                    f"""
+                    INSERT INTO {_RDS_SCHEMA}.deletion_log
+                      (content_sha256, deleted_at, reason, operator, pdf_unlinked)
+                    VALUES (%s, %s, %s, %s, %s)
+                    """,
+                    params,
+                )
+
+        rds_writer.put(_do_rds)
+
+
+def _upsert_report_pg_inner(
+    pg_conn: Any,
+    *,
+    content_sha256: str,
+    source_url_redacted: str,
+    referring_page_url_redacted: str | None,
+    chain_json: str | None,
+    source_org_ein: str,
+    discovered_via: str,
+    hosting_platform: str | None,
+    attribution_confidence: str,
+    archived_at: str,
+    content_type: str,
+    file_size_bytes: int,
+    page_count: int | None,
+    first_page_text: str | None,
+    pdf_creator: str | None,
+    pdf_producer: str | None,
+    pdf_creation_date: str | None,
+    pdf_has_javascript: int,
+    pdf_has_launch: int,
+    pdf_has_embedded: int,
+    pdf_has_uri_actions: int,
+    classification: str | None,
+    classification_confidence: float | None,
+    classifier_model: str,
+    classifier_version: int,
+    classified_at: str | None,
+    report_year: int | None,
+    report_year_source: str | None,
+    extractor_version: int,
+) -> None:
+    """Postgres-flavored parallel of `_upsert_report_inner` for RDS.
+
+    Mirrors the same read-merge-write semantics (attribution rank,
+    classification confidence, monotonic extractor_version, etc.) but
+    targets `lava_impact.reports` with %s placeholders. Called only
+    from the `rds_writer` closure path; SQLite path is unchanged.
+    """
+    with pg_conn.cursor() as cur:
+        cur.execute(
+            f"SELECT source_url_redacted, referring_page_url_redacted, "
+            f"       redirect_chain_json, source_org_ein, discovered_via, "
+            f"       hosting_platform, attribution_confidence, "
+            f"       file_size_bytes, page_count, first_page_text, "
+            f"       pdf_creator, pdf_producer, pdf_creation_date, "
+            f"       pdf_has_javascript, pdf_has_launch, pdf_has_embedded, "
+            f"       pdf_has_uri_actions, classification, "
+            f"       classification_confidence, classifier_model, "
+            f"       classifier_version, classified_at, report_year, "
+            f"       report_year_source, extractor_version "
+            f"FROM {_RDS_SCHEMA}.reports WHERE content_sha256 = %s",
+            (content_sha256,),
+        )
+        row = cur.fetchone()
+
+        if row is None:
+            cur.execute(
+                f"""
+                INSERT INTO {_RDS_SCHEMA}.reports (
+                  content_sha256, source_url_redacted,
+                  referring_page_url_redacted, redirect_chain_json,
+                  source_org_ein, discovered_via, hosting_platform,
+                  attribution_confidence, archived_at, content_type,
+                  file_size_bytes, page_count, first_page_text,
+                  pdf_creator, pdf_producer, pdf_creation_date,
+                  pdf_has_javascript, pdf_has_launch, pdf_has_embedded,
+                  pdf_has_uri_actions, classification,
+                  classification_confidence, classifier_model,
+                  classifier_version, classified_at, report_year,
+                  report_year_source, extractor_version
+                ) VALUES (
+                  %s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,
+                  %s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s
+                )
+                """,
+                (
+                    content_sha256, source_url_redacted,
+                    referring_page_url_redacted, chain_json,
+                    source_org_ein, discovered_via, hosting_platform,
+                    attribution_confidence, archived_at, content_type,
+                    file_size_bytes, page_count, first_page_text,
+                    pdf_creator, pdf_producer, pdf_creation_date,
+                    pdf_has_javascript, pdf_has_launch, pdf_has_embedded,
+                    pdf_has_uri_actions, classification,
+                    classification_confidence, classifier_model,
+                    classifier_version, classified_at, report_year,
+                    report_year_source, extractor_version,
+                ),
+            )
+            return
+
+        (existing_source_url, existing_referring, existing_chain_json,
+         existing_ein, existing_discovered, existing_platform,
+         existing_attr, existing_size, existing_page_count,
+         existing_first_page, existing_pdf_creator,
+         existing_pdf_producer, existing_pdf_creation, existing_has_js,
+         existing_has_launch, existing_has_embedded, existing_has_uri,
+         existing_classification, existing_confidence,
+         existing_model, existing_version, existing_classified_at,
+         existing_report_year, existing_report_year_source,
+         existing_extractor_version) = row
+
+        use_new_source = _prefer_new_source(existing_attr, attribution_confidence)
+        merged = _pick_classification(
+            existing_classification=existing_classification,
+            existing_confidence=existing_confidence,
+            existing_model=existing_model,
+            existing_version=existing_version,
+            existing_classified_at=existing_classified_at,
+            new_classification=classification,
+            new_confidence=classification_confidence,
+            new_model=classifier_model,
+            new_version=classifier_version,
+            new_classified_at=classified_at,
+        )
+        cur.execute(
+            f"""
+            UPDATE {_RDS_SCHEMA}.reports
+               SET source_url_redacted = %s,
+                   referring_page_url_redacted = %s,
+                   redirect_chain_json = %s,
+                   source_org_ein = %s,
+                   discovered_via = %s,
+                   hosting_platform = %s,
+                   attribution_confidence = %s,
+                   file_size_bytes = %s,
+                   page_count = %s,
+                   first_page_text = %s,
+                   pdf_creator = %s,
+                   pdf_producer = %s,
+                   pdf_creation_date = %s,
+                   pdf_has_javascript = %s,
+                   pdf_has_launch = %s,
+                   pdf_has_embedded = %s,
+                   pdf_has_uri_actions = %s,
+                   classification = %s,
+                   classification_confidence = %s,
+                   classifier_model = %s,
+                   classifier_version = %s,
+                   classified_at = %s,
+                   report_year = %s,
+                   report_year_source = %s,
+                   extractor_version = %s
+             WHERE content_sha256 = %s
+            """,
+            (
+                source_url_redacted if use_new_source else existing_source_url,
+                referring_page_url_redacted if use_new_source else existing_referring,
+                chain_json if use_new_source else existing_chain_json,
+                source_org_ein if use_new_source else existing_ein,
+                discovered_via if use_new_source else existing_discovered,
+                hosting_platform if use_new_source else existing_platform,
+                attribution_confidence if use_new_source else existing_attr,
+                max(existing_size or 0, file_size_bytes),
+                _pick_missing(existing_page_count, page_count),
+                _pick_missing(existing_first_page, first_page_text),
+                _pick_missing(existing_pdf_creator, pdf_creator),
+                _pick_missing(existing_pdf_producer, pdf_producer),
+                _pick_missing(existing_pdf_creation, pdf_creation_date),
+                1 if existing_has_js or pdf_has_javascript else 0,
+                1 if existing_has_launch or pdf_has_launch else 0,
+                1 if existing_has_embedded or pdf_has_embedded else 0,
+                1 if existing_has_uri or pdf_has_uri_actions else 0,
+                merged[0], merged[1], merged[2], merged[3], merged[4],
+                _pick_missing(existing_report_year, report_year),
+                _pick_missing(existing_report_year_source, report_year_source),
+                max(existing_extractor_version or 0, extractor_version),
+                content_sha256,
+            ),
+        )
+
 
 __all__ = [
     "record_fetch",
     "upsert_crawled_org",
     "upsert_report",
     "record_deletion",
+    "_upsert_report_pg_inner",
 ]

--- a/lavandula/reports/db_writer.py
+++ b/lavandula/reports/db_writer.py
@@ -211,7 +211,16 @@ def upsert_crawled_org(
                     ON CONFLICT (ein) DO UPDATE SET
                       last_crawled_at = EXCLUDED.last_crawled_at,
                       candidate_count = EXCLUDED.candidate_count,
-                      fetched_count = EXCLUDED.fetched_count
+                      fetched_count = EXCLUDED.fetched_count,
+                      -- SQLite-parity: the crawler passes 0 on re-crawl
+                      -- and classify_null backfills the real value later.
+                      -- GREATEST protects the classify_null-backfilled
+                      -- count from being reset to 0 on re-crawl, matching
+                      -- SQLite's "intentionally NOT updated here" behavior.
+                      confirmed_report_count = GREATEST(
+                        {_RDS_SCHEMA}.crawled_orgs.confirmed_report_count,
+                        EXCLUDED.confirmed_report_count
+                      )
                     """,
                     params,
                 )

--- a/lavandula/reports/db_writer.py
+++ b/lavandula/reports/db_writer.py
@@ -532,6 +532,24 @@ def record_deletion(
         rds_writer.put(_do_rds)
 
 
+def _is_unique_violation(exc: BaseException) -> bool:
+    """Identify psycopg2 UniqueViolation without a hard import dependency.
+
+    Tests and some environments may not have psycopg2 on the path, so
+    we duck-type the SQLSTATE ('23505' = unique_violation per Postgres).
+    """
+    pgcode = getattr(exc, "pgcode", None)
+    if pgcode == "23505":
+        return True
+    cls_name = exc.__class__.__name__
+    if cls_name == "UniqueViolation":
+        return True
+    return False
+
+
+_UPSERT_REPORT_MAX_ATTEMPTS = 2
+
+
 def _upsert_report_pg_inner(
     pg_conn: Any,
     *,
@@ -570,7 +588,106 @@ def _upsert_report_pg_inner(
     classification confidence, monotonic extractor_version, etc.) but
     targets `lava_impact.reports` with %s placeholders. Called only
     from the `rds_writer` closure path; SQLite path is unchanged.
+
+    Race handling: the crawler and classify_null each run independent
+    `RDSDBWriter`s, so two processes can SELECT (miss) → INSERT the
+    same `content_sha256` and lose the race on the Postgres unique
+    key. We catch `UniqueViolation` (SQLSTATE 23505), rollback to a
+    savepoint, and retry the read-merge path which now sees the
+    other writer's row and lands in the UPDATE branch. Bounded to
+    `_UPSERT_REPORT_MAX_ATTEMPTS` to avoid pathological loops.
     """
+    kwargs = dict(
+        content_sha256=content_sha256,
+        source_url_redacted=source_url_redacted,
+        referring_page_url_redacted=referring_page_url_redacted,
+        chain_json=chain_json,
+        source_org_ein=source_org_ein,
+        discovered_via=discovered_via,
+        hosting_platform=hosting_platform,
+        attribution_confidence=attribution_confidence,
+        archived_at=archived_at,
+        content_type=content_type,
+        file_size_bytes=file_size_bytes,
+        page_count=page_count,
+        first_page_text=first_page_text,
+        pdf_creator=pdf_creator,
+        pdf_producer=pdf_producer,
+        pdf_creation_date=pdf_creation_date,
+        pdf_has_javascript=pdf_has_javascript,
+        pdf_has_launch=pdf_has_launch,
+        pdf_has_embedded=pdf_has_embedded,
+        pdf_has_uri_actions=pdf_has_uri_actions,
+        classification=classification,
+        classification_confidence=classification_confidence,
+        classifier_model=classifier_model,
+        classifier_version=classifier_version,
+        classified_at=classified_at,
+        report_year=report_year,
+        report_year_source=report_year_source,
+        extractor_version=extractor_version,
+    )
+    sp_name = "upsert_report_rds"
+    last_exc: BaseException | None = None
+    for _attempt in range(_UPSERT_REPORT_MAX_ATTEMPTS):
+        with pg_conn.cursor() as sp_cur:
+            sp_cur.execute(f"SAVEPOINT {sp_name}")
+        try:
+            _upsert_report_pg_body(pg_conn, **kwargs)
+            with pg_conn.cursor() as sp_cur:
+                sp_cur.execute(f"RELEASE SAVEPOINT {sp_name}")
+            return
+        except Exception as exc:  # noqa: BLE001
+            with pg_conn.cursor() as sp_cur:
+                sp_cur.execute(f"ROLLBACK TO SAVEPOINT {sp_name}")
+            if _is_unique_violation(exc):
+                # Another writer inserted this sha between our SELECT
+                # and INSERT. Retry — the second pass will see the
+                # row and take the UPDATE branch.
+                last_exc = exc
+                continue
+            raise
+    # Exhausted attempts — surface the last UniqueViolation. The
+    # best-effort RDSDBWriter will log WARN and drop the op; SQLite
+    # remains untouched.
+    if last_exc is not None:
+        raise last_exc
+
+
+def _upsert_report_pg_body(
+    pg_conn: Any,
+    *,
+    content_sha256: str,
+    source_url_redacted: str,
+    referring_page_url_redacted: str | None,
+    chain_json: str | None,
+    source_org_ein: str,
+    discovered_via: str,
+    hosting_platform: str | None,
+    attribution_confidence: str,
+    archived_at: str,
+    content_type: str,
+    file_size_bytes: int,
+    page_count: int | None,
+    first_page_text: str | None,
+    pdf_creator: str | None,
+    pdf_producer: str | None,
+    pdf_creation_date: str | None,
+    pdf_has_javascript: int,
+    pdf_has_launch: int,
+    pdf_has_embedded: int,
+    pdf_has_uri_actions: int,
+    classification: str | None,
+    classification_confidence: float | None,
+    classifier_model: str,
+    classifier_version: int,
+    classified_at: str | None,
+    report_year: int | None,
+    report_year_source: str | None,
+    extractor_version: int,
+) -> None:
+    """One read-merge-write attempt against RDS. Called by the retry
+    loop in `_upsert_report_pg_inner`."""
     with pg_conn.cursor() as cur:
         cur.execute(
             f"SELECT source_url_redacted, referring_page_url_redacted, "

--- a/lavandula/reports/rds_db_writer.py
+++ b/lavandula/reports/rds_db_writer.py
@@ -93,11 +93,13 @@ class RDSDBWriter:
 
     # -- submission -------------------------------------------------------
 
-    def put(self, op: RDSWriteOp, *, timeout: float = 30.0) -> None:
-        """Enqueue a Postgres closure. Best-effort: never raises.
+    def put(self, op: RDSWriteOp) -> None:
+        """Enqueue a Postgres closure. Non-blocking, best-effort, never raises.
 
-        If the queue is full for `timeout` seconds, or the writer
-        thread is dead, the op is dropped with a WARNING log.
+        This is on the crawler hot path: every SQLite write site
+        mirrors through here, so we MUST NOT block. If the queue is
+        full or the writer thread is dead, the op is dropped with a
+        WARNING log and the caller continues immediately.
         """
         if self._thread is not None and not self._thread.is_alive():
             self._dropped_on_put += 1
@@ -108,13 +110,13 @@ class RDSDBWriter:
             )
             return
         try:
-            self._q.put(op, timeout=timeout)
+            self._q.put_nowait(op)
         except Full:
             self._dropped_on_put += 1
             log.warning(
-                "rds writer queue saturated for %.1fs; dropping op "
+                "rds writer queue full (size=%d); dropping op "
                 "(total dropped=%d)",
-                timeout, self._dropped_on_put,
+                self._q.maxsize, self._dropped_on_put,
             )
 
     # -- observability ----------------------------------------------------

--- a/lavandula/reports/rds_db_writer.py
+++ b/lavandula/reports/rds_db_writer.py
@@ -1,0 +1,182 @@
+"""Single-thread async writer to RDS Postgres for dual-write (Spec 0013 Phase 3).
+
+Mirrors the interface of `DBWriter` (SQLite) but with a fundamentally
+different failure model: **RDS is best-effort**. A full queue, a
+crashed worker thread, or a raised psycopg2 exception is logged as
+WARNING and dropped — the authoritative SQLite write path is never
+affected.
+
+The worker thread opens raw psycopg2 connections via
+`engine.raw_connection()` and hands them to each submitted closure.
+The closure is expected to run Postgres-flavored SQL (`%s`
+placeholders, `lava_impact.<table>` schema qualification,
+`ON CONFLICT ... DO UPDATE` clauses).
+
+Key differences from `DBWriter`:
+  - `put()` never raises DBWriterSaturated / DBWriterDied; queue
+    saturation or thread death → WARN log + drop (best-effort).
+  - Per-closure failures rollback and log WARNING; the worker keeps
+    going (does not exit on first error).
+  - `stop()` drains with a timeout; ops remaining at the deadline are
+    logged as drift and dropped.
+"""
+from __future__ import annotations
+
+import logging
+import threading
+from queue import Empty, Full, Queue
+from typing import Any, Callable, Optional
+
+log = logging.getLogger("lavandula.reports.rds_db_writer")
+
+RDSWriteOp = Callable[[Any], None]
+
+
+class RDSDBWriter:
+    """Async, best-effort RDS writer for dual-write.
+
+    Closures submitted via `put()` run on a single dedicated thread,
+    each receiving a raw psycopg2 connection (via
+    `engine.raw_connection()`). The closure commits by returning
+    normally; the writer rolls back on exception.
+    """
+
+    def __init__(
+        self,
+        engine: Any,
+        *,
+        maxsize: int = 256,
+        name: str = "lavandula-reports-rds-writer",
+    ) -> None:
+        self._engine = engine
+        self._q: "Queue[RDSWriteOp]" = Queue(maxsize=maxsize)
+        self._stop = threading.Event()
+        self._thread: Optional[threading.Thread] = None
+        self._name = name
+        self._dropped_on_put = 0
+        self._failed_ops = 0
+
+    # -- lifecycle --------------------------------------------------------
+
+    def start(self) -> None:
+        if self._thread is not None:
+            raise RuntimeError("RDSDBWriter already started")
+        self._thread = threading.Thread(
+            target=self._run, name=self._name, daemon=True,
+        )
+        self._thread.start()
+
+    def stop(self, *, timeout: float = 30.0) -> None:
+        """Signal shutdown; drain queue with `timeout` seconds.
+
+        Ops remaining past the deadline are logged as drift and dropped.
+        Never raises.
+        """
+        self._stop.set()
+        if self._thread is not None:
+            self._thread.join(timeout=timeout)
+            if self._thread.is_alive():
+                log.warning(
+                    "rds writer did not finish draining within %.1fs; "
+                    "remaining queue size=%d, dropping on exit",
+                    timeout, self._q.qsize(),
+                )
+            self._thread = None
+        remaining = self._q.qsize()
+        if remaining:
+            log.warning(
+                "rds writer stop: %d ops remained in queue (drift)", remaining,
+            )
+
+    def is_alive(self) -> bool:
+        return self._thread is not None and self._thread.is_alive()
+
+    # -- submission -------------------------------------------------------
+
+    def put(self, op: RDSWriteOp, *, timeout: float = 30.0) -> None:
+        """Enqueue a Postgres closure. Best-effort: never raises.
+
+        If the queue is full for `timeout` seconds, or the writer
+        thread is dead, the op is dropped with a WARNING log.
+        """
+        if self._thread is not None and not self._thread.is_alive():
+            self._dropped_on_put += 1
+            log.warning(
+                "rds writer thread not alive; dropping op "
+                "(total dropped=%d)",
+                self._dropped_on_put,
+            )
+            return
+        try:
+            self._q.put(op, timeout=timeout)
+        except Full:
+            self._dropped_on_put += 1
+            log.warning(
+                "rds writer queue saturated for %.1fs; dropping op "
+                "(total dropped=%d)",
+                timeout, self._dropped_on_put,
+            )
+
+    # -- observability ----------------------------------------------------
+
+    @property
+    def dropped_count(self) -> int:
+        return self._dropped_on_put
+
+    @property
+    def failed_count(self) -> int:
+        return self._failed_ops
+
+    # -- internal ---------------------------------------------------------
+
+    def _run(self) -> None:
+        while not self._stop.is_set() or not self._q.empty():
+            try:
+                op = self._q.get(timeout=0.25)
+            except Empty:
+                continue
+            self._run_one(op)
+
+    def _run_one(self, op: RDSWriteOp) -> None:
+        raw_conn = None
+        try:
+            raw_conn = self._engine.raw_connection()
+        except Exception as exc:  # noqa: BLE001
+            self._failed_ops += 1
+            log.warning(
+                "rds writer: raw_connection() failed (%s); dropping op",
+                exc.__class__.__name__,
+            )
+            return
+        try:
+            op(raw_conn)
+            try:
+                raw_conn.commit()
+            except Exception as commit_exc:  # noqa: BLE001
+                self._failed_ops += 1
+                log.warning(
+                    "rds writer: commit failed (%s); op dropped",
+                    commit_exc.__class__.__name__,
+                )
+                try:
+                    raw_conn.rollback()
+                except Exception:  # noqa: BLE001
+                    pass
+        except Exception as exc:  # noqa: BLE001
+            self._failed_ops += 1
+            log.warning(
+                "rds writer: op failed (%s); rolled back, crawler continues",
+                exc.__class__.__name__,
+            )
+            try:
+                raw_conn.rollback()
+            except Exception:  # noqa: BLE001
+                pass
+        finally:
+            try:
+                raw_conn.close()
+            except Exception:  # noqa: BLE001
+                pass
+
+
+__all__ = ["RDSDBWriter", "RDSWriteOp"]

--- a/lavandula/reports/tests/unit/test_classify_null_dual_write_0013p3.py
+++ b/lavandula/reports/tests/unit/test_classify_null_dual_write_0013p3.py
@@ -1,0 +1,76 @@
+"""Verify `classify_null` threads `rds_writer` through every budget
+call site and the audit-trail `record_fetch` call (Spec 0013 P3).
+
+This closes the gap Codex flagged: budget.check_and_reserve /
+settle / release grew `rds_writer` kwargs, but the only real caller
+is `classify_null`. Without wiring there, the budget_ledger would
+stay SQLite-only in live runs.
+"""
+from __future__ import annotations
+
+import inspect
+from lavandula.reports import budget, db_writer
+from lavandula.reports.tools import classify_null
+
+
+def _signature_params(fn) -> set[str]:
+    return set(inspect.signature(fn).parameters.keys())
+
+
+def test_classify_one_signature_accepts_rds_writer():
+    assert "rds_writer" in _signature_params(classify_null._classify_one)
+
+
+def test_release_reservation_signature_accepts_rds_writer():
+    assert "rds_writer" in _signature_params(classify_null._release_reservation)
+
+
+def test_budget_functions_accept_rds_writer():
+    # Safeguard: if future refactors remove the kwarg, the wiring test
+    # below would silently pass.
+    for fn in (budget.check_and_reserve, budget.settle, budget.release):
+        assert "rds_writer" in _signature_params(fn), fn.__name__
+
+
+def test_classify_null_source_wires_rds_writer_into_budget_calls():
+    """Inspect the source to confirm every budget.* call passes the
+    `rds_writer` kwarg (Codex round-1 finding #2)."""
+    src = inspect.getsource(classify_null)
+    # check_and_reserve is called with rds_writer=rds_writer
+    assert "rds_writer=rds_writer" in src
+    # All three budget calls in the file — be specific per call name.
+    assert "budget.check_and_reserve(" in src
+    assert "budget.settle(" in src
+    assert "budget.release(" in src
+
+    # Assert that none of the three budget call sites appears in the
+    # source without being followed within a few lines by rds_writer=.
+    for fn_name in ("check_and_reserve", "settle", "release"):
+        call_idx = src.find(f"budget.{fn_name}(")
+        assert call_idx != -1, fn_name
+        snippet = src[call_idx:call_idx + 600]
+        assert "rds_writer=" in snippet, (
+            f"budget.{fn_name} call site missing rds_writer kwarg"
+        )
+
+
+def test_classify_null_source_wires_rds_writer_into_record_fetch():
+    """The `record_fetch` audit call for classify events must also
+    mirror to RDS so the fetch_log stays consistent across backends."""
+    src = inspect.getsource(classify_null)
+    call_idx = src.find("db_writer.record_fetch(")
+    assert call_idx != -1
+    snippet = src[call_idx:call_idx + 600]
+    assert "rds_writer=rds_writer" in snippet
+
+
+def test_classify_null_constructs_rds_writer_behind_flag():
+    """The source must construct `RDSDBWriter` only when
+    `LAVANDULA_DUAL_WRITE` is truthy."""
+    src = inspect.getsource(classify_null)
+    assert "LAVANDULA_DUAL_WRITE" in src
+    assert "RDSDBWriter(" in src
+    # Flag gate precedes construction.
+    gate_idx = src.find("LAVANDULA_DUAL_WRITE")
+    ctor_idx = src.find("RDSDBWriter(")
+    assert 0 < gate_idx < ctor_idx

--- a/lavandula/reports/tests/unit/test_classify_null_parallel_tick002.py
+++ b/lavandula/reports/tests/unit/test_classify_null_parallel_tick002.py
@@ -131,10 +131,12 @@ def test_budget_reserve_and_settle_around_each_classify(tmp_path, monkeypatch):
     original_settle = budget.settle
     original_release = budget.release
 
-    def tracking_reserve(conn_, *, estimated_cents, classifier_model):
+    def tracking_reserve(conn_, *, estimated_cents, classifier_model,
+                         rds_writer=None):
         rid = original_reserve(
             conn_, estimated_cents=estimated_cents,
             classifier_model=classifier_model,
+            rds_writer=rds_writer,
         )
         reserves.append(rid)
         return rid
@@ -143,9 +145,10 @@ def test_budget_reserve_and_settle_around_each_classify(tmp_path, monkeypatch):
         settles.append(reservation_id)
         return original_settle(conn_, reservation_id=reservation_id, **kw)
 
-    def tracking_release(conn_, *, reservation_id):
+    def tracking_release(conn_, *, reservation_id, rds_writer=None):
         releases.append(reservation_id)
-        return original_release(conn_, reservation_id=reservation_id)
+        return original_release(conn_, reservation_id=reservation_id,
+                                rds_writer=rds_writer)
 
     monkeypatch.setattr(budget, "check_and_reserve", tracking_reserve)
     monkeypatch.setattr(budget, "settle", tracking_settle)
@@ -212,7 +215,8 @@ def test_budget_exceeded_halts_run(tmp_path, monkeypatch):
 
     classify_calls = []
 
-    def always_exceeded(conn_, *, estimated_cents, classifier_model):
+    def always_exceeded(conn_, *, estimated_cents, classifier_model,
+                        rds_writer=None):
         raise budget.BudgetExceeded("over cap")
 
     monkeypatch.setattr(budget, "check_and_reserve", always_exceeded)

--- a/lavandula/reports/tests/unit/test_crawler_dual_write_flag_0013p3.py
+++ b/lavandula/reports/tests/unit/test_crawler_dual_write_flag_0013p3.py
@@ -1,59 +1,162 @@
-"""Verify that the LAVANDULA_DUAL_WRITE flag gates all RDS work.
+"""Verify that `LAVANDULA_DUAL_WRITE` gates the real RDS construction
+path in `crawler.run()` (Spec 0013 Phase 3).
 
-AC1: with the flag unset or zero, the crawler MUST NOT import
-`lavandula.common.db.make_app_engine` nor construct `RDSDBWriter`.
-AC2: with the flag set, it MUST do both.
+AC1: flag off → `make_app_engine` is NOT called and no `RDSDBWriter`
+     is constructed.
+AC2: flag on  → `make_app_engine` IS called, `RDSDBWriter` is started
+     and stopped exactly once.
 
-We test the wiring logic directly rather than spinning up a full
-crawl, by monkey-patching the factories and inspecting call counts.
+These tests stub out the heavy parts of `crawler.run()` (archive
+probes, flock, encryption check, TLS self-test, DB schema setup,
+per-org processing) so we can exercise the actual decision and
+construction code path without touching the network or filesystem.
 """
 from __future__ import annotations
 
 import os
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
-
-def test_flag_off_no_rds_engine_constructed(monkeypatch):
-    """Mirror the crawler's flag logic and assert no RDS import happens."""
-    monkeypatch.delenv("LAVANDULA_DUAL_WRITE", raising=False)
-
-    calls = {"make_app_engine": 0}
-
-    def fake_factory():
-        calls["make_app_engine"] += 1
-        return MagicMock()
-
-    # Replicate crawler.run()'s decision block:
-    flag = os.getenv("LAVANDULA_DUAL_WRITE", "").strip().lower()
-    enabled = flag in ("1", "true", "yes", "on")
-    if enabled:
-        fake_factory()
-
-    assert enabled is False
-    assert calls["make_app_engine"] == 0
+from lavandula.reports import crawler
 
 
-@pytest.mark.parametrize("val", ["1", "true", "TRUE", "yes", "on"])
-def test_flag_on_variants_enable_rds(monkeypatch, val):
-    monkeypatch.setenv("LAVANDULA_DUAL_WRITE", val)
-    flag = os.getenv("LAVANDULA_DUAL_WRITE", "").strip().lower()
-    assert flag in ("1", "true", "yes", "on")
+class _ArchiveStub:
+    def startup_probe(self):
+        return None
 
 
-@pytest.mark.parametrize("val", ["0", "false", "no", "", "off"])
-def test_flag_off_variants_keep_rds_disabled(monkeypatch, val):
-    monkeypatch.setenv("LAVANDULA_DUAL_WRITE", val)
-    flag = os.getenv("LAVANDULA_DUAL_WRITE", "").strip().lower()
-    assert flag not in ("1", "true", "yes", "on")
+def _run_with_stubs(monkeypatch, tmp_path, *, flag_value=None,
+                    engine_raises: Exception | None = None):
+    """Call crawler.run() with enough stubs that it reaches the
+    dual-write decision block and returns cleanly with zero orgs."""
+    if flag_value is None:
+        monkeypatch.delenv("LAVANDULA_DUAL_WRITE", raising=False)
+    else:
+        monkeypatch.setenv("LAVANDULA_DUAL_WRITE", flag_value)
+
+    # Stub heavy operational steps.
+    monkeypatch.setattr(
+        crawler, "_resolve_archive",
+        lambda parser, args: _ArchiveStub(),
+    )
+    monkeypatch.setattr(
+        crawler, "acquire_flock", lambda path: 999,
+    )
+    monkeypatch.setattr(
+        crawler, "check_encryption_at_rest",
+        lambda data_dir: crawler.EncryptionCheckResult(ok=True),
+    )
+    monkeypatch.setattr(crawler, "tls_self_test", lambda: None)
+
+    class _StubConn:
+        def close(self):
+            pass
+
+        def execute(self, *a, **kw):  # for budget.reconcile_stale_reservations
+            class _C:
+                rowcount = 0
+                def fetchone(self_):
+                    return (0,)
+            return _C()
+
+    monkeypatch.setattr(
+        crawler.schema, "ensure_db",
+        lambda db_path: _StubConn(),
+    )
+    # No seeds → the pool loop short-circuits; writer.start()/stop() still run.
+    monkeypatch.setattr(
+        crawler, "fetch_seeds_from_0001",
+        lambda path: [],
+    )
+    # Bypass budget reconcile (reports.db not real).
+    monkeypatch.setattr(
+        crawler.budget, "reconcile_stale_reservations",
+        lambda conn: 0,
+    )
+    # Silence DBWriter's actual SQLite work — it'd fail on our stub conn.
+    class _DBWriterStub:
+        def __init__(self, *a, **kw):
+            pass
+        def start(self):
+            pass
+        def stop(self):
+            pass
+        def is_alive(self):
+            return True
+    monkeypatch.setattr(crawler, "DBWriter", _DBWriterStub)
+
+    # Engine / RDSDBWriter stubs.
+    engine_sentinel = MagicMock(name="engine")
+    make_engine_calls = {"n": 0}
+
+    def fake_make_engine():
+        make_engine_calls["n"] += 1
+        if engine_raises is not None:
+            raise engine_raises
+        return engine_sentinel
+
+    rds_instances: list[MagicMock] = []
+
+    class _RDSDBWriterStub:
+        def __init__(self, engine, **kwargs):
+            self.engine = engine
+            self.started = 0
+            self.stopped = 0
+            rds_instances.append(self)
+
+        def start(self):
+            self.started += 1
+
+        def stop(self, *args, **kwargs):
+            self.stopped += 1
+
+        def put(self, *a, **k):
+            pass
+
+        def is_alive(self):
+            return True
+
+    monkeypatch.setattr(crawler, "RDSDBWriter", _RDSDBWriterStub)
+    # crawler imports make_app_engine lazily inside run(); patch the
+    # module attribute on lavandula.common.db.
+    import lavandula.common.db as common_db
+    monkeypatch.setattr(common_db, "make_app_engine", fake_make_engine)
+
+    rc = crawler.run([
+        "--archive", str(tmp_path / "archive"),
+        "--skip-tls-self-test",
+        "--skip-encryption-check",
+        "--data-dir", str(tmp_path),
+    ])
+    return rc, make_engine_calls, rds_instances
 
 
-def test_process_org_signature_accepts_rds_queue_kwarg():
-    """AC: process_org accepts `rds_queue` so run() can pass the writer."""
-    import inspect
-    from lavandula.reports.crawler import process_org
-    sig = inspect.signature(process_org)
-    assert "rds_queue" in sig.parameters
-    # Must default to None (optional).
-    assert sig.parameters["rds_queue"].default is None
+def test_flag_off_does_not_construct_rds(monkeypatch, tmp_path):
+    rc, calls, rds = _run_with_stubs(monkeypatch, tmp_path, flag_value=None)
+    assert rc == 0
+    assert calls["n"] == 0, "make_app_engine must NOT be called when flag off"
+    assert rds == [], "RDSDBWriter must NOT be constructed when flag off"
+
+
+@pytest.mark.parametrize("val", ["1", "true", "yes", "on"])
+def test_flag_on_constructs_starts_and_stops_rds(monkeypatch, tmp_path, val):
+    rc, calls, rds = _run_with_stubs(monkeypatch, tmp_path, flag_value=val)
+    assert rc == 0
+    assert calls["n"] == 1, f"make_app_engine must be called exactly once for {val!r}"
+    assert len(rds) == 1
+    assert rds[0].started == 1
+    assert rds[0].stopped == 1
+
+
+def test_flag_on_but_engine_fails_does_not_crash_run(monkeypatch, tmp_path):
+    """If make_app_engine raises at startup, the crawler continues
+    with SQLite only (no RDS writer) and returns 0."""
+    rc, calls, rds = _run_with_stubs(
+        monkeypatch, tmp_path, flag_value="1",
+        engine_raises=RuntimeError("boto creds unavailable"),
+    )
+    assert rc == 0
+    assert calls["n"] == 1
+    # Engine construction raised, so no RDSDBWriter was built.
+    assert rds == []

--- a/lavandula/reports/tests/unit/test_crawler_dual_write_flag_0013p3.py
+++ b/lavandula/reports/tests/unit/test_crawler_dual_write_flag_0013p3.py
@@ -1,0 +1,59 @@
+"""Verify that the LAVANDULA_DUAL_WRITE flag gates all RDS work.
+
+AC1: with the flag unset or zero, the crawler MUST NOT import
+`lavandula.common.db.make_app_engine` nor construct `RDSDBWriter`.
+AC2: with the flag set, it MUST do both.
+
+We test the wiring logic directly rather than spinning up a full
+crawl, by monkey-patching the factories and inspecting call counts.
+"""
+from __future__ import annotations
+
+import os
+from unittest.mock import MagicMock
+
+import pytest
+
+
+def test_flag_off_no_rds_engine_constructed(monkeypatch):
+    """Mirror the crawler's flag logic and assert no RDS import happens."""
+    monkeypatch.delenv("LAVANDULA_DUAL_WRITE", raising=False)
+
+    calls = {"make_app_engine": 0}
+
+    def fake_factory():
+        calls["make_app_engine"] += 1
+        return MagicMock()
+
+    # Replicate crawler.run()'s decision block:
+    flag = os.getenv("LAVANDULA_DUAL_WRITE", "").strip().lower()
+    enabled = flag in ("1", "true", "yes", "on")
+    if enabled:
+        fake_factory()
+
+    assert enabled is False
+    assert calls["make_app_engine"] == 0
+
+
+@pytest.mark.parametrize("val", ["1", "true", "TRUE", "yes", "on"])
+def test_flag_on_variants_enable_rds(monkeypatch, val):
+    monkeypatch.setenv("LAVANDULA_DUAL_WRITE", val)
+    flag = os.getenv("LAVANDULA_DUAL_WRITE", "").strip().lower()
+    assert flag in ("1", "true", "yes", "on")
+
+
+@pytest.mark.parametrize("val", ["0", "false", "no", "", "off"])
+def test_flag_off_variants_keep_rds_disabled(monkeypatch, val):
+    monkeypatch.setenv("LAVANDULA_DUAL_WRITE", val)
+    flag = os.getenv("LAVANDULA_DUAL_WRITE", "").strip().lower()
+    assert flag not in ("1", "true", "yes", "on")
+
+
+def test_process_org_signature_accepts_rds_queue_kwarg():
+    """AC: process_org accepts `rds_queue` so run() can pass the writer."""
+    import inspect
+    from lavandula.reports.crawler import process_org
+    sig = inspect.signature(process_org)
+    assert "rds_queue" in sig.parameters
+    # Must default to None (optional).
+    assert sig.parameters["rds_queue"].default is None

--- a/lavandula/reports/tests/unit/test_db_writer_dual_0013p3.py
+++ b/lavandula/reports/tests/unit/test_db_writer_dual_0013p3.py
@@ -219,10 +219,16 @@ def test_upsert_report_update_path_merges(sqlite_conn):
     _run_ops(rds, pg)
     sql_joined = " \n ".join(pg.all_sql())
     assert "UPDATE lava_impact.reports" in sql_joined
-    # The UPDATE is the second statement on the single cursor.
-    # Its params must include 100 = max(existing 50, new 100).
-    update_stmt = pg.cursors[0].executed[1]
-    assert 100 in update_stmt[1]
+    # Locate the UPDATE statement across all cursors (SAVEPOINT /
+    # SELECT / UPDATE each run on their own cursor context).
+    update_stmts = [
+        (sql, params)
+        for c in pg.cursors for sql, params in c.executed
+        if "UPDATE lava_impact.reports" in sql
+    ]
+    assert update_stmts, "expected an UPDATE statement"
+    # file_size_bytes picks max(existing 50, new 100) = 100.
+    assert 100 in update_stmts[0][1]
 
 
 def test_budget_check_and_reserve_enqueues_preflight(sqlite_conn):

--- a/lavandula/reports/tests/unit/test_db_writer_dual_0013p3.py
+++ b/lavandula/reports/tests/unit/test_db_writer_dual_0013p3.py
@@ -1,0 +1,315 @@
+"""Tests that each db_writer function enqueues a parallel RDS closure
+when `rds_writer` is provided (Spec 0013 Phase 3).
+
+These tests mock the RDS writer as a recording stub and then run each
+submitted closure against a fake psycopg2-like connection to assert
+that the generated SQL uses %s placeholders, schema-qualifies tables
+with `lava_impact.<table>`, omits `id` for auto-id tables, and uses
+the expected ON CONFLICT clauses.
+"""
+from __future__ import annotations
+
+import re
+import sqlite3
+
+import pytest
+
+from lavandula.reports import db_writer, budget
+
+
+# -------------------------------------------------------------------- helpers
+
+
+class _RecordedCursor:
+    def __init__(self, fetchone_result=None):
+        self.executed: list[tuple[str, tuple]] = []
+        self._fetchone_result = fetchone_result
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def execute(self, sql, params=()):
+        self.executed.append((sql, tuple(params) if params else ()))
+
+    def fetchone(self):
+        return self._fetchone_result
+
+
+class _RecordedPgConn:
+    def __init__(self, fetchone_result=None):
+        self.cursors: list[_RecordedCursor] = []
+        self._fetchone_result = fetchone_result
+
+    def cursor(self):
+        c = _RecordedCursor(self._fetchone_result)
+        self.cursors.append(c)
+        return c
+
+    def all_sql(self) -> list[str]:
+        return [sql for c in self.cursors for sql, _ in c.executed]
+
+    def all_params(self) -> list[tuple]:
+        return [p for c in self.cursors for _, p in c.executed]
+
+
+class _RecordingRdsWriter:
+    def __init__(self):
+        self.ops = []
+
+    def put(self, op):
+        self.ops.append(op)
+
+
+def _run_ops(rds, pg_conn):
+    for op in rds.ops:
+        op(pg_conn)
+
+
+# -------------------------------------------------------------------- fixtures
+
+
+@pytest.fixture
+def sqlite_conn(tmp_path):
+    # Use the real schema module to bootstrap an empty reports.db; for
+    # tests where we only care about the RDS side, we route SQLite to a
+    # minimal local schema.
+    from lavandula.reports import schema
+    path = tmp_path / "reports.db"
+    conn = schema.ensure_db(path)
+    yield conn
+    conn.close()
+
+
+# -------------------------------------------------------------------- tests
+
+
+def test_record_fetch_enqueues_postgres_closure(sqlite_conn):
+    rds = _RecordingRdsWriter()
+    db_writer.record_fetch(
+        sqlite_conn,
+        ein="12-3456789",
+        url_redacted="example.com/robots.txt",
+        kind="robots",
+        fetch_status="ok",
+        status_code=200,
+        elapsed_ms=42,
+        notes="n",
+        rds_writer=rds,
+    )
+    assert len(rds.ops) == 1
+    pg = _RecordedPgConn()
+    _run_ops(rds, pg)
+    sql = pg.all_sql()[0]
+    assert "INSERT INTO lava_impact.fetch_log" in sql
+    # Uses %s placeholders, not ?
+    assert "%s" in sql
+    assert "?" not in sql
+    # Auto-id: no `id` column in the INSERT.
+    assert re.search(r"\bid\b", sql.split("VALUES")[0]) is None
+    params = pg.all_params()[0]
+    assert params[0] == "12-3456789"
+    assert params[2] == "robots"
+    assert params[4] == 200
+
+
+def test_upsert_crawled_org_enqueues_postgres_closure(sqlite_conn):
+    rds = _RecordingRdsWriter()
+    db_writer.upsert_crawled_org(
+        sqlite_conn,
+        ein="99-0000001",
+        candidate_count=2,
+        fetched_count=1,
+        confirmed_report_count=0,
+        rds_writer=rds,
+    )
+    assert len(rds.ops) == 1
+    pg = _RecordedPgConn()
+    _run_ops(rds, pg)
+    sql = pg.all_sql()[0]
+    assert "INSERT INTO lava_impact.crawled_orgs" in sql
+    assert "ON CONFLICT (ein) DO UPDATE" in sql
+    # confirmed_report_count intentionally NOT in the DO UPDATE clause
+    assert "confirmed_report_count = EXCLUDED.confirmed_report_count" not in sql
+
+
+def test_record_deletion_omits_id_and_uses_schema(sqlite_conn):
+    rds = _RecordingRdsWriter()
+    db_writer.record_deletion(
+        sqlite_conn,
+        content_sha256="a" * 64,
+        reason="test",
+        operator="builder",
+        pdf_unlinked=1,
+        rds_writer=rds,
+    )
+    assert len(rds.ops) == 1
+    pg = _RecordedPgConn()
+    _run_ops(rds, pg)
+    sql = pg.all_sql()[0]
+    assert "INSERT INTO lava_impact.deletion_log" in sql
+    # No `id` in col list (auto-id table)
+    assert re.search(r"\bid\b", sql.split("VALUES")[0]) is None
+
+
+def _call_upsert_report(sqlite_conn, rds_writer):
+    db_writer.upsert_report(
+        sqlite_conn,
+        content_sha256="b" * 64,
+        source_url_redacted="https://ex.org/doc.pdf",
+        referring_page_url_redacted="https://ex.org/",
+        redirect_chain_redacted=None,
+        source_org_ein="12-3456789",
+        discovered_via="homepage-link",
+        hosting_platform="own-domain",
+        attribution_confidence="own_domain",
+        file_size_bytes=100,
+        page_count=5,
+        first_page_text="hello",
+        pdf_creator=None,
+        pdf_producer=None,
+        pdf_creation_date=None,
+        pdf_has_javascript=0,
+        pdf_has_launch=0,
+        pdf_has_embedded=0,
+        pdf_has_uri_actions=0,
+        classification=None,
+        classification_confidence=None,
+        classifier_model="m",
+        classifier_version=1,
+        report_year=2024,
+        report_year_source="filename",
+        extractor_version=1,
+        rds_writer=rds_writer,
+    )
+
+
+def test_upsert_report_insert_path_targets_schema(sqlite_conn):
+    rds = _RecordingRdsWriter()
+    _call_upsert_report(sqlite_conn, rds)
+    assert len(rds.ops) == 1
+    # Simulate an empty RDS table: fetchone returns None → INSERT path.
+    pg = _RecordedPgConn(fetchone_result=None)
+    _run_ops(rds, pg)
+    sql_joined = " \n ".join(pg.all_sql())
+    assert "FROM lava_impact.reports" in sql_joined  # the SELECT
+    assert "INSERT INTO lava_impact.reports" in sql_joined
+    # Uses %s placeholders
+    assert "%s" in sql_joined
+    assert "?" not in sql_joined
+
+
+def test_upsert_report_update_path_merges(sqlite_conn):
+    rds = _RecordingRdsWriter()
+    _call_upsert_report(sqlite_conn, rds)
+    # Fake an existing row (25-column SELECT shape matches the module's
+    # SELECT list). All fields null-ish except attribution_confidence
+    # set to lower rank so the merge prefers the new source.
+    existing = (
+        "old_url", None, None, "00-0000000", "old",
+        None, "platform_unverified", 50, None, None, None, None, None,
+        0, 0, 0, 0, None, None, "m0", 0, None, None, None, 0,
+    )
+    pg = _RecordedPgConn(fetchone_result=existing)
+    _run_ops(rds, pg)
+    sql_joined = " \n ".join(pg.all_sql())
+    assert "UPDATE lava_impact.reports" in sql_joined
+    # The UPDATE is the second statement on the single cursor.
+    # Its params must include 100 = max(existing 50, new 100).
+    update_stmt = pg.cursors[0].executed[1]
+    assert 100 in update_stmt[1]
+
+
+def test_budget_check_and_reserve_enqueues_preflight(sqlite_conn):
+    rds = _RecordingRdsWriter()
+    from lavandula.reports import config
+    reservation_id = budget.check_and_reserve(
+        sqlite_conn,
+        estimated_cents=10,
+        classifier_model="m",
+        rds_writer=rds,
+    )
+    assert isinstance(reservation_id, int)
+    assert len(rds.ops) == 1
+    pg = _RecordedPgConn()
+    _run_ops(rds, pg)
+    sql = pg.all_sql()[0]
+    assert "INSERT INTO lava_impact.budget_ledger" in sql
+    assert "'preflight'" in sql
+    # Correlation: the notes field encodes the SQLite reservation_id.
+    params = pg.all_params()[0]
+    assert any(f"reserved:{reservation_id}" == p for p in params)
+
+
+def test_budget_settle_enqueues_update(sqlite_conn):
+    rds = _RecordingRdsWriter()
+    reservation_id = budget.check_and_reserve(
+        sqlite_conn, estimated_cents=5, classifier_model="m",
+        rds_writer=rds,
+    )
+    # Drop the reserve op; we only care about settle's op here.
+    rds.ops.clear()
+
+    budget.settle(
+        sqlite_conn,
+        reservation_id=reservation_id,
+        actual_input_tokens=100,
+        actual_output_tokens=50,
+        sha256_classified="c" * 64,
+        rds_writer=rds,
+    )
+    assert len(rds.ops) == 1
+    pg = _RecordedPgConn()
+    _run_ops(rds, pg)
+    sql = pg.all_sql()[0]
+    assert "UPDATE lava_impact.budget_ledger" in sql
+    assert "notes = 'settled'" in sql
+    # WHERE clause matches the correlation key we stored on reserve.
+    params = pg.all_params()[0]
+    assert f"reserved:{reservation_id}" in params
+
+
+def test_budget_release_enqueues_delete(sqlite_conn):
+    rds = _RecordingRdsWriter()
+    reservation_id = budget.check_and_reserve(
+        sqlite_conn, estimated_cents=5, classifier_model="m",
+        rds_writer=rds,
+    )
+    rds.ops.clear()
+
+    budget.release(sqlite_conn, reservation_id=reservation_id, rds_writer=rds)
+    assert len(rds.ops) == 1
+    pg = _RecordedPgConn()
+    _run_ops(rds, pg)
+    sql = pg.all_sql()[0]
+    assert "DELETE FROM lava_impact.budget_ledger" in sql
+
+
+# -------------------------------------------------------------- byte-identity
+
+
+def test_no_rds_writer_means_no_rds_work(sqlite_conn):
+    """Without rds_writer kwarg, behavior must be byte-identical
+    to pre-0013: no RDS closures enqueued (obviously) and no import
+    of lavandula.common.db triggered."""
+    # A simple smoke: each call should succeed with rds_writer=None and
+    # not touch the RDS world.
+    db_writer.record_fetch(
+        sqlite_conn,
+        ein="12-3456789",
+        url_redacted="u",
+        kind="robots",
+        fetch_status="ok",
+    )
+    db_writer.record_deletion(
+        sqlite_conn,
+        content_sha256="a" * 64,
+        reason=None, operator=None, pdf_unlinked=0,
+    )
+    db_writer.upsert_crawled_org(
+        sqlite_conn, ein="99-0000001",
+        candidate_count=1, fetched_count=0, confirmed_report_count=0,
+    )
+    # If we reach here without import errors on boto3/psycopg2, pass.

--- a/lavandula/reports/tests/unit/test_db_writer_dual_0013p3.py
+++ b/lavandula/reports/tests/unit/test_db_writer_dual_0013p3.py
@@ -131,8 +131,11 @@ def test_upsert_crawled_org_enqueues_postgres_closure(sqlite_conn):
     sql = pg.all_sql()[0]
     assert "INSERT INTO lava_impact.crawled_orgs" in sql
     assert "ON CONFLICT (ein) DO UPDATE" in sql
-    # confirmed_report_count intentionally NOT in the DO UPDATE clause
-    assert "confirmed_report_count = EXCLUDED.confirmed_report_count" not in sql
+    # SQLite-parity: crawler passes 0 on re-crawl; GREATEST prevents the
+    # classify_null-backfilled count from being overwritten by 0. Raw
+    # EXCLUDED assignment would cause drift.
+    assert "GREATEST" in sql
+    assert "confirmed_report_count = GREATEST" in sql
 
 
 def test_record_deletion_omits_id_and_uses_schema(sqlite_conn):

--- a/lavandula/reports/tests/unit/test_rds_db_writer_0013p3.py
+++ b/lavandula/reports/tests/unit/test_rds_db_writer_0013p3.py
@@ -1,0 +1,190 @@
+"""Tests for `lavandula.reports.rds_db_writer.RDSDBWriter` (Spec 0013 P3).
+
+Verifies best-effort failure semantics:
+  - queue saturation drops ops with WARN, never raises
+  - writer thread death drops subsequent ops with WARN
+  - per-op exceptions rollback but the writer keeps going
+  - stop() is non-raising and drains with a timeout
+"""
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from unittest.mock import MagicMock
+
+import pytest
+
+from lavandula.reports.rds_db_writer import RDSDBWriter
+
+
+class _FakePgConn:
+    def __init__(self, *, raise_on_cursor: Exception | None = None,
+                 raise_on_commit: Exception | None = None):
+        self.commits = 0
+        self.rollbacks = 0
+        self.closed = False
+        self._raise_on_cursor = raise_on_cursor
+        self._raise_on_commit = raise_on_commit
+        self.cursor_calls = []
+
+    def cursor(self):
+        if self._raise_on_cursor:
+            raise self._raise_on_cursor
+        cur = MagicMock()
+        cur.__enter__ = MagicMock(return_value=cur)
+        cur.__exit__ = MagicMock(return_value=False)
+        self.cursor_calls.append(cur)
+        return cur
+
+    def commit(self):
+        if self._raise_on_commit:
+            raise self._raise_on_commit
+        self.commits += 1
+
+    def rollback(self):
+        self.rollbacks += 1
+
+    def close(self):
+        self.closed = True
+
+
+class _FakeEngine:
+    def __init__(self, conn_factory):
+        self._conn_factory = conn_factory
+        self.calls = 0
+
+    def raw_connection(self):
+        self.calls += 1
+        return self._conn_factory()
+
+
+def _make_writer(engine, **kw):
+    w = RDSDBWriter(engine, **kw)
+    w.start()
+    return w
+
+
+def test_put_runs_closure_and_commits():
+    """Happy path: put(op) executes op(conn) and commits."""
+    conn = _FakePgConn()
+    engine = _FakeEngine(lambda: conn)
+    w = _make_writer(engine)
+    ran = threading.Event()
+
+    def op(c):
+        assert c is conn
+        ran.set()
+
+    w.put(op)
+    assert ran.wait(timeout=2.0)
+    w.stop(timeout=2.0)
+    assert conn.commits == 1
+    assert conn.closed is True
+
+
+def test_op_exception_logs_warning_and_rolls_back(caplog):
+    """An op that raises triggers rollback, WARN log, and writer keeps going."""
+    conn_a = _FakePgConn()
+    conn_b = _FakePgConn()
+    conns = iter([conn_a, conn_b])
+    engine = _FakeEngine(lambda: next(conns))
+    w = _make_writer(engine)
+
+    done = threading.Event()
+
+    def bad(_c):
+        raise RuntimeError("boom")
+
+    def good(_c):
+        done.set()
+
+    with caplog.at_level(logging.WARNING, logger="lavandula.reports.rds_db_writer"):
+        w.put(bad)
+        w.put(good)
+        assert done.wait(timeout=2.0)
+        w.stop(timeout=2.0)
+
+    assert conn_a.rollbacks == 1
+    assert conn_a.commits == 0
+    assert conn_b.commits == 1
+    assert any("op failed" in r.message for r in caplog.records)
+    assert w.failed_count == 1
+
+
+def test_put_on_full_queue_drops_with_warning(caplog):
+    """When the queue is full for `timeout`, put() drops and warns."""
+    # Use a tiny queue + a closure that blocks to force saturation.
+    conn = _FakePgConn()
+    engine = _FakeEngine(lambda: conn)
+    w = RDSDBWriter(engine, maxsize=1)
+    block = threading.Event()
+
+    def slow(_c):
+        block.wait(timeout=5.0)
+
+    w.start()
+    try:
+        w.put(slow)            # worker picks this up, blocks on `block`
+        # Give worker time to pull it off the queue before filling:
+        time.sleep(0.05)
+        w.put(slow)            # fills the 1-slot queue
+        with caplog.at_level(
+            logging.WARNING, logger="lavandula.reports.rds_db_writer"
+        ):
+            # This should drop, not raise.
+            w.put(slow, timeout=0.2)
+        assert w.dropped_count >= 1
+        assert any("saturated" in r.message for r in caplog.records)
+    finally:
+        block.set()
+        w.stop(timeout=2.0)
+
+
+def test_put_when_thread_dead_drops_with_warning(caplog, monkeypatch):
+    """If the worker thread is not alive, put() logs a drop and returns."""
+    conn = _FakePgConn()
+    engine = _FakeEngine(lambda: conn)
+    w = RDSDBWriter(engine)
+    w.start()
+    # Force the thread to exit by signalling stop.
+    w._stop.set()
+    w._thread.join(timeout=2.0)
+    assert not w.is_alive()
+
+    with caplog.at_level(logging.WARNING, logger="lavandula.reports.rds_db_writer"):
+        w.put(lambda _c: None)
+    assert w.dropped_count == 1
+    assert any("not alive" in r.message for r in caplog.records)
+
+
+def test_raw_connection_failure_logs_and_drops(caplog):
+    """engine.raw_connection() raising is logged and the op is dropped."""
+    def bad_factory():
+        raise RuntimeError("no db")
+
+    class _E:
+        def raw_connection(self):
+            return bad_factory()
+
+    w = _make_writer(_E())
+    done = threading.Event()
+
+    with caplog.at_level(logging.WARNING, logger="lavandula.reports.rds_db_writer"):
+        w.put(lambda _c: done.set())
+        # Give worker time to attempt raw_connection and fail.
+        time.sleep(0.3)
+        w.stop(timeout=2.0)
+    assert any("raw_connection()" in r.message for r in caplog.records)
+    assert w.failed_count == 1
+    # Op was not actually executed since connection failed.
+    assert not done.is_set()
+
+
+def test_stop_is_idempotent_and_non_raising():
+    conn = _FakePgConn()
+    engine = _FakeEngine(lambda: conn)
+    w = _make_writer(engine)
+    w.stop(timeout=1.0)
+    # Calling stop again must not raise.
+    w.stop(timeout=0.5)

--- a/lavandula/reports/tests/unit/test_rds_db_writer_0013p3.py
+++ b/lavandula/reports/tests/unit/test_rds_db_writer_0013p3.py
@@ -112,9 +112,13 @@ def test_op_exception_logs_warning_and_rolls_back(caplog):
     assert w.failed_count == 1
 
 
-def test_put_on_full_queue_drops_with_warning(caplog):
-    """When the queue is full for `timeout`, put() drops and warns."""
-    # Use a tiny queue + a closure that blocks to force saturation.
+def test_put_on_full_queue_drops_immediately(caplog):
+    """When the queue is full, put() drops immediately — NO blocking.
+
+    This is the Phase 3 contract: `put` is non-blocking because it
+    runs on the crawler hot path; any wait would propagate RDS
+    latency into SQLite-authoritative writes.
+    """
     conn = _FakePgConn()
     engine = _FakeEngine(lambda: conn)
     w = RDSDBWriter(engine, maxsize=1)
@@ -126,16 +130,44 @@ def test_put_on_full_queue_drops_with_warning(caplog):
     w.start()
     try:
         w.put(slow)            # worker picks this up, blocks on `block`
-        # Give worker time to pull it off the queue before filling:
-        time.sleep(0.05)
-        w.put(slow)            # fills the 1-slot queue
+        time.sleep(0.05)        # let worker drain the queue
+        w.put(slow)             # fills the 1-slot queue
         with caplog.at_level(
             logging.WARNING, logger="lavandula.reports.rds_db_writer"
         ):
-            # This should drop, not raise.
-            w.put(slow, timeout=0.2)
+            start = time.monotonic()
+            w.put(slow)         # must return immediately, not block
+            elapsed = time.monotonic() - start
+        # Non-blocking contract: < 100ms even on a loaded CI box.
+        assert elapsed < 0.1, f"put() blocked for {elapsed:.3f}s"
         assert w.dropped_count >= 1
-        assert any("saturated" in r.message for r in caplog.records)
+        assert any("queue full" in r.message for r in caplog.records)
+    finally:
+        block.set()
+        w.stop(timeout=2.0)
+
+
+def test_put_is_non_blocking_under_sustained_saturation():
+    """Flood a saturated writer and assert every put returns fast."""
+    conn = _FakePgConn()
+    engine = _FakeEngine(lambda: conn)
+    w = RDSDBWriter(engine, maxsize=1)
+    block = threading.Event()
+
+    def slow(_c):
+        block.wait(timeout=5.0)
+
+    w.start()
+    try:
+        w.put(slow)          # worker picks this up
+        time.sleep(0.05)
+        w.put(slow)          # fills queue
+        for _ in range(50):
+            t0 = time.monotonic()
+            w.put(lambda _c: None)
+            # Each call must be non-blocking regardless of queue state.
+            assert time.monotonic() - t0 < 0.05
+        assert w.dropped_count >= 50
     finally:
         block.set()
         w.stop(timeout=2.0)

--- a/lavandula/reports/tests/unit/test_upsert_report_race_0013p3.py
+++ b/lavandula/reports/tests/unit/test_upsert_report_race_0013p3.py
@@ -1,0 +1,224 @@
+"""Races two `_upsert_report_pg_inner` calls against the same
+content_sha256 using an in-memory fake Postgres (Spec 0013 P3).
+
+Codex round-3 finding: the crawler and classify_null each run
+independent `RDSDBWriter`s, so both can SELECT (miss), INSERT, and
+hit a UniqueViolation on `content_sha256`. The retry loop must
+recover by re-running the read-merge path and landing in UPDATE.
+"""
+from __future__ import annotations
+
+import threading
+
+import pytest
+
+from lavandula.reports import db_writer
+
+
+class _FakeUniqueViolation(Exception):
+    """Duck-typed psycopg2.errors.UniqueViolation (SQLSTATE 23505)."""
+    pgcode = "23505"
+
+
+class _FakePgState:
+    """Shared Postgres-side state guarded by a lock. Simulates:
+      - SELECT ... WHERE content_sha256 = %s  → fetchone / None
+      - INSERT INTO ... (content_sha256, …)   → unique violation if exists
+      - UPDATE ... WHERE content_sha256 = %s  → update in place
+      - SAVEPOINT / RELEASE / ROLLBACK        → no-ops (single-txn fake)
+    """
+    def __init__(self):
+        self.rows: dict[str, list] = {}  # sha -> 25-tuple (existing shape)
+        self.lock = threading.Lock()
+        self.insert_attempts = 0
+        self.update_attempts = 0
+
+
+class _FakeCursor:
+    def __init__(self, state: _FakePgState, *, stall_before_insert: threading.Event | None = None):
+        self._state = state
+        self._fetched: list | None = None
+        self._stall = stall_before_insert
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+    def execute(self, sql, params=()):
+        s = " ".join(sql.split())
+        if s.startswith("SAVEPOINT") or s.startswith("RELEASE") or s.startswith("ROLLBACK"):
+            return
+        if s.startswith("SELECT source_url_redacted"):
+            sha = params[0]
+            with self._state.lock:
+                self._fetched = list(self._state.rows.get(sha, []))
+                if not self._fetched:
+                    self._fetched = None
+            return
+        if s.startswith("INSERT INTO lava_impact.reports"):
+            if self._stall is not None:
+                # Let the racing thread overtake before we commit.
+                self._stall.wait(timeout=2.0)
+            sha = params[0]
+            with self._state.lock:
+                self._state.insert_attempts += 1
+                if sha in self._state.rows:
+                    raise _FakeUniqueViolation("dup key: content_sha256")
+                # Store the 25-col projection the SELECT path reads back.
+                # Columns we mirror: source_url_redacted, referring,
+                # chain_json, ein, discovered, platform, attr, size,
+                # page_count, first_page_text, creator, producer,
+                # creation_date, js, launch, embedded, uri,
+                # classification, confidence, model, version,
+                # classified_at, report_year, report_year_source,
+                # extractor_version.
+                self._state.rows[sha] = [
+                    params[1], params[2], params[3], params[4], params[5],
+                    params[6], params[7], params[10], params[11], params[12],
+                    params[13], params[14], params[15], params[16], params[17],
+                    params[18], params[19], params[20], params[21], params[22],
+                    params[23], params[24], params[25], params[26], params[27],
+                ]
+            return
+        if s.startswith("UPDATE lava_impact.reports"):
+            with self._state.lock:
+                self._state.update_attempts += 1
+                sha = params[-1]
+                # Just record the update; we don't need to fully
+                # reapply all columns for the race assertion.
+                if sha in self._state.rows:
+                    pass
+            return
+        raise AssertionError(f"unexpected SQL: {s[:80]}")
+
+    def fetchone(self):
+        if self._fetched is None:
+            return None
+        return tuple(self._fetched)
+
+
+class _FakePgConn:
+    def __init__(self, state, *, stall_before_insert=None):
+        self._state = state
+        self._stall = stall_before_insert
+
+    def cursor(self):
+        return _FakeCursor(self._state, stall_before_insert=self._stall)
+
+
+def _call_upsert(pg_conn, sha: str, *, attribution="own_domain", size=100):
+    db_writer._upsert_report_pg_inner(
+        pg_conn,
+        content_sha256=sha,
+        source_url_redacted="https://ex.org/doc.pdf",
+        referring_page_url_redacted=None,
+        chain_json=None,
+        source_org_ein="12-3456789",
+        discovered_via="homepage-link",
+        hosting_platform="own-domain",
+        attribution_confidence=attribution,
+        archived_at="2026-04-22T00:00:00+00:00",
+        content_type="application/pdf",
+        file_size_bytes=size,
+        page_count=5,
+        first_page_text="hello",
+        pdf_creator=None,
+        pdf_producer=None,
+        pdf_creation_date=None,
+        pdf_has_javascript=0,
+        pdf_has_launch=0,
+        pdf_has_embedded=0,
+        pdf_has_uri_actions=0,
+        classification=None,
+        classification_confidence=None,
+        classifier_model="m",
+        classifier_version=1,
+        classified_at=None,
+        report_year=2024,
+        report_year_source="filename",
+        extractor_version=1,
+    )
+
+
+def test_concurrent_insert_race_recovers_via_update():
+    """Two threads upsert the same sha concurrently. The loser of the
+    INSERT race gets UniqueViolation, the retry loop re-SELECTs, and
+    the second attempt lands in UPDATE — no exception propagates out."""
+    state = _FakePgState()
+    gate = threading.Event()
+
+    # First writer stalls inside its INSERT so the second writer can
+    # slip in its own SELECT-miss → INSERT-success.
+    conn_a = _FakePgConn(state, stall_before_insert=gate)
+    conn_b = _FakePgConn(state)
+
+    errs: list[BaseException] = []
+
+    def run_a():
+        try:
+            _call_upsert(conn_a, "a" * 64)
+        except BaseException as exc:  # noqa: BLE001
+            errs.append(exc)
+
+    def run_b():
+        # Let the second caller race past the first.
+        try:
+            _call_upsert(conn_b, "a" * 64)
+        except BaseException as exc:  # noqa: BLE001
+            errs.append(exc)
+        finally:
+            # Release A so its stalled INSERT proceeds (and hits the
+            # unique violation, triggering the retry loop).
+            gate.set()
+
+    t_a = threading.Thread(target=run_a)
+    t_b = threading.Thread(target=run_b)
+    t_a.start()
+    # Ensure A is parked inside the stalling INSERT before B starts.
+    import time; time.sleep(0.05)
+    t_b.start()
+    t_a.join(timeout=5.0)
+    t_b.join(timeout=5.0)
+
+    assert errs == [], f"unexpected exceptions: {errs}"
+    # Exactly one row survived.
+    assert len(state.rows) == 1
+    # B inserted; A retried and landed in UPDATE (or vice versa).
+    assert state.insert_attempts >= 2
+    assert state.update_attempts >= 1
+
+
+def test_retry_loop_bounded_by_max_attempts():
+    """If the racing writer keeps re-inserting between our SELECT and
+    INSERT, the retry loop must give up instead of looping forever."""
+    state = _FakePgState()
+
+    class _AlwaysMissingSelectCursor(_FakeCursor):
+        """A cursor whose SELECT always reports 'no row' — this pushes
+        _upsert_report_pg_inner down the INSERT branch every attempt,
+        and the INSERT then always raises UniqueViolation because we
+        pre-seed the row."""
+        def execute(self, sql, params=()):
+            s = " ".join(sql.split())
+            if s.startswith("SELECT source_url_redacted"):
+                self._fetched = None  # always miss
+                return
+            super().execute(sql, params)
+
+    class _PathologicalConn:
+        def __init__(self, state_):
+            self._state = state_
+
+        def cursor(self):
+            return _AlwaysMissingSelectCursor(self._state)
+
+    state.rows["a" * 64] = [None] * 25  # pre-existing row to force dup
+    conn = _PathologicalConn(state)
+
+    with pytest.raises(_FakeUniqueViolation):
+        _call_upsert(conn, "a" * 64)
+
+    # Retry bound: attempted 2x insert, gave up on the second dup.
+    assert state.insert_attempts == db_writer._UPSERT_REPORT_MAX_ATTEMPTS

--- a/lavandula/reports/tools/classify_null.py
+++ b/lavandula/reports/tools/classify_null.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import argparse
 import datetime as dt
+import os
 import signal
 import sqlite3
 import subprocess
@@ -37,6 +38,7 @@ from lavandula.reports.classify import (
     classify_first_page,
     estimate_cents,
 )
+from lavandula.reports.rds_db_writer import RDSDBWriter
 
 
 class _BudgetHalt(SystemExit):
@@ -148,7 +150,7 @@ def _get_thread_classifier():
 
 
 def _classify_one(sha: str, text: str, *, conn=None, db_lock=None,
-                  budget_enabled=False, halt_event=None):
+                  budget_enabled=False, halt_event=None, rds_writer=None):
     """Worker-side classify call. Returns (sha, result_or_exc_tuple).
 
     When `budget_enabled`, wraps the classifier call with
@@ -169,6 +171,7 @@ def _classify_one(sha: str, text: str, *, conn=None, db_lock=None,
                     conn,
                     estimated_cents=est,
                     classifier_model=config.CLASSIFIER_MODEL,
+                    rds_writer=rds_writer,
                 )
         except budget.BudgetExceeded as exc:
             if halt_event is not None:
@@ -182,15 +185,15 @@ def _classify_one(sha: str, text: str, *, conn=None, db_lock=None,
             text, client=client, raise_on_error=False
         )
     except ClassifierError as exc:
-        _release_reservation(conn, db_lock, reservation_id)
+        _release_reservation(conn, db_lock, reservation_id, rds_writer)
         return sha, ("schema_error", exc)
     except Exception as exc:  # noqa: BLE001
-        _release_reservation(conn, db_lock, reservation_id)
+        _release_reservation(conn, db_lock, reservation_id, rds_writer)
         return sha, ("unexpected", exc)
 
     if budget_enabled and reservation_id is not None:
         if result.classification is None:
-            _release_reservation(conn, db_lock, reservation_id)
+            _release_reservation(conn, db_lock, reservation_id, rds_writer)
         else:
             try:
                 with db_lock:
@@ -200,20 +203,22 @@ def _classify_one(sha: str, text: str, *, conn=None, db_lock=None,
                         actual_input_tokens=getattr(result, "input_tokens", 0) or 0,
                         actual_output_tokens=getattr(result, "output_tokens", 0) or 0,
                         sha256_classified=sha,
+                        rds_writer=rds_writer,
                     )
             except Exception:  # noqa: BLE001
-                _release_reservation(conn, db_lock, reservation_id)
+                _release_reservation(conn, db_lock, reservation_id, rds_writer)
                 raise
 
     return sha, ("ok", result)
 
 
-def _release_reservation(conn, db_lock, reservation_id) -> None:
+def _release_reservation(conn, db_lock, reservation_id, rds_writer=None) -> None:
     if reservation_id is None or db_lock is None:
         return
     try:
         with db_lock:
-            budget.release(conn, reservation_id=reservation_id)
+            budget.release(conn, reservation_id=reservation_id,
+                           rds_writer=rds_writer)
     except Exception:  # noqa: BLE001,S110  # nosec B110 — best-effort rollback
         pass
 
@@ -322,6 +327,26 @@ def main() -> int:
     halt_event = threading.Event()
     halt_message = {"text": ""}
 
+    # Spec 0013 Phase 3: opt-in dual-write to RDS. When the flag is
+    # off, NO RDS engine is constructed (byte-identical pre-0013).
+    rds_writer: RDSDBWriter | None = None
+    dual_write_flag = os.getenv("LAVANDULA_DUAL_WRITE", "").strip().lower()
+    if dual_write_flag in ("1", "true", "yes", "on"):
+        try:
+            from lavandula.common.db import make_app_engine
+            engine = make_app_engine()
+            rds_writer = RDSDBWriter(engine)
+            rds_writer.start()
+            print("LAVANDULA_DUAL_WRITE on: RDS writer started",
+                  file=sys.stderr)
+        except Exception as exc:  # noqa: BLE001
+            print(
+                f"LAVANDULA_DUAL_WRITE on but RDS setup failed "
+                f"({type(exc).__name__}); continuing with SQLite only",
+                file=sys.stderr,
+            )
+            rds_writer = None
+
     # fetch_log may or may not exist on the DB (full reports.db vs. a
     # test fixture). Probe once so per-row calls don't keep erroring.
     fetch_log_enabled = True
@@ -347,6 +372,7 @@ def main() -> int:
                     kind="classify",
                     fetch_status=fetch_status,
                     notes=notes or None,
+                    rds_writer=rds_writer,
                 )
                 conn.commit()
         except sqlite3.OperationalError:
@@ -397,6 +423,7 @@ def main() -> int:
                 db_lock=db_lock,
                 budget_enabled=budget_enabled,
                 halt_event=halt_event,
+                rds_writer=rds_writer,
             ): i
             for i, row in enumerate(rows, 1)
         }
@@ -516,6 +543,12 @@ def main() -> int:
         print(f"  {cls:<14} {classification_counts[cls]}")
 
     conn.close()
+    if rds_writer is not None:
+        try:
+            rds_writer.stop()
+        except Exception as exc:  # noqa: BLE001
+            print(f"rds writer stop raised ({type(exc).__name__}); ignoring",
+                  file=sys.stderr)
     if halt_event.is_set():
         print(f"\nHALT: classifier budget cap exceeded — {halt_message['text']}",
               file=sys.stderr)

--- a/locard/plans/0013-phase3-dual-write.md
+++ b/locard/plans/0013-phase3-dual-write.md
@@ -1,0 +1,282 @@
+# Plan 0013 Phase 3 — SQLite/RDS Dual-Write Wrapper
+
+**Spec**: `locard/specs/0013-rds-postgres-migration.md` Phase 3  
+**Depends on**: Phase 1 (IAM adapter, merged) + Phase 2 (backfill tool, merged)  
+**Date**: 2026-04-22
+
+---
+
+## Scope
+
+Enable the crawler to write every `reports` / `fetch_log` /
+`crawled_orgs` / `budget_ledger` / `deletion_log` update to BOTH
+SQLite (unchanged) AND RDS (new). SQLite stays authoritative;
+RDS is best-effort during stabilization.
+
+Feature flag: `LAVANDULA_DUAL_WRITE` (default off). When off,
+behavior is byte-identical to pre-0013.
+
+Phase 4 (read flip) is NOT in this PR.
+
+---
+
+## Non-goals
+
+- Changing crawler CLI / argv — the feature flag is purely env-var
+- Unifying SQLite + Postgres via a single SQLAlchemy dialect layer —
+  deferred to Phase 5+ retire
+- Modifying the seed-enumerate or resolver write paths — out of scope
+  (those touch `nonprofits_seed` / `runs`, backfill handles them for
+  now; crawl hot-path dual-write is the near-term need)
+- `lavandula.nonprofits.*` hot-path changes — scope is crawler only
+
+---
+
+## Architecture
+
+### The wrapper principle
+
+Each existing `db_writer` function already accepts an optional
+`db_writer` kwarg (the TICK-002 SQLite queue). This PR adds a
+parallel optional `rds_writer` kwarg. When BOTH are provided, each
+function submits TWO parallel closures — one SQLite-flavored, one
+Postgres-flavored — to separate queues.
+
+```python
+def upsert_report(conn, *, db_writer=None, rds_writer=None, ...):
+    def _do_sqlite(target_conn):
+        # existing logic unchanged
+        ...
+    def _do_rds(pg_conn):
+        # parallel Postgres logic with Postgres-flavored SQL
+        ...
+    # Dispatch to SQLite (mandatory) and RDS (optional, best-effort)
+    if db_writer is not None:
+        db_writer.put(_do_sqlite)
+    else:
+        _do_sqlite(conn); conn.commit()
+    if rds_writer is not None:
+        rds_writer.put(_do_rds)
+```
+
+### RDS writer — new class
+
+`lavandula/reports/rds_db_writer.py`:
+
+```python
+class RDSDBWriter:
+    """Single-thread async writer that mirrors DBWriter's interface,
+    but writes to RDS via SQLAlchemy. Queue is bounded; failures are
+    logged and dropped (RDS is best-effort during Phase 3)."""
+
+    def __init__(self, engine, maxsize: int = 256): ...
+    def start(self) -> None: ...
+    def put(self, op: Callable[[psycopg2_conn], None], timeout: float = 30.0) -> None:
+        """Enqueue a Postgres-flavored write closure. Non-blocking
+        unless queue is full; if queue is saturated, logs a WARNING
+        and drops the op (RDS is best-effort). Never raises."""
+    def stop(self) -> None:
+        """Drain queue with a timeout; log drift if ops remain."""
+    def is_alive(self) -> bool: ...
+```
+
+**Key difference from `DBWriter` (SQLite)**:
+- `DBWriter` raises on failure (SQLite is authoritative)
+- `RDSDBWriter` logs and drops on failure (RDS is best-effort)
+- `RDSDBWriter` uses SQLAlchemy engine connections (via `engine.raw_connection()` for psycopg2-level access, since we're using `execute_values`-style bulk ops in some paths)
+
+### Per-function dual closure
+
+Five db_writer functions grow an `rds_writer` kwarg + parallel
+closure:
+
+1. `record_fetch` — `fetch_log` INSERT
+2. `upsert_crawled_org` — `crawled_orgs` INSERT ... ON CONFLICT DO
+   UPDATE
+3. `upsert_report` — `reports` INSERT ... ON CONFLICT DO UPDATE with
+   attribution-rank logic
+4. `record_deletion` — `deletion_log` INSERT
+5. Budget ledger writes (in `budget.py` — 2 call sites wrapping
+   `INSERT INTO budget_ledger`)
+
+For each, the Postgres closure uses:
+- Placeholders: `%s` (psycopg2 style) instead of `?` (sqlite3 style)
+- Schema qualification: all inserts target `lava_impact.<table>`
+- Conflict clauses: `ON CONFLICT (pk) DO UPDATE SET col = EXCLUDED.col, ...`
+  instead of SQLite's `INSERT OR REPLACE`
+- Auto-id tables (`fetch_log`, `budget_ledger`, `deletion_log`): omit
+  the `id` column entirely, let Postgres assign
+
+### Crawler wiring
+
+`crawler.run()`:
+
+```python
+dual_write_enabled = os.getenv("LAVANDULA_DUAL_WRITE", "").lower() in ("1", "true", "yes")
+rds_writer = None
+if dual_write_enabled:
+    from lavandula.common.db import make_app_engine
+    engine = make_app_engine()
+    rds_writer = RDSDBWriter(engine)
+    rds_writer.start()
+
+# ... existing DBWriter setup ...
+
+try:
+    # ... per-org processing, passing BOTH writers to each db_writer call ...
+finally:
+    if rds_writer is not None:
+        rds_writer.stop()  # drain RDS queue with timeout
+    writer.stop()  # existing SQLite writer
+```
+
+### Failure model
+
+| Scenario | Behavior |
+|----------|---------|
+| RDS reachable, write succeeds | Both backends have the row |
+| RDS write raises (5xx, permission, constraint violation) | WARN log, row skipped on RDS side, SQLite unchanged, crawler continues |
+| RDS unreachable at startup | Startup `make_app_engine()` succeeds (lazy), first PUT fails — treated as scenario above |
+| RDS queue saturated (>256 backlog) | WARN log, op dropped, crawler continues |
+| RDSDBWriter thread dies | WARN log each subsequent PUT ("writer not alive"), ops dropped, crawler continues |
+| IAM token expired mid-run | SQLAlchemy's `pool_pre_ping` + `pool_recycle` from Phase 1 handles this; transparent retry within a single PUT |
+
+Critical property: **no RDS failure mode can fail the SQLite write
+or interrupt the crawler**. The only way RDS failures surface
+operationally is via the `verify_dual_write` tool and the WARN logs.
+
+### Drift detection tool
+
+`lavandula/common/tools/verify_dual_write.py`:
+
+```
+python -m lavandula.common.tools.verify_dual_write \
+  --sqlite PATH/reports.db \
+  [--table TABLE]...
+```
+
+For each table, compares:
+- Row counts
+- MIN/MAX of timestamp columns (catches "RDS is 30 min behind")
+- A sample of PKs present in one backend but not the other
+
+Outputs:
+```
+=== reports ===
+  sqlite count:    180
+  rds count:       178   (drift: -2)
+  missing in rds:  <sha1>, <sha2>
+```
+
+Exit 0 if drift is zero; exit 1 if any drift detected (lets ops
+decide to backfill or investigate).
+
+---
+
+## Deliverables
+
+| Path | Status |
+|------|--------|
+| `lavandula/reports/rds_db_writer.py` | NEW |
+| `lavandula/reports/db_writer.py` | EXTEND — five functions grow `rds_writer` kwarg + parallel closure |
+| `lavandula/reports/budget.py` | EXTEND — two writes get `rds_writer` parallel closure |
+| `lavandula/reports/crawler.py` | EXTEND — feature flag → construct/start/stop RDSDBWriter |
+| `lavandula/common/tools/verify_dual_write.py` | NEW |
+| `lavandula/reports/tests/unit/test_rds_db_writer_0013p3.py` | NEW — writer lifecycle + failure model |
+| `lavandula/reports/tests/unit/test_db_writer_dual_0013p3.py` | NEW — each of 5 functions in dual-write mode |
+| `lavandula/common/tests/unit/test_verify_dual_write_0013p3.py` | NEW |
+
+---
+
+## Acceptance Criteria
+
+**AC1** — `LAVANDULA_DUAL_WRITE=0` (or unset): crawler behavior is
+byte-identical to pre-0013. No RDS connection opened. Verified by
+a test that spies on `make_app_engine` and asserts zero calls.
+
+**AC2** — `LAVANDULA_DUAL_WRITE=1`: crawler opens an RDS engine at
+startup via `make_app_engine()` and constructs an `RDSDBWriter`.
+
+**AC3** — Each of the 5 db_writer functions, when called with both
+`db_writer` and `rds_writer`, submits a parallel Postgres-flavored
+closure to the RDS queue.
+
+**AC4** — RDS write failure (simulated) is logged as WARN, does NOT
+raise, does NOT affect the SQLite write path.
+
+**AC5** — `RDSDBWriter.put()` never blocks the caller beyond a
+30-second queue-put timeout. On queue saturation, the op is dropped
+with WARN.
+
+**AC6** — `RDSDBWriter.stop()` drains the queue with a configurable
+timeout (default 30s), logs drift if ops remain.
+
+**AC7** — `RDSDBWriter` thread death is detected by `is_alive()`; the
+crawler's `finally` block handles it gracefully (no crash at stop).
+
+**AC8** — `verify_dual_write.py` reports row-count drift per table
+and exit 0/1 correctly.
+
+**AC9** — Postgres write SQL uses `%s` placeholders, schema-
+qualified table names (`lava_impact.<table>`), and correct
+`ON CONFLICT` clauses per table.
+
+**AC10** — Auto-id tables (`fetch_log`, `budget_ledger`,
+`deletion_log`) omit the `id` column in the RDS INSERT.
+
+**AC11** — Unit tests mock all RDS I/O; no live AWS in the default
+suite. Integration test behind `LAVANDULA_LIVE_RDS=1` verifies an
+actual round-trip insert for one row per table.
+
+**AC12** — Per-function SQL tests assert the generated Postgres
+statement matches the expected `INSERT INTO lava_impact.X ...`
+shape with correct placeholders and conflict clauses.
+
+---
+
+## Traps to Avoid
+
+1. **Don't mutate the shared DBWriter signature.** Existing callers
+   pass `db_writer=writer`; the new `rds_writer` is optional and
+   defaulted to `None`. Back-compat is preserved.
+
+2. **Don't use the same queue for SQLite and RDS.** They have
+   different failure semantics (SQLite must succeed; RDS is
+   best-effort). Keep them separate.
+
+3. **Don't let RDS failures surface as crawler exit codes.** The
+   only acceptable observable is a WARN log. A poisoned RDS path
+   must not degrade the authoritative SQLite path.
+
+4. **Don't forget `pool_pre_ping` is on the engine already** (Phase
+   1). Mid-connection token expiry is handled transparently. Don't
+   add duplicate retry logic.
+
+5. **Don't pass the SQLAlchemy ORM session.** The closures receive
+   a raw psycopg2 connection via `engine.raw_connection()`. This
+   mirrors the TICK-002 pattern where SQLite closures receive a
+   `sqlite3.Connection`.
+
+6. **Don't skip the `id`-column omission for auto-id tables.** SQLite
+   has `id` as the source of truth (autoincrement); Postgres MUST
+   assign its own to avoid PK conflicts. Same rule as Phase 2.
+
+7. **Don't duplicate the queue-saturation abort logic from DBWriter.**
+   SQLite queue saturation = crawler failure (TICK-002 round 5). RDS
+   queue saturation = drop with WARN. The two writers' failure
+   models differ on purpose.
+
+8. **Don't ship without the drift detector.** `verify_dual_write` is
+   how we know dual-write is stable enough to flip reads in Phase 4.
+   Without it, we're flying blind.
+
+---
+
+## Post-merge work (architect, not builder)
+
+1. Set `LAVANDULA_DUAL_WRITE=1` in a small test crawl (e.g., re-run
+   88-org TX against the Haiku seeds) and verify RDS receives all
+   rows.
+2. Run `verify_dual_write --sqlite <reports.db>` to confirm zero drift.
+3. Let dual-write run for 2+ real crawls; check drift periodically.
+4. When drift stays at zero across ≥2 crawls, move to Phase 4 (read flip).


### PR DESCRIPTION
## Summary
- Adds `RDSDBWriter` (best-effort async Postgres writer) plus `rds_writer` kwarg on every db_writer / budget function with a parallel Postgres-flavored closure.
- Crawler wires the writer behind `LAVANDULA_DUAL_WRITE` (default off → byte-identical to pre-0013). RDS failures WARN and drop; never fail SQLite or the crawler.
- Adds `python -m lavandula.common.tools.verify_dual_write` drift-detection tool.
- 31 new unit tests; all 316 project unit tests pass.

## Test plan
- [x] unit: `RDSDBWriter` queue-saturation, thread-death, per-op failure, raw_connection failure — all drop-with-WARN.
- [x] unit: each of 5 write paths (record_fetch, upsert_crawled_org, upsert_report insert+update, record_deletion, budget reserve/settle/release) enqueues a Postgres closure with `%s` placeholders, `lava_impact.<table>` qualification, and correct ON CONFLICT clauses.
- [x] unit: auto-id tables (fetch_log, deletion_log, budget_ledger) omit `id`.
- [x] unit: verify_dual_write reports drift / no-drift correctly.
- [x] regression: full unit suite (316 passed, 2 skipped).

Integration test (behind `LAVANDULA_LIVE_RDS=1`) is out of scope for this PR; the architect's post-merge plan runs a live dual-write crawl and `verify_dual_write` for drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)