### PR TITLE
[Spec 0030] 990 Filing Index Automation & S3 Archive

### DIFF
--- a/lavandula/dashboard/pipeline/forms.py
+++ b/lavandula/dashboard/pipeline/forms.py
@@ -182,40 +182,34 @@ class ClassifierForm(forms.Form):
 
 
 def _clean_990_common(cleaned_data):
-    """Shared validation for 990 index/parse forms: state-or-ein + years."""
-    if not cleaned_data.get("state") and not cleaned_data.get("ein"):
-        raise forms.ValidationError("State or EIN is required.")
+    """Shared validation for 990 index/parse forms."""
     ein = cleaned_data.get("ein")
     if ein and not re.match(r"^\d{9}$", ein):
         raise forms.ValidationError("EIN must be exactly 9 digits.")
     years_str = cleaned_data.get("years", "")
-    if not re.match(r"^\d{4}(\s*,\s*\d{4})*$", years_str):
-        raise forms.ValidationError("Years must be comma-separated 4-digit years.")
-    year_list = [int(y.strip()) for y in years_str.split(",")]
-    current_year = datetime.date.today().year
-    for y in year_list:
-        if y < 2019 or y > current_year:
-            raise forms.ValidationError(
-                f"Year {y} outside valid range [2019, {current_year}]."
-            )
-    if len(year_list) > 5:
-        raise forms.ValidationError("Maximum 5 years per request.")
+    if years_str:
+        if not re.match(r"^\d{4}(\s*,\s*\d{4})*$", years_str):
+            raise forms.ValidationError("Years must be comma-separated 4-digit years.")
+        year_list = [int(y.strip()) for y in years_str.split(",")]
+        current_year = datetime.date.today().year
+        for y in year_list:
+            if y < 2017 or y > current_year:
+                raise forms.ValidationError(
+                    f"Year {y} outside valid range [2017, {current_year}]."
+                )
+        if len(year_list) > 10:
+            raise forms.ValidationError("Maximum 10 years per request.")
     return cleaned_data
 
 
 class EnrichIndexForm(forms.Form):
-    state = forms.ChoiceField(
-        choices=[("", "—")] + STATE_CHOICES,
-        required=False,
-        widget=forms.Select(attrs={"class": _SELECT}),
-    )
     ein = forms.CharField(
         max_length=9, required=False,
-        widget=forms.TextInput(attrs={"class": _SELECT, "placeholder": "123456789"}),
+        widget=forms.TextInput(attrs={"class": _SELECT, "placeholder": "EIN (optional)"}),
     )
     years = forms.CharField(
-        initial=str(datetime.date.today().year),
-        widget=forms.TextInput(attrs={"class": _SELECT, "placeholder": "2023,2024"}),
+        required=False,
+        widget=forms.TextInput(attrs={"class": _SELECT, "placeholder": "2024,2025 (optional)"}),
     )
 
     def clean(self):
@@ -223,25 +217,12 @@ class EnrichIndexForm(forms.Form):
 
 
 class EnrichParseForm(forms.Form):
-    state = forms.ChoiceField(
-        choices=[("", "—")] + STATE_CHOICES,
-        required=False,
-        widget=forms.Select(attrs={"class": _SELECT}),
-    )
     ein = forms.CharField(
         max_length=9, required=False,
-        widget=forms.TextInput(attrs={"class": _SELECT, "placeholder": "123456789"}),
+        widget=forms.TextInput(attrs={"class": _SELECT, "placeholder": "EIN (optional)"}),
     )
-    years = forms.CharField(
-        initial=str(datetime.date.today().year),
-        widget=forms.TextInput(attrs={"class": _SELECT, "placeholder": "2023,2024"}),
-    )
-    limit = forms.IntegerField(
-        required=False, min_value=1, max_value=999999,
-        widget=forms.NumberInput(attrs={"class": _SELECT, "placeholder": "Optional"}),
-    )
-    skip_download = forms.BooleanField(required=False, label="Skip Download (cached only)")
     reparse = forms.BooleanField(required=False, label="Reparse errors")
+    backfill = forms.BooleanField(required=False, label="Backfill (all unprocessed)")
 
     def clean(self):
         return _clean_990_common(super().clean())

--- a/lavandula/dashboard/pipeline/management/commands/load_990_index.py
+++ b/lavandula/dashboard/pipeline/management/commands/load_990_index.py
@@ -157,23 +157,23 @@ class Command(BaseCommand):
 
         engine = make_app_engine()
 
-        with engine.connect() as conn:
-            conn.execute(
-                text("SELECT pg_advisory_lock(hashtext(:key))"),
-                {"key": _LOCK_KEY},
-            )
-            conn.commit()
+        lock_conn = engine.connect()
+        lock_conn.execute(
+            text("SELECT pg_advisory_lock(hashtext(:key))"),
+            {"key": _LOCK_KEY},
+        )
+        lock_conn.commit()
 
         try:
             for year in sorted(years):
                 self._load_year(engine, year, ein_filter)
         finally:
-            with engine.connect() as conn:
-                conn.execute(
-                    text("SELECT pg_advisory_unlock(hashtext(:key))"),
-                    {"key": _LOCK_KEY},
-                )
-                conn.commit()
+            lock_conn.execute(
+                text("SELECT pg_advisory_unlock(hashtext(:key))"),
+                {"key": _LOCK_KEY},
+            )
+            lock_conn.commit()
+            lock_conn.close()
 
     def _load_year(self, engine, year: int, ein_filter: str | None):
         url = TEOS_INDEX_URL.format(year=year)
@@ -202,7 +202,7 @@ class Command(BaseCommand):
 
         rows_scanned = 0
         rows_inserted = 0
-        rows_skipped = 0
+        rows_updated = 0
         batch = []
 
         insert_sql = text("""
@@ -216,16 +216,18 @@ class Command(BaseCommand):
                  now(), now())
             ON CONFLICT (object_id) DO UPDATE SET
                 last_seen_at = now()
+            RETURNING (xmax = 0) AS inserted
         """)
 
         def flush_batch(conn, batch_rows):
-            nonlocal rows_inserted, rows_skipped
+            nonlocal rows_inserted, rows_updated
             for row_params in batch_rows:
                 result = conn.execute(insert_sql, row_params)
-                if result.rowcount > 0:
+                row = result.fetchone()
+                if row and row[0]:
                     rows_inserted += 1
                 else:
-                    rows_skipped += 1
+                    rows_updated += 1
 
         with engine.begin() as conn:
             for row in reader:
@@ -284,11 +286,11 @@ class Command(BaseCommand):
                 "year": year,
                 "scanned": rows_scanned,
                 "inserted": rows_inserted,
-                "skipped": rows_skipped,
+                "skipped": rows_updated,
                 "duration": round(duration, 2),
             })
 
         self.stdout.write(
             f"  {year}: scanned={rows_scanned} inserted={rows_inserted} "
-            f"skipped={rows_skipped} ({duration:.1f}s)"
+            f"updated={rows_updated} ({duration:.1f}s)"
         )

--- a/lavandula/dashboard/pipeline/management/commands/load_990_index.py
+++ b/lavandula/dashboard/pipeline/management/commands/load_990_index.py
@@ -1,0 +1,294 @@
+"""Bulk-load IRS TEOS filing index CSVs into filing_index (Spec 0030).
+
+Downloads each year's index CSV, filters to RETURN_TYPE='990', and bulk-inserts
+into filing_index with ON CONFLICT handling. Supports 9-column (2017-2023) and
+10-column (2024+) formats.
+
+Usage:
+    python3 manage.py load_990_index                  # all available years
+    python3 manage.py load_990_index --years 2024,2025
+    python3 manage.py load_990_index --current-year   # nightly cron
+    python3 manage.py load_990_index --ein 131624241  # single EIN filter
+"""
+from __future__ import annotations
+
+import csv
+import datetime
+import io
+import ipaddress
+import logging
+import re
+import socket
+import time
+from urllib.parse import urlparse
+
+import requests
+from django.core.management.base import BaseCommand
+from sqlalchemy import text
+
+from lavandula.common.db import make_app_engine
+
+log = logging.getLogger(__name__)
+
+TEOS_INDEX_URL = (
+    "https://apps.irs.gov/pub/epostcard/990/xml/{year}/index_{year}.csv"
+)
+
+_COL_RETURN_ID = 0
+_COL_FILING_TYPE = 1
+_COL_EIN = 2
+_COL_TAX_PERIOD = 3
+_COL_SUB_DATE = 4
+_COL_TAXPAYER_NAME = 5
+_COL_RETURN_TYPE = 6
+_COL_DLN = 7
+_COL_OBJECT_ID = 8
+_COL_XML_BATCH_ID = 9
+
+_EIN_RE = re.compile(r"^\d{9}$", re.ASCII)
+_OBJECT_ID_RE = re.compile(r"^\d+$", re.ASCII)
+_BATCH_ID_RE = re.compile(r"^\d{4}_TEOS_XML_(0[1-9]|1[0-2])[A-D]$", re.ASCII)
+
+_MAX_CSV_BYTES = 200 * 1024 * 1024  # 200 MB
+_BATCH_SIZE = 5000
+_MIN_YEAR = 2017
+_LOCK_KEY = "990-family"
+
+
+def _resolve_and_check_host(hostname: str) -> None:
+    """Resolve hostname and reject private/link-local IPs (SSRF defense)."""
+    try:
+        addrs = socket.getaddrinfo(hostname, None)
+    except socket.gaierror:
+        raise ValueError(f"Cannot resolve hostname: {hostname}")
+    for family, _, _, _, sockaddr in addrs:
+        ip = ipaddress.ip_address(sockaddr[0])
+        if ip.is_private or ip.is_loopback or ip.is_link_local:
+            raise ValueError(
+                f"Hostname {hostname} resolves to private IP {ip}"
+            )
+
+
+def _safe_download_csv(url: str) -> io.StringIO:
+    """Download CSV with size cap and SSRF protections."""
+    parsed = urlparse(url)
+    if parsed.hostname != "apps.irs.gov":
+        raise ValueError(f"Unexpected hostname in URL: {parsed.hostname}")
+    if parsed.scheme != "https":
+        raise ValueError(f"Non-HTTPS scheme: {parsed.scheme}")
+
+    _resolve_and_check_host(parsed.hostname)
+
+    resp = requests.get(url, stream=True, timeout=120, allow_redirects=False)
+
+    if resp.status_code in (301, 302, 303, 307, 308):
+        location = resp.headers.get("Location", "")
+        redirect_parsed = urlparse(location)
+        if redirect_parsed.hostname != "apps.irs.gov":
+            raise ValueError(
+                f"Redirect to non-IRS host: {redirect_parsed.hostname}"
+            )
+        if redirect_parsed.scheme != "https":
+            raise ValueError(f"Redirect to non-HTTPS: {redirect_parsed.scheme}")
+        _resolve_and_check_host(redirect_parsed.hostname)
+        resp = requests.get(location, stream=True, timeout=120, allow_redirects=False)
+
+    if resp.status_code == 404:
+        return None
+
+    resp.raise_for_status()
+
+    chunks = []
+    bytes_read = 0
+    for chunk in resp.iter_content(chunk_size=65536):
+        bytes_read += len(chunk)
+        if bytes_read > _MAX_CSV_BYTES:
+            raise ValueError(
+                f"CSV exceeds size limit ({_MAX_CSV_BYTES} bytes)"
+            )
+        chunks.append(chunk)
+
+    raw = b"".join(chunks)
+    return io.StringIO(raw.decode("utf-8", errors="replace"))
+
+
+class Command(BaseCommand):
+    help = "Bulk-load IRS TEOS 990 filing index into filing_index table"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--years",
+            type=str,
+            default=None,
+            help="Comma-separated years to load (default: all 2017-current)",
+        )
+        parser.add_argument(
+            "--current-year",
+            action="store_true",
+            help="Only load the current year (for nightly cron)",
+        )
+        parser.add_argument(
+            "--ein",
+            type=str,
+            default=None,
+            help="Only insert/update rows matching this EIN",
+        )
+
+    def handle(self, *args, **options):
+        current_year = datetime.date.today().year
+
+        if options["current_year"]:
+            years = [current_year]
+        elif options["years"]:
+            years = []
+            for y in options["years"].split(","):
+                y = y.strip()
+                if not re.match(r"^\d{4}$", y):
+                    self.stderr.write(f"Invalid year: {y}")
+                    return
+                years.append(int(y))
+        else:
+            years = list(range(_MIN_YEAR, current_year + 1))
+
+        ein_filter = options.get("ein")
+        if ein_filter and not _EIN_RE.match(ein_filter):
+            self.stderr.write(f"Invalid EIN: {ein_filter}")
+            return
+
+        engine = make_app_engine()
+
+        with engine.connect() as conn:
+            conn.execute(
+                text("SELECT pg_advisory_lock(hashtext(:key))"),
+                {"key": _LOCK_KEY},
+            )
+            conn.commit()
+
+        try:
+            for year in sorted(years):
+                self._load_year(engine, year, ein_filter)
+        finally:
+            with engine.connect() as conn:
+                conn.execute(
+                    text("SELECT pg_advisory_unlock(hashtext(:key))"),
+                    {"key": _LOCK_KEY},
+                )
+                conn.commit()
+
+    def _load_year(self, engine, year: int, ein_filter: str | None):
+        url = TEOS_INDEX_URL.format(year=year)
+        self.stdout.write(f"Loading index for {year}...")
+
+        t0 = time.monotonic()
+
+        try:
+            csv_data = _safe_download_csv(url)
+        except ValueError as e:
+            self.stderr.write(f"  Skipping {year}: {e}")
+            return
+
+        if csv_data is None:
+            self.stdout.write(f"  {year}: 404 (not available)")
+            return
+
+        reader = csv.reader(csv_data)
+        header = next(reader, None)
+        if header is None:
+            self.stdout.write(f"  {year}: empty CSV")
+            return
+
+        col_count = len(header)
+        self.stdout.write(f"  {year}: {col_count}-column format")
+
+        rows_scanned = 0
+        rows_inserted = 0
+        rows_skipped = 0
+        batch = []
+
+        insert_sql = text("""
+            INSERT INTO lava_corpus.filing_index
+                (object_id, ein, tax_period, return_type, sub_date,
+                 taxpayer_name, xml_batch_id, filing_year, status,
+                 first_indexed_at, last_seen_at)
+            VALUES
+                (:object_id, :ein, :tax_period, :return_type, :sub_date,
+                 :taxpayer_name, :xml_batch_id, :filing_year, 'indexed',
+                 now(), now())
+            ON CONFLICT (object_id) DO UPDATE SET
+                last_seen_at = now()
+        """)
+
+        def flush_batch(conn, batch_rows):
+            nonlocal rows_inserted, rows_skipped
+            for row_params in batch_rows:
+                result = conn.execute(insert_sql, row_params)
+                if result.rowcount > 0:
+                    rows_inserted += 1
+                else:
+                    rows_skipped += 1
+
+        with engine.begin() as conn:
+            for row in reader:
+                rows_scanned += 1
+                if len(row) < 9:
+                    continue
+
+                return_type = row[_COL_RETURN_TYPE].strip()
+                if return_type != "990":
+                    continue
+
+                row_ein = row[_COL_EIN].strip()
+                if not _EIN_RE.match(row_ein):
+                    continue
+
+                if ein_filter and row_ein != ein_filter:
+                    continue
+
+                object_id = row[_COL_OBJECT_ID].strip()
+                if not _OBJECT_ID_RE.match(object_id):
+                    continue
+
+                xml_batch_id = (
+                    row[_COL_XML_BATCH_ID].strip() if len(row) > 9 else None
+                )
+                if xml_batch_id and not _BATCH_ID_RE.match(xml_batch_id):
+                    xml_batch_id = None
+
+                batch.append({
+                    "object_id": object_id,
+                    "ein": row_ein,
+                    "tax_period": row[_COL_TAX_PERIOD].strip(),
+                    "return_type": return_type,
+                    "sub_date": row[_COL_SUB_DATE].strip() or None,
+                    "taxpayer_name": row[_COL_TAXPAYER_NAME].strip() or None,
+                    "xml_batch_id": xml_batch_id or None,
+                    "filing_year": year,
+                })
+
+                if len(batch) >= _BATCH_SIZE:
+                    flush_batch(conn, batch)
+                    batch = []
+
+            if batch:
+                flush_batch(conn, batch)
+
+        duration = time.monotonic() - t0
+
+        with engine.begin() as conn:
+            conn.execute(text("""
+                INSERT INTO lava_corpus.index_refresh_log
+                    (filing_year, rows_scanned, rows_inserted, rows_skipped, duration_sec)
+                VALUES
+                    (:year, :scanned, :inserted, :skipped, :duration)
+            """), {
+                "year": year,
+                "scanned": rows_scanned,
+                "inserted": rows_inserted,
+                "skipped": rows_skipped,
+                "duration": round(duration, 2),
+            })
+
+        self.stdout.write(
+            f"  {year}: scanned={rows_scanned} inserted={rows_inserted} "
+            f"skipped={rows_skipped} ({duration:.1f}s)"
+        )

--- a/lavandula/dashboard/pipeline/management/commands/process_990_auto.py
+++ b/lavandula/dashboard/pipeline/management/commands/process_990_auto.py
@@ -392,6 +392,19 @@ class Command(BaseCommand):
                         stats["errors"] += 1
                     continue
 
+                with engine.begin() as conn:
+                    conn.execute(text("""
+                        UPDATE lava_corpus.filing_index
+                        SET zip_checksum = :checksum
+                        WHERE filing_year = :year
+                          AND xml_batch_id = :batch_id
+                          AND zip_checksum IS NULL
+                    """), {
+                        "checksum": checksum,
+                        "year": year,
+                        "batch_id": batch_id,
+                    })
+
             self._extract_batch(
                 engine, archive, year, batch_id, batch_filings, stats
             )

--- a/lavandula/dashboard/pipeline/management/commands/process_990_auto.py
+++ b/lavandula/dashboard/pipeline/management/commands/process_990_auto.py
@@ -153,14 +153,22 @@ def _download_zip_to_s3(
     return None
 
 
+class _ParseError:
+    """Sentinel indicating a parse failure (not timeout)."""
+    def __init__(self, error_type: str):
+        self.error_type = error_type
+
+
 def _parse_xml_with_timeout(xml_bytes: bytes):
-    """Parse 990 XML with a process-level timeout."""
+    """Parse 990 XML with a process-level timeout. Returns result, None (timeout), or _ParseError."""
     with concurrent.futures.ProcessPoolExecutor(max_workers=1) as pool:
         future = pool.submit(parse_990_xml, xml_bytes)
         try:
             return future.result(timeout=_XML_PARSE_TIMEOUT)
         except concurrent.futures.TimeoutError:
             return None
+        except Exception as e:
+            return _ParseError(type(e).__name__)
 
 
 def _record_filing_error(
@@ -201,31 +209,31 @@ class Command(BaseCommand):
         engine = make_app_engine()
         archive = S3990Archive()
 
-        with engine.connect() as conn:
-            conn.execute(
-                text(f"SET lock_timeout = '{_LOCK_TIMEOUT}'")
+        lock_conn = engine.connect()
+        lock_conn.execute(text(f"SET lock_timeout = '{_LOCK_TIMEOUT}'"))
+        lock_conn.commit()
+        try:
+            lock_conn.execute(
+                text("SELECT pg_advisory_lock(hashtext(:key))"),
+                {"key": _LOCK_KEY},
             )
-            try:
-                conn.execute(
-                    text("SELECT pg_advisory_lock(hashtext(:key))"),
-                    {"key": _LOCK_KEY},
-                )
-            except Exception as e:
-                self.stderr.write(
-                    f"Could not acquire advisory lock (another job running?): {e}"
-                )
-                return
-            conn.commit()
+            lock_conn.commit()
+        except Exception as e:
+            self.stderr.write(
+                f"Could not acquire advisory lock (another job running?): {e}"
+            )
+            lock_conn.close()
+            return
 
         try:
             self._run(engine, archive, options)
         finally:
-            with engine.connect() as conn:
-                conn.execute(
-                    text("SELECT pg_advisory_unlock(hashtext(:key))"),
-                    {"key": _LOCK_KEY},
-                )
-                conn.commit()
+            lock_conn.execute(
+                text("SELECT pg_advisory_unlock(hashtext(:key))"),
+                {"key": _LOCK_KEY},
+            )
+            lock_conn.commit()
+            lock_conn.close()
 
     def _run(self, engine, archive: S3990Archive, options: dict):
         ein_filter = options.get("ein")
@@ -236,24 +244,24 @@ class Command(BaseCommand):
         if options["reparse"]:
             self._reset_errors(engine, ein_filter, options["backfill"])
 
-        # Pass 1: Download indexed filings
-        download_filings = self._query_filings(
-            engine, "indexed", ein_filter, options["backfill"]
-        )
-        # Pass 2: Parse already-downloaded filings
-        parse_filings = self._query_filings(
-            engine, "downloaded", ein_filter, backfill=True
-        )
-
         stats = {
             "downloaded": 0, "parsed": 0, "errors": 0, "skipped": 0
         }
 
+        # Pass 1: Download indexed filings
+        download_filings = self._query_filings(
+            engine, "indexed", ein_filter, options["backfill"]
+        )
         if download_filings:
             self._process_download_pass(
                 engine, archive, download_filings, stats
             )
 
+        # Pass 2: Parse downloaded filings (re-query AFTER download pass
+        # so newly-downloaded filings are included in this run)
+        parse_filings = self._query_filings(
+            engine, "downloaded", ein_filter, backfill=True
+        )
         if parse_filings:
             self._process_parse_pass(engine, archive, parse_filings, stats)
 
@@ -557,15 +565,10 @@ class Command(BaseCommand):
                 stats["errors"] += 1
                 continue
 
-            try:
-                if hasattr(result, "people") and result.people is not None:
-                    pass
-                else:
-                    result = parse_990_xml(xml_bytes)
-            except Exception as e:
+            if isinstance(result, _ParseError):
                 _record_filing_error(
                     engine, oid, ErrorCode.XML_PARSE_FAILED,
-                    type(e).__name__
+                    result.error_type
                 )
                 stats["errors"] += 1
                 continue
@@ -576,7 +579,7 @@ class Command(BaseCommand):
     def _upsert_people_and_mark_parsed(self, engine, result, filing: dict):
         oid = filing["object_id"]
 
-        upsert_sql = text("""
+        insert_sql = text("""
             INSERT INTO lava_corpus.people
                 (ein, tax_period, object_id, person_name, title, person_type,
                  avg_hours_per_week, reportable_comp, related_org_comp, other_comp,
@@ -595,11 +598,16 @@ class Command(BaseCommand):
         """)
 
         with engine.begin() as conn:
+            conn.execute(
+                text("DELETE FROM lava_corpus.people WHERE object_id = :oid"),
+                {"oid": oid},
+            )
+
             if result.people:
                 meta = result.metadata
                 for p in result.people:
                     name = unicodedata.normalize("NFC", p.person_name.strip())
-                    conn.execute(upsert_sql, {
+                    conn.execute(insert_sql, {
                         "ein": meta.ein,
                         "tax_period": meta.tax_period,
                         "object_id": oid,

--- a/lavandula/dashboard/pipeline/management/commands/process_990_auto.py
+++ b/lavandula/dashboard/pipeline/management/commands/process_990_auto.py
@@ -1,0 +1,642 @@
+"""Auto-process 990 filings for tracked orgs via S3 (Spec 0030).
+
+Downloads batch zips (cached in S3), extracts per-org XMLs, parses them,
+and upserts people data. Reconciliation-based: processes any filing_index
+rows for nonprofits_seed EINs that are still at status='indexed'.
+
+Usage:
+    python3 manage.py process_990_auto                # incremental (last 7 days)
+    python3 manage.py process_990_auto --backfill     # all unprocessed
+    python3 manage.py process_990_auto --ein 131624241
+    python3 manage.py process_990_auto --reparse      # retry error filings
+"""
+from __future__ import annotations
+
+import concurrent.futures
+import enum
+import io
+import ipaddress
+import logging
+import re
+import socket
+import time
+import unicodedata
+import zipfile
+from urllib.parse import urlparse
+
+import defusedxml.ElementTree as ET
+import requests
+from django.core.management.base import BaseCommand
+from sqlalchemy import text
+
+from lavandula.common.db import make_app_engine
+from lavandula.nonprofits.irs990_parser import parse_990_xml
+from lavandula.nonprofits.s3_990 import S3990Archive
+
+log = logging.getLogger(__name__)
+
+TEOS_ZIP_URL = (
+    "https://apps.irs.gov/pub/epostcard/990/xml/{year}/{batch_id}.zip"
+)
+
+_LOCK_KEY = "990-family"
+_LOCK_TIMEOUT = "1h"
+
+_MAX_MEMBER_SIZE = 50 * 1024 * 1024  # 50 MB
+_MAX_ZIP_SIZE = 5 * 1024 * 1024 * 1024  # 5 GB
+_MAX_BATCH_EXTRACTED = 10 * 1024 * 1024 * 1024  # 10 GB per batch
+_MAX_MEMBERS_PER_ZIP = 200_000
+_BOMB_RATIO = 100
+_XML_PARSE_TIMEOUT = 30
+
+_MEMBER_NAME_RE = re.compile(r"^([\w]+/)?\d+_public\.xml$", re.ASCII)
+_EIN_RE = re.compile(r"^\d{9}$", re.ASCII)
+_OBJECT_ID_RE = re.compile(r"^\d+$", re.ASCII)
+_BATCH_ID_RE = re.compile(r"^\d{4}_TEOS_XML_(0[1-9]|1[0-2])[A-D]$", re.ASCII)
+
+_RETRY_DELAYS = [2, 4, 8]
+_MAX_RETRIES = 3
+_RETRYABLE_STATUS = {429, 500, 502, 503, 504}
+_DOWNLOAD_DELAY = 5
+
+
+class ErrorCode(enum.Enum):
+    ZIP_MEMBER_MISSING = "ZIP_MEMBER_MISSING"
+    ZIP_BOMB_DETECTED = "ZIP_BOMB_DETECTED"
+    ZIP_CORRUPT = "ZIP_CORRUPT"
+    ZIP_DOWNLOAD_FAILED = "ZIP_DOWNLOAD_FAILED"
+    ZIP_MEMBER_INVALID_NAME = "ZIP_MEMBER_INVALID_NAME"
+    ZIP_MEMBER_TOO_LARGE = "ZIP_MEMBER_TOO_LARGE"
+    XML_PARSE_FAILED = "XML_PARSE_FAILED"
+    XML_PARSE_TIMEOUT = "XML_PARSE_TIMEOUT"
+    S3_UPLOAD_FAILED = "S3_UPLOAD_FAILED"
+    S3_OBJECT_MISSING = "S3_OBJECT_MISSING"
+    BATCH_EXTRACT_LIMIT = "BATCH_EXTRACT_LIMIT"
+
+
+def _sanitize_detail(detail: str) -> str:
+    """Strip potentially sensitive info from error details."""
+    detail = re.sub(r"https?://[^\s]+", "[URL]", detail)
+    detail = re.sub(r"/[\w/.-]+", "[PATH]", detail)
+    return detail[:200]
+
+
+def _resolve_and_check_host(hostname: str) -> None:
+    try:
+        addrs = socket.getaddrinfo(hostname, None)
+    except socket.gaierror:
+        raise ValueError(f"Cannot resolve: {hostname}")
+    for _, _, _, _, sockaddr in addrs:
+        ip = ipaddress.ip_address(sockaddr[0])
+        if ip.is_private or ip.is_loopback or ip.is_link_local:
+            raise ValueError(f"Private IP detected for {hostname}")
+
+
+def _download_zip_to_s3(
+    year: int, batch_id: str, archive: S3990Archive
+) -> str | None:
+    """Download IRS zip and upload to S3. Returns checksum or None on failure."""
+    url = TEOS_ZIP_URL.format(year=year, batch_id=batch_id)
+    parsed = urlparse(url)
+
+    if parsed.hostname != "apps.irs.gov" or parsed.scheme != "https":
+        raise ValueError(f"Invalid IRS URL: {url}")
+    _resolve_and_check_host(parsed.hostname)
+
+    for attempt in range(_MAX_RETRIES):
+        try:
+            resp = requests.get(
+                url, stream=True, timeout=300, allow_redirects=False
+            )
+
+            if resp.status_code in (301, 302, 303, 307, 308):
+                location = resp.headers.get("Location", "")
+                rp = urlparse(location)
+                if rp.hostname != "apps.irs.gov" or rp.scheme != "https":
+                    raise ValueError(f"Redirect to non-IRS host: {location}")
+                _resolve_and_check_host(rp.hostname)
+                resp = requests.get(
+                    location, stream=True, timeout=300, allow_redirects=False
+                )
+
+            if resp.status_code == 404:
+                return None
+
+            if resp.status_code in _RETRYABLE_STATUS:
+                if attempt < _MAX_RETRIES - 1:
+                    time.sleep(_RETRY_DELAYS[attempt])
+                    continue
+                resp.raise_for_status()
+
+            resp.raise_for_status()
+
+            buf = io.BytesIO()
+            bytes_read = 0
+            for chunk in resp.iter_content(chunk_size=65536):
+                bytes_read += len(chunk)
+                if bytes_read > _MAX_ZIP_SIZE:
+                    raise ValueError(
+                        f"Zip exceeds {_MAX_ZIP_SIZE} byte limit"
+                    )
+                buf.write(chunk)
+
+            buf.seek(0)
+            checksum = archive.upload_zip(year, batch_id, buf)
+            return checksum
+
+        except requests.ConnectionError:
+            if attempt < _MAX_RETRIES - 1:
+                time.sleep(_RETRY_DELAYS[attempt])
+                continue
+            raise
+
+    return None
+
+
+def _parse_xml_with_timeout(xml_bytes: bytes):
+    """Parse 990 XML with a process-level timeout."""
+    with concurrent.futures.ProcessPoolExecutor(max_workers=1) as pool:
+        future = pool.submit(parse_990_xml, xml_bytes)
+        try:
+            return future.result(timeout=_XML_PARSE_TIMEOUT)
+        except concurrent.futures.TimeoutError:
+            return None
+
+
+def _record_filing_error(
+    engine, object_id: str, code: ErrorCode, detail: str = ""
+):
+    safe_detail = _sanitize_detail(detail)
+    msg = f"{code.value}: {safe_detail}" if safe_detail else code.value
+    with engine.begin() as conn:
+        conn.execute(text("""
+            UPDATE lava_corpus.filing_index
+            SET status = 'error', error_message = :msg
+            WHERE object_id = :oid
+        """), {"msg": msg[:500], "oid": object_id})
+
+
+class Command(BaseCommand):
+    help = "Auto-process 990 filings for tracked orgs (download, extract, parse)"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--backfill",
+            action="store_true",
+            help="Process all unprocessed filings (no time filter)",
+        )
+        parser.add_argument(
+            "--ein",
+            type=str,
+            default=None,
+            help="Process only filings for this EIN",
+        )
+        parser.add_argument(
+            "--reparse",
+            action="store_true",
+            help="Also re-process filings in error state",
+        )
+
+    def handle(self, *args, **options):
+        engine = make_app_engine()
+        archive = S3990Archive()
+
+        with engine.connect() as conn:
+            conn.execute(
+                text(f"SET lock_timeout = '{_LOCK_TIMEOUT}'")
+            )
+            try:
+                conn.execute(
+                    text("SELECT pg_advisory_lock(hashtext(:key))"),
+                    {"key": _LOCK_KEY},
+                )
+            except Exception as e:
+                self.stderr.write(
+                    f"Could not acquire advisory lock (another job running?): {e}"
+                )
+                return
+            conn.commit()
+
+        try:
+            self._run(engine, archive, options)
+        finally:
+            with engine.connect() as conn:
+                conn.execute(
+                    text("SELECT pg_advisory_unlock(hashtext(:key))"),
+                    {"key": _LOCK_KEY},
+                )
+                conn.commit()
+
+    def _run(self, engine, archive: S3990Archive, options: dict):
+        ein_filter = options.get("ein")
+        if ein_filter and not _EIN_RE.match(ein_filter):
+            self.stderr.write(f"Invalid EIN: {ein_filter}")
+            return
+
+        if options["reparse"]:
+            self._reset_errors(engine, ein_filter, options["backfill"])
+
+        # Pass 1: Download indexed filings
+        download_filings = self._query_filings(
+            engine, "indexed", ein_filter, options["backfill"]
+        )
+        # Pass 2: Parse already-downloaded filings
+        parse_filings = self._query_filings(
+            engine, "downloaded", ein_filter, backfill=True
+        )
+
+        stats = {
+            "downloaded": 0, "parsed": 0, "errors": 0, "skipped": 0
+        }
+
+        if download_filings:
+            self._process_download_pass(
+                engine, archive, download_filings, stats
+            )
+
+        if parse_filings:
+            self._process_parse_pass(engine, archive, parse_filings, stats)
+
+        self.stdout.write(
+            f"Done: downloaded={stats['downloaded']} parsed={stats['parsed']} "
+            f"errors={stats['errors']} skipped={stats['skipped']}"
+        )
+
+    def _query_filings(
+        self, engine, status: str, ein_filter: str | None, backfill: bool
+    ) -> list[dict]:
+        conditions = [
+            "fi.status = :status",
+            "fi.xml_batch_id IS NOT NULL",
+            "fi.ein IN (SELECT ein FROM lava_corpus.nonprofits_seed)",
+        ]
+        params = {"status": status}
+
+        if ein_filter:
+            conditions.append("fi.ein = :ein")
+            params["ein"] = ein_filter
+
+        if not backfill and status == "indexed":
+            conditions.append(
+                "fi.first_indexed_at >= now() - interval '7 days'"
+            )
+
+        where = " AND ".join(conditions)
+        sql = text(f"""
+            SELECT fi.object_id, fi.ein, fi.tax_period,
+                   fi.xml_batch_id, fi.filing_year, fi.s3_xml_key
+            FROM lava_corpus.filing_index fi
+            WHERE {where}
+            ORDER BY fi.filing_year, fi.xml_batch_id, fi.object_id
+        """)
+
+        with engine.connect() as conn:
+            rows = conn.execute(sql, params).fetchall()
+
+        return [
+            {
+                "object_id": r[0],
+                "ein": r[1],
+                "tax_period": r[2],
+                "xml_batch_id": r[3],
+                "filing_year": r[4],
+                "s3_xml_key": r[5],
+            }
+            for r in rows
+        ]
+
+    def _reset_errors(self, engine, ein_filter: str | None, backfill: bool):
+        conditions = [
+            "status = 'error'",
+            "ein IN (SELECT ein FROM lava_corpus.nonprofits_seed)",
+        ]
+        params = {}
+        if ein_filter:
+            conditions.append("ein = :ein")
+            params["ein"] = ein_filter
+        if not backfill:
+            conditions.append(
+                "first_indexed_at >= now() - interval '7 days'"
+            )
+
+        where = " AND ".join(conditions)
+        with engine.begin() as conn:
+            result = conn.execute(text(f"""
+                UPDATE lava_corpus.filing_index
+                SET status = 'indexed', error_message = NULL, s3_xml_key = NULL
+                WHERE {where}
+            """), params)
+            if result.rowcount > 0:
+                self.stdout.write(
+                    f"Reset {result.rowcount} error filings to indexed"
+                )
+
+    def _process_download_pass(
+        self, engine, archive: S3990Archive, filings: list[dict], stats: dict
+    ):
+        batches: dict[tuple[int, str], list[dict]] = {}
+        for f in filings:
+            key = (f["filing_year"], f["xml_batch_id"])
+            batches.setdefault(key, []).append(f)
+
+        self.stdout.write(
+            f"Download pass: {len(filings)} filings in {len(batches)} batches"
+        )
+
+        last_download = 0.0
+
+        for (year, batch_id), batch_filings in batches.items():
+            if not _BATCH_ID_RE.match(batch_id):
+                for f in batch_filings:
+                    _record_filing_error(
+                        engine, f["object_id"], ErrorCode.ZIP_DOWNLOAD_FAILED,
+                        "Invalid batch_id format"
+                    )
+                    stats["errors"] += 1
+                continue
+
+            if not archive.zip_exists(year, batch_id):
+                elapsed = time.monotonic() - last_download
+                if elapsed < _DOWNLOAD_DELAY:
+                    time.sleep(_DOWNLOAD_DELAY - elapsed)
+
+                try:
+                    checksum = _download_zip_to_s3(year, batch_id, archive)
+                    last_download = time.monotonic()
+                except Exception as e:
+                    log.error("Zip download failed %s: %s", batch_id, e)
+                    for f in batch_filings:
+                        _record_filing_error(
+                            engine, f["object_id"],
+                            ErrorCode.ZIP_DOWNLOAD_FAILED,
+                            str(type(e).__name__)
+                        )
+                        stats["errors"] += 1
+                    continue
+
+                if checksum is None:
+                    for f in batch_filings:
+                        _record_filing_error(
+                            engine, f["object_id"],
+                            ErrorCode.ZIP_DOWNLOAD_FAILED,
+                            "404 from IRS"
+                        )
+                        stats["errors"] += 1
+                    continue
+
+            self._extract_batch(
+                engine, archive, year, batch_id, batch_filings, stats
+            )
+
+    def _extract_batch(
+        self,
+        engine,
+        archive: S3990Archive,
+        year: int,
+        batch_id: str,
+        filings: list[dict],
+        stats: dict,
+    ):
+        try:
+            zip_stream = archive.open_zip(year, batch_id)
+        except Exception as e:
+            log.error("Failed to open zip %s from S3: %s", batch_id, e)
+            for f in filings:
+                _record_filing_error(
+                    engine, f["object_id"], ErrorCode.ZIP_CORRUPT,
+                    str(type(e).__name__)
+                )
+                stats["errors"] += 1
+            return
+
+        try:
+            zf = zipfile.ZipFile(zip_stream)
+        except zipfile.BadZipFile:
+            for f in filings:
+                _record_filing_error(
+                    engine, f["object_id"], ErrorCode.ZIP_CORRUPT,
+                    "BadZipFile"
+                )
+                stats["errors"] += 1
+            return
+
+        with zf:
+            if len(zf.namelist()) > _MAX_MEMBERS_PER_ZIP:
+                for f in filings:
+                    _record_filing_error(
+                        engine, f["object_id"], ErrorCode.ZIP_BOMB_DETECTED,
+                        "Member count exceeds limit"
+                    )
+                    stats["errors"] += 1
+                return
+
+            cumulative_extracted = 0
+
+            for filing in filings:
+                oid = filing["object_id"]
+                ein = filing["ein"]
+
+                nested_name = f"{batch_id}/{oid}_public.xml"
+                flat_name = f"{oid}_public.xml"
+
+                info = None
+                member_name = None
+                try:
+                    info = zf.getinfo(nested_name)
+                    member_name = nested_name
+                except KeyError:
+                    try:
+                        info = zf.getinfo(flat_name)
+                        member_name = flat_name
+                    except KeyError:
+                        _record_filing_error(
+                            engine, oid, ErrorCode.ZIP_MEMBER_MISSING,
+                            f"Tried {oid}_public.xml"
+                        )
+                        stats["errors"] += 1
+                        continue
+
+                if not _MEMBER_NAME_RE.match(info.filename):
+                    _record_filing_error(
+                        engine, oid, ErrorCode.ZIP_MEMBER_INVALID_NAME, ""
+                    )
+                    stats["errors"] += 1
+                    continue
+
+                compress_size = max(info.compress_size, 1)
+                if info.file_size / compress_size > _BOMB_RATIO:
+                    _record_filing_error(
+                        engine, oid, ErrorCode.ZIP_BOMB_DETECTED,
+                        f"Ratio {info.file_size / compress_size:.0f}:1"
+                    )
+                    stats["errors"] += 1
+                    continue
+
+                if info.file_size > _MAX_MEMBER_SIZE:
+                    _record_filing_error(
+                        engine, oid, ErrorCode.ZIP_MEMBER_TOO_LARGE,
+                        f"{info.file_size} bytes"
+                    )
+                    stats["errors"] += 1
+                    continue
+
+                cumulative_extracted += info.file_size
+                if cumulative_extracted > _MAX_BATCH_EXTRACTED:
+                    _record_filing_error(
+                        engine, oid, ErrorCode.BATCH_EXTRACT_LIMIT, ""
+                    )
+                    stats["errors"] += 1
+                    continue
+
+                try:
+                    xml_bytes = zf.read(member_name)
+                except Exception:
+                    _record_filing_error(
+                        engine, oid, ErrorCode.ZIP_CORRUPT,
+                        "Read failed"
+                    )
+                    stats["errors"] += 1
+                    continue
+
+                if len(xml_bytes) > _MAX_MEMBER_SIZE:
+                    _record_filing_error(
+                        engine, oid, ErrorCode.ZIP_BOMB_DETECTED,
+                        "Actual size exceeds limit"
+                    )
+                    stats["errors"] += 1
+                    continue
+
+                try:
+                    s3_key = archive.upload_xml(ein, oid, xml_bytes)
+                except Exception as e:
+                    _record_filing_error(
+                        engine, oid, ErrorCode.S3_UPLOAD_FAILED,
+                        type(e).__name__
+                    )
+                    stats["errors"] += 1
+                    continue
+
+                with engine.begin() as conn:
+                    conn.execute(text("""
+                        UPDATE lava_corpus.filing_index
+                        SET status = 'downloaded',
+                            s3_xml_key = :s3_key
+                        WHERE object_id = :oid AND status = 'indexed'
+                    """), {"s3_key": s3_key, "oid": oid})
+
+                stats["downloaded"] += 1
+
+    def _process_parse_pass(
+        self, engine, archive: S3990Archive, filings: list[dict], stats: dict
+    ):
+        self.stdout.write(f"Parse pass: {len(filings)} filings")
+
+        for filing in filings:
+            oid = filing["object_id"]
+            ein = filing["ein"]
+            s3_key = filing["s3_xml_key"]
+
+            if not s3_key:
+                s3_key = f"xml/{ein}/{oid}.xml"
+
+            try:
+                xml_bytes = archive.read_xml(s3_key)
+            except Exception:
+                _record_filing_error(
+                    engine, oid, ErrorCode.S3_OBJECT_MISSING,
+                    "Could not read XML from S3"
+                )
+                stats["errors"] += 1
+                continue
+
+            result = _parse_xml_with_timeout(xml_bytes)
+            if result is None:
+                _record_filing_error(
+                    engine, oid, ErrorCode.XML_PARSE_TIMEOUT, ""
+                )
+                stats["errors"] += 1
+                continue
+
+            try:
+                if hasattr(result, "people") and result.people is not None:
+                    pass
+                else:
+                    result = parse_990_xml(xml_bytes)
+            except Exception as e:
+                _record_filing_error(
+                    engine, oid, ErrorCode.XML_PARSE_FAILED,
+                    type(e).__name__
+                )
+                stats["errors"] += 1
+                continue
+
+            self._upsert_people_and_mark_parsed(engine, result, filing)
+            stats["parsed"] += 1
+
+    def _upsert_people_and_mark_parsed(self, engine, result, filing: dict):
+        oid = filing["object_id"]
+
+        upsert_sql = text("""
+            INSERT INTO lava_corpus.people
+                (ein, tax_period, object_id, person_name, title, person_type,
+                 avg_hours_per_week, reportable_comp, related_org_comp, other_comp,
+                 base_comp, bonus, other_reportable, deferred_comp,
+                 nontaxable_benefits, total_comp_sch_j,
+                 services_desc, is_officer, is_director, is_key_employee,
+                 is_highest_comp, is_former)
+            VALUES
+                (:ein, :tax_period, :object_id, :person_name, :title, :person_type,
+                 :avg_hours_per_week, :reportable_comp, :related_org_comp, :other_comp,
+                 :base_comp, :bonus, :other_reportable, :deferred_comp,
+                 :nontaxable_benefits, :total_comp_sch_j,
+                 :services_desc, :is_officer, :is_director, :is_key_employee,
+                 :is_highest_comp, :is_former)
+            ON CONFLICT (ein, object_id, person_name, person_type) DO NOTHING
+        """)
+
+        with engine.begin() as conn:
+            if result.people:
+                meta = result.metadata
+                for p in result.people:
+                    name = unicodedata.normalize("NFC", p.person_name.strip())
+                    conn.execute(upsert_sql, {
+                        "ein": meta.ein,
+                        "tax_period": meta.tax_period,
+                        "object_id": oid,
+                        "person_name": name,
+                        "title": p.title,
+                        "person_type": p.person_type,
+                        "avg_hours_per_week": (
+                            float(p.avg_hours_per_week)
+                            if p.avg_hours_per_week is not None else None
+                        ),
+                        "reportable_comp": p.reportable_comp,
+                        "related_org_comp": p.related_org_comp,
+                        "other_comp": p.other_comp,
+                        "base_comp": p.base_comp,
+                        "bonus": p.bonus,
+                        "other_reportable": p.other_reportable,
+                        "deferred_comp": p.deferred_comp,
+                        "nontaxable_benefits": p.nontaxable_benefits,
+                        "total_comp_sch_j": p.total_comp_sch_j,
+                        "services_desc": p.services_desc,
+                        "is_officer": p.is_officer,
+                        "is_director": p.is_director,
+                        "is_key_employee": p.is_key_employee,
+                        "is_highest_comp": p.is_highest_comp,
+                        "is_former": p.is_former,
+                    })
+
+            conn.execute(text("""
+                UPDATE lava_corpus.filing_index
+                SET status = 'parsed',
+                    parsed_at = now(),
+                    return_ts = :return_ts,
+                    is_amended = :is_amended,
+                    error_message = NULL
+                WHERE object_id = :oid
+            """), {
+                "oid": oid,
+                "return_ts": result.metadata.return_ts,
+                "is_amended": result.metadata.is_amended,
+            })

--- a/lavandula/dashboard/pipeline/management/commands/reset_990_status.py
+++ b/lavandula/dashboard/pipeline/management/commands/reset_990_status.py
@@ -1,0 +1,163 @@
+"""Reset filing_index status for operator recovery (Spec 0030).
+
+Resets filings from error/downloaded/parsed back to 'indexed' so they
+can be re-processed. Logs all resets to filing_status_audit.
+
+Usage:
+    python3 manage.py reset_990_status --ein 030440761
+    python3 manage.py reset_990_status --object-id 202423190349...
+    python3 manage.py reset_990_status --status error --max-rows 1000
+"""
+from __future__ import annotations
+
+import os
+import pwd
+import logging
+
+from django.core.management.base import BaseCommand, CommandError
+from sqlalchemy import text
+
+from lavandula.common.db import make_app_engine
+
+log = logging.getLogger(__name__)
+
+_ALLOWED_SOURCE_STATES = {"error", "downloaded", "parsed", "skipped"}
+_LOCK_KEY = "990-family"
+
+
+def _get_operator_name() -> str:
+    return os.environ.get(
+        "SUDO_USER", pwd.getpwuid(os.getuid()).pw_name
+    )
+
+
+class Command(BaseCommand):
+    help = "Reset filing_index status to 'indexed' for re-processing"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--ein", type=str, default=None,
+            help="Reset all filings for this EIN",
+        )
+        parser.add_argument(
+            "--object-id", type=str, default=None,
+            help="Reset a specific filing by object_id",
+        )
+        parser.add_argument(
+            "--status", type=str, default=None,
+            choices=sorted(_ALLOWED_SOURCE_STATES),
+            help="Reset all filings with this status",
+        )
+        parser.add_argument(
+            "--max-rows", type=int, default=None,
+            help="Maximum rows to reset (required for --status bulk operations)",
+        )
+        parser.add_argument(
+            "--yes", action="store_true",
+            help="Skip confirmation prompt",
+        )
+
+    def handle(self, *args, **options):
+        ein = options["ein"]
+        object_id = options["object_id"]
+        status_filter = options["status"]
+        max_rows = options["max_rows"]
+        skip_confirm = options["yes"]
+
+        if not ein and not object_id and not status_filter:
+            raise CommandError(
+                "Must specify --ein, --object-id, or --status"
+            )
+
+        if status_filter and not ein and not object_id and not max_rows:
+            raise CommandError(
+                "--max-rows is required for bulk --status operations"
+            )
+
+        engine = make_app_engine()
+
+        conditions = []
+        params = {}
+
+        if object_id:
+            conditions.append("object_id = :oid")
+            params["oid"] = object_id
+        elif ein:
+            conditions.append("ein = :ein")
+            params["ein"] = ein
+
+        if status_filter:
+            conditions.append("status = :status")
+            params["status"] = status_filter
+        else:
+            conditions.append("status = ANY(:allowed)")
+            params["allowed"] = list(_ALLOWED_SOURCE_STATES)
+
+        conditions.append("status != 'indexed'")
+        conditions.append("status != 'batch_unresolvable'")
+
+        where = " AND ".join(conditions)
+
+        with engine.connect() as conn:
+            count = conn.execute(
+                text(f"SELECT COUNT(*) FROM lava_corpus.filing_index WHERE {where}"),
+                params,
+            ).scalar()
+
+        if count == 0:
+            self.stdout.write("No filings match the criteria.")
+            return
+
+        if max_rows and count > max_rows:
+            raise CommandError(
+                f"Matched {count} rows exceeds --max-rows {max_rows}. "
+                f"Increase --max-rows or narrow the filter."
+            )
+
+        if not skip_confirm:
+            self.stdout.write(f"Will reset {count} filing(s) to 'indexed'.")
+            confirm = input("Proceed? [y/N] ")
+            if confirm.lower() != "y":
+                self.stdout.write("Aborted.")
+                return
+
+        operator = _get_operator_name()
+        cmd_args = " ".join(
+            f"--{k}={v}" for k, v in options.items()
+            if v and k not in ("yes", "verbosity", "settings", "pythonpath",
+                               "traceback", "no_color", "force_color",
+                               "skip_checks")
+        )
+
+        with engine.begin() as conn:
+            rows = conn.execute(text(f"""
+                SELECT object_id, status
+                FROM lava_corpus.filing_index
+                WHERE {where}
+            """), params).fetchall()
+
+            for row in rows:
+                conn.execute(text("""
+                    INSERT INTO lava_corpus.filing_status_audit
+                        (filing_id, old_status, new_status, reset_by, command_args)
+                    VALUES
+                        (:fid, :old, 'indexed', :who, :args)
+                """), {
+                    "fid": row[0],
+                    "old": row[1],
+                    "who": operator,
+                    "args": cmd_args,
+                })
+
+            result = conn.execute(text(f"""
+                UPDATE lava_corpus.filing_index
+                SET status = 'indexed',
+                    error_message = NULL,
+                    s3_xml_key = NULL
+                WHERE {where}
+            """), params)
+
+        self.stdout.write(
+            f"Reset {result.rowcount} filing(s) to 'indexed'. "
+            f"Operator: {operator}"
+        )

--- a/lavandula/dashboard/pipeline/management/commands/resolve_990_batches.py
+++ b/lavandula/dashboard/pipeline/management/commands/resolve_990_batches.py
@@ -1,0 +1,339 @@
+"""Resolve xml_batch_id for 2017-2023 filings via zip central directory scan (Spec 0030).
+
+For filings where xml_batch_id IS NULL, probes IRS batch zips to find which
+batch contains each object_id. Uses HTTP Range requests when supported to read
+only the zip central directory, falling back to full download otherwise.
+
+Usage:
+    python3 manage.py resolve_990_batches               # all years with NULL batch IDs
+    python3 manage.py resolve_990_batches --years 2022  # specific year
+"""
+from __future__ import annotations
+
+import io
+import ipaddress
+import logging
+import re
+import socket
+import struct
+import tempfile
+import time
+import zipfile
+from urllib.parse import urlparse
+
+import requests
+from django.core.management.base import BaseCommand
+from sqlalchemy import text
+
+from lavandula.common.db import make_app_engine
+
+log = logging.getLogger(__name__)
+
+TEOS_ZIP_URL = (
+    "https://apps.irs.gov/pub/epostcard/990/xml/{year}/{batch_id}.zip"
+)
+
+_BATCH_ID_RE = re.compile(r"^\d{4}_TEOS_XML_(0[1-9]|1[0-2])[A-D]$", re.ASCII)
+_MEMBER_OID_RE = re.compile(r"^(?:[\w]+/)?(\d+)_public\.xml$", re.ASCII)
+_LOCK_KEY = "990-family"
+
+_EOCD_SIZE = 22
+_EOCD_SIGNATURE = b"PK\x05\x06"
+_EOCD64_LOCATOR_SIGNATURE = b"PK\x06\x07"
+_EOCD64_SIGNATURE = b"PK\x06\x06"
+_MAX_TAIL_READ = 65536
+
+
+def _resolve_and_check_host(hostname: str) -> None:
+    try:
+        addrs = socket.getaddrinfo(hostname, None)
+    except socket.gaierror:
+        raise ValueError(f"Cannot resolve hostname: {hostname}")
+    for _, _, _, _, sockaddr in addrs:
+        ip = ipaddress.ip_address(sockaddr[0])
+        if ip.is_private or ip.is_loopback or ip.is_link_local:
+            raise ValueError(f"Hostname resolves to private IP: {ip}")
+
+
+def _enumerate_batch_ids(year: int) -> list[str]:
+    """Generate all possible batch IDs for a year."""
+    ids = []
+    for month in range(1, 13):
+        for suffix in "ABCD":
+            ids.append(f"{year}_TEOS_XML_{month:02d}{suffix}")
+    return ids
+
+
+def _probe_range_support(url: str) -> bool:
+    """Check if server supports HTTP Range requests."""
+    resp = requests.head(url, timeout=30, allow_redirects=False)
+    if resp.status_code in (301, 302, 303, 307, 308):
+        return False
+    if resp.status_code != 200:
+        return False
+    accept_ranges = resp.headers.get("Accept-Ranges", "").lower()
+    return accept_ranges == "bytes"
+
+
+def _get_content_length(url: str) -> int | None:
+    """Get file size via HEAD request."""
+    resp = requests.head(url, timeout=30, allow_redirects=False)
+    if resp.status_code != 200:
+        return None
+    cl = resp.headers.get("Content-Length")
+    return int(cl) if cl else None
+
+
+def _read_central_directory_via_range(url: str) -> list[str] | None:
+    """Read zip central directory using Range requests. Returns member filenames."""
+    file_size = _get_content_length(url)
+    if file_size is None:
+        return None
+
+    tail_size = min(_MAX_TAIL_READ, file_size)
+    start = file_size - tail_size
+    resp = requests.get(
+        url,
+        headers={"Range": f"bytes={start}-{file_size - 1}"},
+        timeout=60,
+        allow_redirects=False,
+    )
+
+    if resp.status_code != 206:
+        return None
+
+    if len(resp.content) > _MAX_TAIL_READ:
+        return None
+
+    tail = resp.content
+
+    eocd_offset = tail.rfind(_EOCD_SIGNATURE)
+    if eocd_offset == -1:
+        return None
+
+    cd_offset = None
+    cd_size = None
+
+    loc_offset = tail.rfind(_EOCD64_LOCATOR_SIGNATURE)
+    if loc_offset != -1 and loc_offset + 20 <= len(tail):
+        eocd64_abs_offset = struct.unpack_from("<Q", tail, loc_offset + 8)[0]
+        if eocd64_abs_offset >= start:
+            eocd64_rel = eocd64_abs_offset - start
+            if (eocd64_rel + 56 <= len(tail) and
+                    tail[eocd64_rel:eocd64_rel + 4] == _EOCD64_SIGNATURE):
+                cd_size = struct.unpack_from("<Q", tail, eocd64_rel + 40)[0]
+                cd_offset = struct.unpack_from("<Q", tail, eocd64_rel + 48)[0]
+
+    if cd_offset is None:
+        cd_size = struct.unpack_from("<I", tail, eocd_offset + 12)[0]
+        cd_offset = struct.unpack_from("<I", tail, eocd_offset + 16)[0]
+        if cd_offset == 0xFFFFFFFF or cd_size == 0xFFFFFFFF:
+            return None
+
+    cd_resp = requests.get(
+        url,
+        headers={"Range": f"bytes={cd_offset}-{cd_offset + cd_size - 1}"},
+        timeout=120,
+        allow_redirects=False,
+    )
+    if cd_resp.status_code != 206:
+        return None
+
+    cd_data = cd_resp.content
+    filenames = []
+    pos = 0
+    while pos + 46 <= len(cd_data):
+        sig = cd_data[pos:pos + 4]
+        if sig != b"PK\x01\x02":
+            break
+        name_len = struct.unpack_from("<H", cd_data, pos + 28)[0]
+        extra_len = struct.unpack_from("<H", cd_data, pos + 30)[0]
+        comment_len = struct.unpack_from("<H", cd_data, pos + 32)[0]
+        name_start = pos + 46
+        name_end = name_start + name_len
+        if name_end > len(cd_data):
+            break
+        filename = cd_data[name_start:name_end].decode("utf-8", errors="replace")
+        filenames.append(filename)
+        pos = name_end + extra_len + comment_len
+
+    return filenames
+
+
+def _read_central_directory_full_download(url: str) -> list[str] | None:
+    """Download full zip to temp file and read member list."""
+    resp = requests.get(url, stream=True, timeout=300, allow_redirects=False)
+    if resp.status_code != 200:
+        return None
+
+    with tempfile.NamedTemporaryFile(suffix=".zip", delete=True) as tmp:
+        for chunk in resp.iter_content(chunk_size=65536):
+            tmp.write(chunk)
+        tmp.flush()
+
+        try:
+            with zipfile.ZipFile(tmp.name) as zf:
+                return zf.namelist()
+        except zipfile.BadZipFile:
+            return None
+
+
+def _extract_object_ids(filenames: list[str]) -> dict[str, str]:
+    """Map object_id -> member_name from zip member filenames."""
+    mapping = {}
+    for fn in filenames:
+        m = _MEMBER_OID_RE.match(fn)
+        if m:
+            mapping[m.group(1)] = fn
+    return mapping
+
+
+class Command(BaseCommand):
+    help = "Resolve xml_batch_id for filings where it is NULL (2017-2023)"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--years",
+            type=str,
+            default=None,
+            help="Comma-separated years to resolve (default: all with NULL batch IDs)",
+        )
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Show what would be done without updating the database",
+        )
+
+    def handle(self, *args, **options):
+        engine = make_app_engine()
+
+        if options["years"]:
+            years = [int(y.strip()) for y in options["years"].split(",")]
+        else:
+            with engine.connect() as conn:
+                rows = conn.execute(text("""
+                    SELECT DISTINCT filing_year
+                    FROM lava_corpus.filing_index
+                    WHERE xml_batch_id IS NULL AND status != 'batch_unresolvable'
+                    ORDER BY filing_year
+                """)).fetchall()
+                years = [r[0] for r in rows]
+
+        if not years:
+            self.stdout.write("No years with unresolved batch IDs.")
+            return
+
+        self.stdout.write(f"Resolving batch IDs for years: {years}")
+
+        with engine.connect() as conn:
+            conn.execute(
+                text("SELECT pg_advisory_lock(hashtext(:key))"),
+                {"key": _LOCK_KEY},
+            )
+            conn.commit()
+
+        try:
+            probe_url = TEOS_ZIP_URL.format(
+                year=years[0],
+                batch_id=f"{years[0]}_TEOS_XML_01A",
+            )
+            parsed = urlparse(probe_url)
+            _resolve_and_check_host(parsed.hostname)
+            range_supported = _probe_range_support(probe_url)
+            self.stdout.write(
+                f"HTTP Range support: {'yes' if range_supported else 'no'}"
+            )
+
+            for year in sorted(years):
+                self._resolve_year(
+                    engine, year, range_supported, options["dry_run"]
+                )
+        finally:
+            with engine.connect() as conn:
+                conn.execute(
+                    text("SELECT pg_advisory_unlock(hashtext(:key))"),
+                    {"key": _LOCK_KEY},
+                )
+                conn.commit()
+
+    def _resolve_year(
+        self, engine, year: int, range_supported: bool, dry_run: bool
+    ):
+        self.stdout.write(f"\nYear {year}:")
+
+        with engine.connect() as conn:
+            unresolved = conn.execute(text("""
+                SELECT COUNT(*)
+                FROM lava_corpus.filing_index
+                WHERE filing_year = :year AND xml_batch_id IS NULL
+                  AND status != 'batch_unresolvable'
+            """), {"year": year}).scalar()
+
+        if unresolved == 0:
+            self.stdout.write(f"  No unresolved filings for {year}")
+            return
+
+        self.stdout.write(f"  {unresolved} filings need batch resolution")
+
+        batch_ids = _enumerate_batch_ids(year)
+        total_resolved = 0
+
+        for batch_id in batch_ids:
+            url = TEOS_ZIP_URL.format(year=year, batch_id=batch_id)
+
+            head_resp = requests.head(url, timeout=30, allow_redirects=False)
+            if head_resp.status_code != 200:
+                continue
+
+            self.stdout.write(f"  Scanning {batch_id}...")
+
+            if range_supported:
+                filenames = _read_central_directory_via_range(url)
+            else:
+                filenames = _read_central_directory_full_download(url)
+
+            if filenames is None:
+                self.stdout.write(f"    Failed to read central directory")
+                continue
+
+            oid_map = _extract_object_ids(filenames)
+            self.stdout.write(
+                f"    {len(oid_map)} XML members found"
+            )
+
+            if not oid_map or dry_run:
+                if dry_run and oid_map:
+                    total_resolved += len(oid_map)
+                continue
+
+            oid_list = list(oid_map.keys())
+            with engine.begin() as conn:
+                result = conn.execute(text("""
+                    UPDATE lava_corpus.filing_index
+                    SET xml_batch_id = :batch_id
+                    WHERE object_id = ANY(:oids)
+                      AND xml_batch_id IS NULL
+                """), {"batch_id": batch_id, "oids": oid_list})
+                total_resolved += result.rowcount
+
+            time.sleep(1)
+
+        if not dry_run:
+            with engine.begin() as conn:
+                result = conn.execute(text("""
+                    UPDATE lava_corpus.filing_index
+                    SET status = 'batch_unresolvable'
+                    WHERE filing_year = :year
+                      AND xml_batch_id IS NULL
+                      AND status = 'indexed'
+                """), {"year": year})
+                unresolvable = result.rowcount
+
+            self.stdout.write(
+                f"  Year {year}: resolved={total_resolved} "
+                f"unresolvable={unresolvable}"
+            )
+        else:
+            self.stdout.write(
+                f"  Year {year}: would resolve ~{total_resolved} (dry run)"
+            )

--- a/lavandula/dashboard/pipeline/models.py
+++ b/lavandula/dashboard/pipeline/models.py
@@ -56,6 +56,15 @@ class CrawledOrg(models.Model):
 
 
 class FilingIndex(models.Model):
+    STATUS_CHOICES = [
+        ("indexed", "Indexed"),
+        ("downloaded", "Downloaded"),
+        ("parsed", "Parsed"),
+        ("error", "Error"),
+        ("batch_unresolvable", "Batch Unresolvable"),
+        ("skipped", "Skipped"),
+    ]
+
     object_id = models.CharField(primary_key=True, max_length=30)
     ein = models.CharField(max_length=9)
     tax_period = models.CharField(max_length=6)
@@ -66,10 +75,14 @@ class FilingIndex(models.Model):
     taxpayer_name = models.TextField(null=True)
     xml_batch_id = models.CharField(max_length=30, null=True)
     filing_year = models.IntegerField()
-    status = models.CharField(max_length=20)
+    status = models.CharField(max_length=20, choices=STATUS_CHOICES)
     error_message = models.TextField(null=True)
     parsed_at = models.DateTimeField(null=True)
     run_id = models.CharField(max_length=50, null=True)
+    first_indexed_at = models.DateTimeField(null=True)
+    last_seen_at = models.DateTimeField(null=True)
+    s3_xml_key = models.TextField(null=True)
+    zip_checksum = models.TextField(null=True)
 
     class Meta:
         managed = False
@@ -77,6 +90,22 @@ class FilingIndex(models.Model):
 
     def __str__(self):
         return f"{self.object_id} ({self.ein} {self.tax_period})"
+
+
+class IndexRefreshLog(models.Model):
+    filing_year = models.IntegerField()
+    refreshed_at = models.DateTimeField()
+    rows_scanned = models.IntegerField(default=0)
+    rows_inserted = models.IntegerField(default=0)
+    rows_skipped = models.IntegerField(default=0)
+    duration_sec = models.DecimalField(max_digits=8, decimal_places=2, null=True)
+
+    class Meta:
+        managed = False
+        db_table = "index_refresh_log"
+
+    def __str__(self):
+        return f"Refresh {self.filing_year} @ {self.refreshed_at}"
 
 
 class Person(models.Model):

--- a/lavandula/dashboard/pipeline/orchestrator.py
+++ b/lavandula/dashboard/pipeline/orchestrator.py
@@ -73,17 +73,16 @@ COMMAND_MAP: dict[str, dict[str, Any]] = {
             "re_classify_definition": {"type": "text", "pattern": r"^[a-z][a-z0-9_]*:v\d+$", "flag": "--re-classify-definition"},
         },
     },
-    # Legacy: kept for historical job display only. No dashboard UI creates 990-enrich jobs.
+    # Deprecated: enrich_990 now delegates to load_990_index + process_990_auto.
+    # Kept for historical job display only. No dashboard UI creates 990-enrich jobs.
     "990-enrich": {
         "cmd": ["python3", "-m", "lavandula.nonprofits.tools.enrich_990"],
         "params": {
-            "state": {"type": "choice", "choices": US_STATES, "flag": "--state"},
-            "years": {"type": "text", "pattern": r"^\d{4}(\s*,\s*\d{4})*$", "flag": "--years"},
-            "limit": {"type": "int", "min": 1, "max": 999999, "flag": "--limit"},
+            "ein": {"type": "text", "pattern": r"^\d{9}$", "flag": "--ein"},
         },
     },
     "990-index": {
-        "cmd": ["python3", "manage.py", "load_990_index"],
+        "cmd": ["python3", "lavandula/dashboard/manage.py", "load_990_index"],
         "params": {
             "ein": {"type": "text", "pattern": r"^\d{9}$", "flag": "--ein"},
             "years": {"type": "text", "pattern": r"^\d{4}(\s*,\s*\d{4})*$", "flag": "--years"},
@@ -91,7 +90,7 @@ COMMAND_MAP: dict[str, dict[str, Any]] = {
         },
     },
     "990-parse": {
-        "cmd": ["python3", "manage.py", "process_990_auto"],
+        "cmd": ["python3", "lavandula/dashboard/manage.py", "process_990_auto"],
         "params": {
             "ein": {"type": "text", "pattern": r"^\d{9}$", "flag": "--ein"},
             "reparse": {"type": "bool", "flag": "--reparse"},

--- a/lavandula/dashboard/pipeline/orchestrator.py
+++ b/lavandula/dashboard/pipeline/orchestrator.py
@@ -87,6 +87,7 @@ COMMAND_MAP: dict[str, dict[str, Any]] = {
         "params": {
             "ein": {"type": "text", "pattern": r"^\d{9}$", "flag": "--ein"},
             "years": {"type": "text", "pattern": r"^\d{4}(\s*,\s*\d{4})*$", "flag": "--years"},
+            "current_year": {"type": "bool", "flag": "--current-year"},
         },
     },
     "990-parse": {

--- a/lavandula/dashboard/pipeline/orchestrator.py
+++ b/lavandula/dashboard/pipeline/orchestrator.py
@@ -83,22 +83,18 @@ COMMAND_MAP: dict[str, dict[str, Any]] = {
         },
     },
     "990-index": {
-        "cmd": ["python3", "-m", "lavandula.nonprofits.tools.enrich_990", "--index-only"],
+        "cmd": ["python3", "manage.py", "load_990_index"],
         "params": {
-            "state": {"type": "choice", "choices": US_STATES, "flag": "--state"},
             "ein": {"type": "text", "pattern": r"^\d{9}$", "flag": "--ein"},
             "years": {"type": "text", "pattern": r"^\d{4}(\s*,\s*\d{4})*$", "flag": "--years"},
         },
     },
     "990-parse": {
-        "cmd": ["python3", "-m", "lavandula.nonprofits.tools.enrich_990", "--parse-only"],
+        "cmd": ["python3", "manage.py", "process_990_auto"],
         "params": {
-            "state": {"type": "choice", "choices": US_STATES, "flag": "--state"},
             "ein": {"type": "text", "pattern": r"^\d{9}$", "flag": "--ein"},
-            "years": {"type": "text", "pattern": r"^\d{4}(\s*,\s*\d{4})*$", "flag": "--years"},
-            "limit": {"type": "int", "min": 1, "max": 999999, "flag": "--limit"},
-            "skip_download": {"type": "bool", "flag": "--skip-download"},
             "reparse": {"type": "bool", "flag": "--reparse"},
+            "backfill": {"type": "bool", "flag": "--backfill"},
         },
     },
 }

--- a/lavandula/dashboard/pipeline/templates/pipeline/990_index.html
+++ b/lavandula/dashboard/pipeline/templates/pipeline/990_index.html
@@ -4,6 +4,20 @@
 {% block content %}
 <h1 class="text-2xl font-bold text-gray-900 mb-6">990 Index Controls</h1>
 
+{% if last_refresh %}
+<div class="bg-green-50 border border-green-200 rounded-lg p-4 mb-6">
+  <div class="flex items-center justify-between">
+    <div>
+      <span class="text-sm font-medium text-green-800">Last index refresh:</span>
+      <span class="text-sm text-green-700">{{ last_refresh.refreshed_at }} (year {{ last_refresh.filing_year }})</span>
+    </div>
+    <div class="text-sm text-green-700">
+      {{ total_filings|default:"0" }} total filings indexed
+    </div>
+  </div>
+</div>
+{% endif %}
+
 <div class="grid grid-cols-1 lg:grid-cols-3 gap-6">
   <!-- Status + Form -->
   <div class="space-y-4">
@@ -43,24 +57,44 @@
   </div>
 
   <!-- Filing Counts -->
-  <div class="lg:col-span-2 bg-white rounded-lg shadow p-5">
-    <h2 class="text-lg font-semibold text-gray-900 mb-3">
-      Filing Index Counts
-      {% if scoped %}<span class="text-sm font-normal text-gray-500">(filtered)</span>{% else %}<span class="text-sm font-normal text-gray-500">(global)</span>{% endif %}
-    </h2>
-    <div class="grid grid-cols-2 md:grid-cols-4 gap-4 mb-4">
-      {% for sc in status_counts %}
-      <div class="border rounded p-3 text-center">
-        <span class="inline-block px-2 py-0.5 rounded text-xs font-medium {{ sc.status|filing_badge }}">{{ sc.status }}</span>
-        <div class="text-2xl font-bold mt-1">{{ sc.count|default:"0" }}</div>
+  <div class="lg:col-span-2 space-y-6">
+    <div class="bg-white rounded-lg shadow p-5">
+      <h2 class="text-lg font-semibold text-gray-900 mb-3">Filing Index Counts</h2>
+      <div class="grid grid-cols-2 md:grid-cols-4 gap-4 mb-4">
+        {% for sc in status_counts %}
+        <div class="border rounded p-3 text-center">
+          <span class="inline-block px-2 py-0.5 rounded text-xs font-medium {{ sc.status|filing_badge }}">{{ sc.status }}</span>
+          <div class="text-2xl font-bold mt-1">{{ sc.count|default:"0" }}</div>
+        </div>
+        {% empty %}
+        <div class="col-span-4 text-gray-500 text-sm">No filings found.</div>
+        {% endfor %}
       </div>
-      {% empty %}
-      <div class="col-span-4 text-gray-500 text-sm">No filings found.</div>
-      {% endfor %}
+      <p class="text-sm text-gray-500">Total filings: {{ total_filings }}</p>
     </div>
-    <p class="text-sm text-gray-500">Total filings: {{ total_filings }}</p>
-    {% if scope_truncated %}
-    <p class="text-sm text-amber-600 mt-2">Counts are approximate — state has more than 10,000 orgs; results are capped.</p>
+
+    {% if refresh_by_year %}
+    <div class="bg-white rounded-lg shadow p-5">
+      <h2 class="text-lg font-semibold text-gray-900 mb-3">Index Refresh History</h2>
+      <table class="w-full text-sm">
+        <thead>
+          <tr class="text-left text-gray-500 border-b">
+            <th class="pb-2">Year</th>
+            <th class="pb-2">Last Refresh</th>
+            <th class="pb-2 text-right">Filings Loaded</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for row in refresh_by_year %}
+          <tr class="border-b border-gray-100">
+            <td class="py-2 font-medium">{{ row.filing_year }}</td>
+            <td class="py-2 text-gray-600">{{ row.last_refresh|default:"Never" }}</td>
+            <td class="py-2 text-right">{{ row.total_inserted|default:"0" }}</td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
     {% endif %}
   </div>
 </div>

--- a/lavandula/dashboard/pipeline/templates/pipeline/990_parse.html
+++ b/lavandula/dashboard/pipeline/templates/pipeline/990_parse.html
@@ -26,11 +26,7 @@
       </div>
       {% endif %}
       <div class="mt-3 text-sm text-gray-500">
-        {% if cache_count is not None %}
-        Cache: {{ cache_count }} zips, {{ cache_size_gb|floatformat:1 }} GB
-        {% else %}
-        Cache: unavailable
-        {% endif %}
+        Storage: S3 (lavandula-990-corpus)
       </div>
     </div>
 
@@ -51,10 +47,7 @@
 
   <!-- Filing Counts + People -->
   <div class="lg:col-span-2 bg-white rounded-lg shadow p-5">
-    <h2 class="text-lg font-semibold text-gray-900 mb-3">
-      Filing &amp; People Counts
-      {% if scoped %}<span class="text-sm font-normal text-gray-500">(filtered)</span>{% else %}<span class="text-sm font-normal text-gray-500">(global)</span>{% endif %}
-    </h2>
+    <h2 class="text-lg font-semibold text-gray-900 mb-3">Filing &amp; People Counts</h2>
     <div class="grid grid-cols-2 md:grid-cols-4 gap-4 mb-4">
       {% for sc in status_counts %}
       <div class="border rounded p-3 text-center">
@@ -69,9 +62,6 @@
       <span>Total filings: {{ total_filings }}</span>
       <span>Total people: {{ people_count }}</span>
     </div>
-    {% if scope_truncated %}
-    <p class="text-sm text-amber-600 mt-2">Counts are approximate — state has more than 10,000 orgs; results are capped.</p>
-    {% endif %}
   </div>
 </div>
 {% endblock %}

--- a/lavandula/dashboard/pipeline/views.py
+++ b/lavandula/dashboard/pipeline/views.py
@@ -2,6 +2,7 @@ import socket
 
 from django.contrib import messages
 from django.contrib.auth.mixins import LoginRequiredMixin
+from django.db import models
 from django.db.models import Count, Q
 from django.http import HttpResponse, HttpResponseRedirect
 from django.shortcuts import get_object_or_404, redirect
@@ -23,6 +24,7 @@ class HtmxLoginRequiredMixin(LoginRequiredMixin):
 from .models import (
     CrawledOrg,
     FilingIndex,
+    IndexRefreshLog,
     Job,
     NonprofitSeed,
     Person,
@@ -559,37 +561,6 @@ class OrgDetailView(LoginRequiredMixin, DetailView):
 # 990 Pipeline Controls
 # ---------------------------------------------------------------------------
 
-def _build_990_status_qs(request, form_cls):
-    """Build scoped filing_index queryset from GET params, validated via form."""
-    scope_form = form_cls(request.GET)
-    if scope_form.is_valid():
-        state = scope_form.cleaned_data.get("state") or None
-        ein = scope_form.cleaned_data.get("ein") or None
-        years_param = scope_form.cleaned_data.get("years") or None
-    else:
-        state = ein = years_param = None
-
-    qs = FilingIndex.objects.using("pipeline").all()
-    scoped = bool(state or ein or years_param)
-    scope_truncated = False
-
-    if scoped:
-        if ein:
-            qs = qs.filter(ein=ein)
-        elif state:
-            ein_list = list(
-                NonprofitSeed.objects.filter(state=state)
-                .values_list("ein", flat=True)[:10000]
-            )
-            if len(ein_list) >= 10000:
-                scope_truncated = True
-            qs = qs.filter(ein__in=ein_list)
-        if years_param:
-            year_list = [int(y) for y in years_param.split(",") if y.strip().isdigit()]
-            qs = qs.filter(filing_year__in=year_list)
-
-    return qs, scoped, scope_truncated
-
 
 class EnrichIndexView(LoginRequiredMixin, TemplateView):
     template_name = "pipeline/990_index.html"
@@ -601,11 +572,30 @@ class EnrichIndexView(LoginRequiredMixin, TemplateView):
         from .forms import EnrichIndexForm
         ctx["form"] = EnrichIndexForm()
 
-        qs, scoped, scope_truncated = _build_990_status_qs(self.request, EnrichIndexForm)
+        qs = FilingIndex.objects.using("pipeline").all()
+        ein = self.request.GET.get("ein")
+        if ein:
+            qs = qs.filter(ein=ein)
         ctx["status_counts"] = list(qs.values("status").annotate(count=Count("status")))
         ctx["total_filings"] = qs.count()
-        ctx["scoped"] = scoped
-        ctx["scope_truncated"] = scope_truncated
+
+        try:
+            last_refresh = IndexRefreshLog.objects.using("pipeline").order_by(
+                "-refreshed_at"
+            ).first()
+            ctx["last_refresh"] = last_refresh
+        except Exception:
+            ctx["last_refresh"] = None
+
+        ctx["refresh_by_year"] = list(
+            IndexRefreshLog.objects.using("pipeline")
+            .values("filing_year")
+            .annotate(
+                last_refresh=models.Max("refreshed_at"),
+                total_inserted=models.Sum("rows_inserted"),
+            )
+            .order_by("-filing_year")
+        )
         return ctx
 
 
@@ -628,10 +618,6 @@ class EnrichIndexJobCreateView(LoginRequiredMixin, View):
         params = {}
         if config.get("ein"):
             params["ein"] = config["ein"]
-        elif config.get("state"):
-            params["state"] = config["state"]
-        if config.get("years"):
-            params["years"] = config["years"]
         if params:
             from urllib.parse import urlencode
             return redirect(f"{reverse('enrich_index')}?{urlencode(params)}")
@@ -642,57 +628,23 @@ class EnrichParseView(LoginRequiredMixin, TemplateView):
     template_name = "pipeline/990_parse.html"
 
     def get_context_data(self, **kwargs):
-        from pathlib import Path
-
         ctx = super().get_context_data(**kwargs)
         ctx["running_job"] = Job.objects.filter(phase="990-parse", status="running").first()
         ctx["pending_job"] = Job.objects.filter(phase="990-parse", status="pending").first()
         from .forms import EnrichParseForm
         ctx["form"] = EnrichParseForm()
 
-        qs, scoped, scope_truncated = _build_990_status_qs(self.request, EnrichParseForm)
+        qs = FilingIndex.objects.using("pipeline").all()
+        ein = self.request.GET.get("ein")
+        if ein:
+            qs = qs.filter(ein=ein)
         ctx["status_counts"] = list(qs.values("status").annotate(count=Count("status")))
         ctx["total_filings"] = qs.count()
-        ctx["scoped"] = scoped
-        ctx["scope_truncated"] = scope_truncated
 
-        # People count (scoped same way)
         people_qs = Person.objects.using("pipeline").all()
-        scope_form = EnrichParseForm(self.request.GET)
-        if scope_form.is_valid():
-            ein = scope_form.cleaned_data.get("ein") or None
-            state = scope_form.cleaned_data.get("state") or None
-            years_param = scope_form.cleaned_data.get("years") or None
-        else:
-            ein = state = years_param = None
-
         if ein:
             people_qs = people_qs.filter(ein=ein)
-        elif state:
-            ein_list = list(
-                NonprofitSeed.objects.filter(state=state)
-                .values_list("ein", flat=True)[:10000]
-            )
-            if len(ein_list) >= 10000:
-                ctx["scope_truncated"] = True
-            people_qs = people_qs.filter(ein__in=ein_list)
-        if years_param:
-            year_list = [y.strip() for y in years_param.split(",") if y.strip().isdigit()]
-            year_q = Q()
-            for y in year_list:
-                year_q |= Q(tax_period__startswith=y)
-            if year_q:
-                people_qs = people_qs.filter(year_q)
         ctx["people_count"] = people_qs.count()
-
-        # Cache status
-        cache_dir = Path.home() / ".lavandula" / "990-cache"
-        try:
-            zips = list(cache_dir.glob("*.zip"))
-            ctx["cache_count"] = len(zips)
-            ctx["cache_size_gb"] = sum(f.stat().st_size for f in zips) / (1024 ** 3)
-        except (OSError, PermissionError):
-            ctx["cache_count"] = None
 
         return ctx
 
@@ -716,10 +668,6 @@ class EnrichParseJobCreateView(LoginRequiredMixin, View):
         params = {}
         if config.get("ein"):
             params["ein"] = config["ein"]
-        elif config.get("state"):
-            params["state"] = config["state"]
-        if config.get("years"):
-            params["years"] = config["years"]
         if params:
             from urllib.parse import urlencode
             return redirect(f"{reverse('enrich_parse')}?{urlencode(params)}")

--- a/lavandula/migrations/rds/migration_011_990_index_automation.sql
+++ b/lavandula/migrations/rds/migration_011_990_index_automation.sql
@@ -1,0 +1,64 @@
+-- Migration 011: 990 Filing Index Automation & S3 Archive (Spec 0030)
+--
+-- Adds columns to filing_index for automation tracking, creates
+-- index_refresh_log and filing_status_audit tables.
+
+BEGIN;
+
+-- Allow NULL xml_batch_id for 2017-2023 filings (already nullable from 010
+-- CREATE TABLE, but ensure it's explicit)
+ALTER TABLE lava_corpus.filing_index
+  ALTER COLUMN xml_batch_id DROP NOT NULL;
+
+-- New columns for automation.
+-- first_indexed_at/last_seen_at added WITHOUT defaults so existing rows get NULL.
+-- The bulk loader sets first_indexed_at = now() on INSERT and last_seen_at = now()
+-- on both INSERT and UPDATE.
+ALTER TABLE lava_corpus.filing_index
+  ADD COLUMN IF NOT EXISTS first_indexed_at TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS last_seen_at TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS s3_xml_key TEXT,
+  ADD COLUMN IF NOT EXISTS zip_checksum TEXT;
+
+-- Index for incremental processing window queries
+CREATE INDEX IF NOT EXISTS idx_filing_first_indexed
+  ON lava_corpus.filing_index(first_indexed_at)
+  WHERE first_indexed_at IS NOT NULL;
+
+-- Index for auto-process worker joins
+CREATE INDEX IF NOT EXISTS idx_filing_status_batch
+  ON lava_corpus.filing_index(status, xml_batch_id)
+  WHERE status = 'indexed' AND xml_batch_id IS NOT NULL;
+
+-- Refresh log: one row per year per loader run
+CREATE TABLE IF NOT EXISTS lava_corpus.index_refresh_log (
+    id              SERIAL PRIMARY KEY,
+    filing_year     INTEGER NOT NULL,
+    refreshed_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+    rows_scanned    INTEGER NOT NULL DEFAULT 0,
+    rows_inserted   INTEGER NOT NULL DEFAULT 0,
+    rows_skipped    INTEGER NOT NULL DEFAULT 0,
+    duration_sec    NUMERIC(8,2)
+);
+
+-- Audit log for status resets
+CREATE TABLE IF NOT EXISTS lava_corpus.filing_status_audit (
+    id              SERIAL PRIMARY KEY,
+    filing_id       TEXT NOT NULL,
+    old_status      TEXT NOT NULL,
+    new_status      TEXT NOT NULL,
+    reset_by        TEXT NOT NULL,
+    reset_at        TIMESTAMPTZ NOT NULL DEFAULT now(),
+    command_args    TEXT
+);
+
+-- GRANTs
+GRANT SELECT, INSERT ON lava_corpus.index_refresh_log TO app_user1;
+GRANT SELECT ON lava_corpus.index_refresh_log TO ro_user1;
+GRANT USAGE, SELECT ON SEQUENCE lava_corpus.index_refresh_log_id_seq TO app_user1;
+
+GRANT SELECT, INSERT ON lava_corpus.filing_status_audit TO app_user1;
+GRANT SELECT ON lava_corpus.filing_status_audit TO ro_user1;
+GRANT USAGE, SELECT ON SEQUENCE lava_corpus.filing_status_audit_id_seq TO app_user1;
+
+COMMIT;

--- a/lavandula/nonprofits/s3_990.py
+++ b/lavandula/nonprofits/s3_990.py
@@ -1,0 +1,215 @@
+"""S3-backed archive for IRS 990 corpus (Spec 0030).
+
+Manages batch zips and extracted per-org XML files in the
+lavandula-990-corpus bucket. All keys are validated against strict
+patterns to prevent path traversal or SSRF via crafted inputs.
+
+Bucket structure:
+    s3://lavandula-990-corpus/
+      zips/{year}/{batch_id}.zip
+      xml/{ein}/{object_id}.xml
+"""
+from __future__ import annotations
+
+import io
+import logging
+import os
+import re
+import tempfile
+from typing import IO
+
+import boto3
+from botocore.config import Config
+from botocore.exceptions import ClientError
+
+log = logging.getLogger(__name__)
+
+_EIN_RE = re.compile(r"^\d{9}$", re.ASCII)
+_OBJECT_ID_RE = re.compile(r"^\d+$", re.ASCII)
+_BATCH_ID_RE = re.compile(r"^\d{4}_TEOS_XML_(0[1-9]|1[0-2])[A-D]$", re.ASCII)
+
+_DEFAULT_BUCKET = "lavandula-990-corpus"
+_MULTIPART_THRESHOLD = 100 * 1024 * 1024  # 100 MB
+_SPILL_THRESHOLD = 500 * 1024 * 1024  # 500 MB
+
+
+def _validate_ein(ein: str) -> None:
+    if not _EIN_RE.match(ein):
+        raise ValueError(f"Invalid EIN: {ein!r}")
+
+
+def _validate_object_id(object_id: str) -> None:
+    if not _OBJECT_ID_RE.match(object_id):
+        raise ValueError(f"Invalid object_id: {object_id!r}")
+
+
+def _validate_batch_id(batch_id: str) -> None:
+    if not _BATCH_ID_RE.match(batch_id):
+        raise ValueError(f"Invalid batch_id: {batch_id!r}")
+
+
+def _validate_year(year: int) -> None:
+    if not (2017 <= year <= 2099):
+        raise ValueError(f"Invalid year: {year}")
+
+
+class S3990Archive:
+    """S3 client for the 990 corpus bucket."""
+
+    def __init__(
+        self,
+        bucket: str = _DEFAULT_BUCKET,
+        *,
+        endpoint_url: str | None = None,
+        client=None,
+    ):
+        self.bucket = bucket
+        effective_endpoint = (
+            endpoint_url
+            if endpoint_url is not None
+            else os.getenv("LAVANDULA_S3_ENDPOINT_URL")
+        )
+        self._client = client if client is not None else self._make_client(
+            effective_endpoint
+        )
+
+    @staticmethod
+    def _make_client(endpoint_url: str | None):
+        cfg = Config(retries={"max_attempts": 3, "mode": "standard"})
+        return boto3.client(
+            "s3",
+            region_name="us-east-1",
+            endpoint_url=endpoint_url,
+            config=cfg,
+        )
+
+    def _zip_key(self, year: int, batch_id: str) -> str:
+        _validate_year(year)
+        _validate_batch_id(batch_id)
+        return f"zips/{year}/{batch_id}.zip"
+
+    def _xml_key(self, ein: str, object_id: str) -> str:
+        _validate_ein(ein)
+        _validate_object_id(object_id)
+        return f"xml/{ein}/{object_id}.xml"
+
+    def zip_exists(self, year: int, batch_id: str) -> bool:
+        """HEAD check for cached batch zip."""
+        key = self._zip_key(year, batch_id)
+        try:
+            self._client.head_object(Bucket=self.bucket, Key=key)
+            return True
+        except ClientError as e:
+            code = e.response.get("Error", {}).get("Code", "")
+            if code in ("404", "NoSuchKey", "NotFound"):
+                return False
+            raise
+
+    def upload_zip(
+        self, year: int, batch_id: str, stream: IO[bytes]
+    ) -> str:
+        """Upload IRS batch zip to S3. Returns ChecksumSHA256."""
+        key = self._zip_key(year, batch_id)
+
+        data = stream.read()
+        resp = self._client.put_object(
+            Bucket=self.bucket,
+            Key=key,
+            Body=data,
+            ServerSideEncryption="AES256",
+            ChecksumAlgorithm="SHA256",
+        )
+
+        checksum = resp.get("ChecksumSHA256")
+        if not checksum:
+            raise RuntimeError(
+                f"S3 did not return ChecksumSHA256 for {key}"
+            )
+        return checksum
+
+    def verify_zip_integrity(
+        self, year: int, batch_id: str, expected_checksum: str
+    ) -> bool:
+        """Verify cached zip integrity via ChecksumSHA256 comparison."""
+        key = self._zip_key(year, batch_id)
+        try:
+            resp = self._client.head_object(
+                Bucket=self.bucket,
+                Key=key,
+                ChecksumMode="ENABLED",
+            )
+        except ClientError:
+            return False
+
+        actual = resp.get("ChecksumSHA256", "")
+        return actual == expected_checksum
+
+    def open_zip(self, year: int, batch_id: str) -> IO[bytes]:
+        """Download zip from S3 into a file-like object.
+
+        Small zips (<500 MB) stay in memory. Large ones spill to a temp file.
+        """
+        key = self._zip_key(year, batch_id)
+
+        resp = self._client.head_object(Bucket=self.bucket, Key=key)
+        size = resp.get("ContentLength", 0)
+
+        get_resp = self._client.get_object(Bucket=self.bucket, Key=key)
+        body = get_resp["Body"]
+
+        if size <= _SPILL_THRESHOLD:
+            buf = io.BytesIO()
+            for chunk in body.iter_chunks(chunk_size=65536):
+                buf.write(chunk)
+            buf.seek(0)
+            return buf
+        else:
+            tmp = tempfile.SpooledTemporaryFile(
+                max_size=_SPILL_THRESHOLD, mode="w+b"
+            )
+            for chunk in body.iter_chunks(chunk_size=65536):
+                tmp.write(chunk)
+            tmp.seek(0)
+            return tmp
+
+    def upload_xml(self, ein: str, object_id: str, data: bytes) -> str:
+        """Upload extracted XML to S3. Returns the s3 key."""
+        key = self._xml_key(ein, object_id)
+        self._client.put_object(
+            Bucket=self.bucket,
+            Key=key,
+            Body=data,
+            ContentType="application/xml",
+            ServerSideEncryption="AES256",
+        )
+        return key
+
+    def read_xml(self, s3_key: str) -> bytes:
+        """Read XML from S3 by key."""
+        resp = self._client.get_object(Bucket=self.bucket, Key=s3_key)
+        return resp["Body"].read()
+
+    def xml_exists(self, ein: str, object_id: str) -> bool:
+        """HEAD check for extracted XML."""
+        key = self._xml_key(ein, object_id)
+        try:
+            self._client.head_object(Bucket=self.bucket, Key=key)
+            return True
+        except ClientError as e:
+            code = e.response.get("Error", {}).get("Code", "")
+            if code in ("404", "NoSuchKey", "NotFound"):
+                return False
+            raise
+
+    def get_zip_checksum(self, year: int, batch_id: str) -> str | None:
+        """Get stored ChecksumSHA256 for a cached zip."""
+        key = self._zip_key(year, batch_id)
+        try:
+            resp = self._client.head_object(
+                Bucket=self.bucket,
+                Key=key,
+                ChecksumMode="ENABLED",
+            )
+            return resp.get("ChecksumSHA256")
+        except ClientError:
+            return None

--- a/lavandula/nonprofits/teos_download.py
+++ b/lavandula/nonprofits/teos_download.py
@@ -26,7 +26,7 @@ TEOS_ZIP_URL = (
 )
 
 _MAX_MEMBER_SIZE = 50 * 1024 * 1024  # 50 MB
-_MEMBER_NAME_RE = re.compile(r"^[\w]+/\d+_public\.xml$")
+_MEMBER_NAME_RE = re.compile(r"^([\w]+/)?\d+_public\.xml$")
 _MAX_RETRIES = 3
 _RETRY_DELAYS = [2, 4, 8]
 _RETRYABLE_STATUS = {429, 500, 502, 503, 504}
@@ -354,18 +354,25 @@ def _process_single_filing(
     stats: ProcessStats,
 ) -> None:
     object_id = filing["object_id"]
-    member_name = f"{xml_batch_id}/{object_id}_public.xml"
+    # IRS zips use nested paths (2024: {batch}/{oid}_public.xml) or flat (2025: {oid}_public.xml)
+    nested_name = f"{xml_batch_id}/{object_id}_public.xml"
+    flat_name = f"{object_id}_public.xml"
 
     try:
-        info = zf.getinfo(member_name)
+        info = zf.getinfo(nested_name)
+        member_name = nested_name
     except KeyError:
-        log.error("Member %s not found in zip", member_name)
-        _mark_filing_error(
-            engine, object_id,
-            f"Missing member {member_name} in zip", run_id,
-        )
-        stats.filings_error += 1
-        return
+        try:
+            info = zf.getinfo(flat_name)
+            member_name = flat_name
+        except KeyError:
+            log.error("Member %s not found in zip (tried nested and flat)", object_id)
+            _mark_filing_error(
+                engine, object_id,
+                f"Missing member {object_id}_public.xml in zip", run_id,
+            )
+            stats.filings_error += 1
+            return
 
     if not _MEMBER_NAME_RE.match(info.filename):
         _mark_filing_error(

--- a/lavandula/nonprofits/teos_index.py
+++ b/lavandula/nonprofits/teos_index.py
@@ -1,13 +1,16 @@
-"""TEOS index CSV downloader and filter (Spec 0026).
+"""TEOS index CSV downloader and filter (Spec 0026, updated Spec 0030).
 
 Downloads the IRS TEOS index CSV for a given year, filters to
 RETURN_TYPE='990' and matching EINs, inserts into filing_index.
+
+Supports both 9-column (2017-2023) and 10-column (2024+) CSV formats.
 """
 from __future__ import annotations
 
 import csv
 import io
 import logging
+import re
 from dataclasses import dataclass
 
 import requests
@@ -30,6 +33,10 @@ _COL_RETURN_TYPE = 6
 _COL_DLN = 7
 _COL_OBJECT_ID = 8
 _COL_XML_BATCH_ID = 9
+
+_EIN_RE = re.compile(r"^\d{9}$", re.ASCII)
+_OBJECT_ID_RE = re.compile(r"^\d+$", re.ASCII)
+_BATCH_ID_RE = re.compile(r"^\d{4}_TEOS_XML_(0[1-9]|1[0-2])[A-D]$", re.ASCII)
 
 
 @dataclass
@@ -116,7 +123,7 @@ def download_and_filter_index(
     with engine.begin() as conn:
         for row in reader:
             stats.rows_scanned += 1
-            if len(row) < 10:
+            if len(row) < 9:
                 continue
 
             return_type = row[_COL_RETURN_TYPE].strip()
@@ -127,8 +134,20 @@ def download_and_filter_index(
             if row_ein not in ein_set:
                 continue
 
-            stats.rows_matched += 1
+            if not _EIN_RE.match(row_ein):
+                continue
+
             object_id = row[_COL_OBJECT_ID].strip()
+            if not _OBJECT_ID_RE.match(object_id):
+                continue
+
+            xml_batch_id = (
+                row[_COL_XML_BATCH_ID].strip() if len(row) > 9 else None
+            )
+            if xml_batch_id and not _BATCH_ID_RE.match(xml_batch_id):
+                xml_batch_id = None
+
+            stats.rows_matched += 1
 
             result = conn.execute(_INSERT_SQL, {
                 "object_id": object_id,
@@ -137,7 +156,7 @@ def download_and_filter_index(
                 "return_type": return_type,
                 "sub_date": row[_COL_SUB_DATE].strip() or None,
                 "taxpayer_name": row[_COL_TAXPAYER_NAME].strip() or None,
-                "xml_batch_id": row[_COL_XML_BATCH_ID].strip() or None,
+                "xml_batch_id": xml_batch_id or None,
                 "filing_year": year,
                 "run_id": None,
             })

--- a/lavandula/nonprofits/tools/enrich_990.py
+++ b/lavandula/nonprofits/tools/enrich_990.py
@@ -1,10 +1,18 @@
 """CLI entry point for 990 Leadership & Contractor Intelligence (Spec 0026).
 
-Enriches seeded nonprofits with leadership, key employee, and contractor
-data from IRS 990 XML filings (TEOS bulk download).
+DEPRECATED: This module now delegates to the new management commands
+introduced in Spec 0030. The --index-only path calls load_990_index,
+and the --parse-only path calls process_990_auto. The combined mode
+runs both sequentially.
+
+The old local-cache-based code path is retained for the combined
+(non-index-only, non-parse-only) mode as a fallback until the S3
+infrastructure is fully validated.
 
 Usage:
-    python3 -m lavandula.nonprofits.tools.enrich_990 --state NY --years 2020,2021,2022,2023,2024
+    python3 -m lavandula.nonprofits.tools.enrich_990 --state NY --years 2024
+    python3 -m lavandula.nonprofits.tools.enrich_990 --ein 131624241 --index-only
+    python3 -m lavandula.nonprofits.tools.enrich_990 --ein 131624241 --parse-only
 """
 from __future__ import annotations
 
@@ -12,6 +20,7 @@ import argparse
 import datetime as dt
 import logging
 import re
+import subprocess
 import sys
 from pathlib import Path
 from uuid import uuid4
@@ -25,6 +34,8 @@ log = logging.getLogger(__name__)
 _EIN_RE = re.compile(r"^\d{9}$")
 _STATE_RE = re.compile(r"^[A-Z]{2}$")
 _YEAR_RE = re.compile(r"^\d{4}$")
+
+_MANAGE_PY = Path(__file__).resolve().parents[3] / "dashboard" / "manage.py"
 
 
 def _validate_ein(value: str) -> str:
@@ -55,36 +66,20 @@ def _validate_years(value: str) -> list[int]:
     return years
 
 
-def _validate_cache_dir(value: str) -> Path:
-    p = Path(value).expanduser()
-    if p.is_symlink():
-        raise argparse.ArgumentTypeError(
-            f"Cache directory must not be a symlink: {value}"
-        )
-    p = p.resolve()
-    if not p.is_dir():
-        raise argparse.ArgumentTypeError(
-            f"Cache directory does not exist: {value}"
-        )
-    return p
-
-
 def _default_years() -> list[int]:
     current = dt.date.today().year
     return list(range(current - 4, current + 1))
 
 
-def _log_cache_size(cache_dir: Path) -> None:
-    total = sum(f.stat().st_size for f in cache_dir.glob("*.zip"))
-    if total > 0:
-        log.info(
-            "Cache dir %s: %d zip files, %.1f GB total",
-            cache_dir,
-            sum(1 for _ in cache_dir.glob("*.zip")),
-            total / (1024 ** 3),
-        )
-    else:
-        log.info("Cache dir %s: empty", cache_dir)
+def _run_management_command(cmd_args: list[str]) -> int:
+    """Run a Django management command via subprocess."""
+    full_cmd = [sys.executable, str(_MANAGE_PY)] + cmd_args
+    log.info("Running: %s", " ".join(full_cmd))
+    result = subprocess.run(
+        full_cmd,
+        cwd=str(_MANAGE_PY.parent),
+    )
+    return result.returncode
 
 
 def main(argv: list[str] | None = None) -> None:
@@ -108,8 +103,8 @@ def main(argv: list[str] | None = None) -> None:
         help="Process a single EIN (bypasses --state)",
     )
     ap.add_argument(
-        "--cache-dir", type=_validate_cache_dir,
-        help="Directory for cached zip files (default: ~/.lavandula/990-cache/)",
+        "--cache-dir", type=str, default=None,
+        help="(Deprecated) Directory for cached zip files",
     )
     ap.add_argument(
         "--skip-download", action="store_true",
@@ -123,11 +118,11 @@ def main(argv: list[str] | None = None) -> None:
     mode_group = ap.add_mutually_exclusive_group()
     mode_group.add_argument(
         "--index-only", action="store_true",
-        help="Run only index download, skip parse/import",
+        help="Run only index download via load_990_index",
     )
     mode_group.add_argument(
         "--parse-only", action="store_true",
-        help="Skip index download, run only parse/import",
+        help="Run only parse via process_990_auto",
     )
 
     args = ap.parse_args(argv)
@@ -142,69 +137,44 @@ def main(argv: list[str] | None = None) -> None:
 
     years = args.years or _default_years()
 
-    if args.cache_dir:
-        cache_dir = args.cache_dir
-    else:
-        cache_dir = Path.home() / ".lavandula" / "990-cache"
-        if cache_dir.is_symlink():
-            log.error("Default cache dir is a symlink — aborting")
-            sys.exit(1)
-        cache_dir.mkdir(parents=True, exist_ok=True)
+    if args.index_only:
+        cmd = ["load_990_index"]
+        if args.ein:
+            cmd.extend(["--ein", args.ein])
+        if args.years:
+            cmd.extend(["--years", ",".join(str(y) for y in years)])
+        rc = _run_management_command(cmd)
+        sys.exit(rc)
 
-    _log_cache_size(cache_dir)
+    if args.parse_only:
+        cmd = ["process_990_auto"]
+        if args.ein:
+            cmd.extend(["--ein", args.ein])
+        if args.reparse:
+            cmd.append("--reparse")
+        rc = _run_management_command(cmd)
+        sys.exit(rc)
 
-    run_id = str(uuid4())
-    log.info("Run ID: %s", run_id)
-
-    engine = make_app_engine()
-
-    ein_set: set[str] | None = None
+    # Combined mode: run index then parse via new commands
+    index_cmd = ["load_990_index"]
     if args.ein:
-        ein_set = {args.ein}
-    elif args.state:
-        from lavandula.nonprofits.teos_index import _load_ein_set
-        ein_set = _load_ein_set(engine, state=args.state, limit=args.limit)
-        log.info("Loaded %d EINs for state %s", len(ein_set), args.state)
+        index_cmd.extend(["--ein", args.ein])
+    if args.years:
+        index_cmd.extend(["--years", ",".join(str(y) for y in years)])
 
-    if not args.parse_only:
-        for year in years:
-            try:
-                stats = download_and_filter_index(
-                    engine=engine,
-                    year=year,
-                    state=args.state if not args.ein else None,
-                    ein=args.ein,
-                    limit=args.limit,
-                )
-                log.info(
-                    "Index %d: inserted=%d matched=%d",
-                    year, stats.rows_inserted, stats.rows_matched,
-                )
-            except Exception:
-                log.exception("Failed to process index for year %d", year)
+    rc = _run_management_command(index_cmd)
+    if rc != 0:
+        log.error("Index command failed with exit code %d", rc)
+        sys.exit(rc)
 
-    if not args.index_only:
-        proc_stats = process_filings(
-            engine=engine,
-            cache_dir=cache_dir,
-            skip_download=args.skip_download,
-            reparse=args.reparse,
-            run_id=run_id,
-            ein_set=ein_set,
-            filing_years=years,
-        )
+    parse_cmd = ["process_990_auto"]
+    if args.ein:
+        parse_cmd.extend(["--ein", args.ein])
+    if args.reparse:
+        parse_cmd.append("--reparse")
 
-        log.info(
-            "Done: processed=%d parsed=%d skipped=%d errors=%d people=%d "
-            "zips_downloaded=%d zips_cached=%d",
-            proc_stats.filings_processed,
-            proc_stats.filings_parsed,
-            proc_stats.filings_skipped,
-            proc_stats.filings_error,
-            proc_stats.people_upserted,
-            proc_stats.zips_downloaded,
-            proc_stats.zips_cached,
-        )
+    rc = _run_management_command(parse_cmd)
+    sys.exit(rc)
 
 
 if __name__ == "__main__":

--- a/lavandula/systemd/990-nightly.service
+++ b/lavandula/systemd/990-nightly.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=990 index refresh and auto-process
+
+[Service]
+Type=oneshot
+User=ubuntu
+WorkingDirectory=/home/ubuntu/research/lavandula/dashboard
+ExecStart=/bin/bash -c '/usr/bin/python3 manage.py load_990_index --current-year 2>&1 | logger -t 990-index; /usr/bin/python3 manage.py process_990_auto 2>&1 | logger -t 990-auto'
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=990-nightly
+TimeoutStartSec=7200

--- a/lavandula/systemd/990-nightly.timer
+++ b/lavandula/systemd/990-nightly.timer
@@ -1,0 +1,9 @@
+[Unit]
+Description=Nightly 990 index refresh and auto-process
+
+[Timer]
+OnCalendar=*-*-* 03:00:00 UTC
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/locard/plans/0030-990-index-automation.md
+++ b/locard/plans/0030-990-index-automation.md
@@ -61,6 +61,16 @@ CREATE TABLE IF NOT EXISTS lava_corpus.index_refresh_log (
     rows_skipped    INTEGER NOT NULL DEFAULT 0,
     duration_sec    NUMERIC(8,2)
 );
+
+CREATE TABLE IF NOT EXISTS lava_corpus.filing_status_audit (
+    id              SERIAL PRIMARY KEY,
+    filing_id       INTEGER NOT NULL,
+    old_status      TEXT NOT NULL,
+    new_status      TEXT NOT NULL,
+    reset_by        TEXT NOT NULL,
+    reset_at        TIMESTAMPTZ NOT NULL DEFAULT now(),
+    command_args    TEXT
+);
 ```
 
 **teos_index.py changes:**
@@ -92,16 +102,17 @@ CREATE TABLE IF NOT EXISTS lava_corpus.index_refresh_log (
 - Arguments: `--years` (comma-separated), `--current-year` (flag), `--ein` (single EIN for ad-hoc — still downloads and streams the full CSV, but only inserts/updates rows matching this EIN; this preserves the bulk-load architecture while allowing targeted refreshes from the dashboard)
 - Default years: 2017 through current year (detect available years by probing HEAD on index URL)
 - For each year:
-  1. Download CSV via `requests.get()` with streaming, byte counter capped at 200 MB
-  2. Verify hostname is `apps.irs.gov` (reject redirects to other hosts)
+  1. Download CSV via `requests.get(url, stream=True, allow_redirects=False)` with byte counter capped at 200 MB. If response is 3xx, extract Location header, validate `urlparse(location).hostname == "apps.irs.gov"` and `urlparse(location).scheme == "https"`, then re-issue. Block link-local/private IPs via socket-level check (resolve DNS, reject `ipaddress.ip_address(resolved).is_private`). This prevents SSRF via redirects to instance metadata or internal endpoints.
+  2. All IRS URL construction uses a hardcoded template — never interpolate user/CSV-derived values into the hostname or path prefix
   3. Parse with `csv.reader`, detect column count from header row
-  4. For each `RETURN_TYPE == '990'` row, validate fields (EIN, OBJECT_ID, XML_BATCH_ID patterns)
+  4. For each `RETURN_TYPE == '990'` row, validate fields with `re.ASCII` flag: EIN `^\d{9}$`, OBJECT_ID `^\d+$`, XML_BATCH_ID `^\d{4}_TEOS_XML_(0[1-9]|1[0-2])[A-D]$` (exact IRS pattern: year + month 01-12 + sub-batch A-D)
   5. Bulk insert via `ON CONFLICT (object_id) DO UPDATE SET last_seen_at = now()`
   6. Record stats in `index_refresh_log`
 - Concurrency: acquire session-level `pg_advisory_lock(hashtext('990-family'))` at command start, release at command end. Session-level (not transaction-scoped) because the command uses multiple transactions for batch inserts — a transaction-scoped lock would release between batches and fail to serialize against concurrent runs.
 
 **Key design decisions:**
 - Use SQLAlchemy engine (same as `teos_index.py`) for bulk inserts, not Django ORM — batch performance matters for 2.6M rows
+- **All SQL MUST use parameterized queries** (`:param` placeholders with bound values). String interpolation (`f"INSERT ... {value}"`) is forbidden for any CSV/XML-derived data. This applies across all phases — reviewers MUST grep for f-string SQL patterns in PR review.
 - Stream CSV parsing — don't buffer entire 90 MB file in memory
 - The existing `download_and_filter_index()` in `teos_index.py` is NOT reused — it filters by EIN set, which we don't want for bulk load. New code path.
 
@@ -129,7 +140,7 @@ CREATE TABLE IF NOT EXISTS lava_corpus.index_refresh_log (
 2. If Range supported:
    - For each year 2017–2023, enumerate batch zips (`{year}_TEOS_XML_{01A..12A}`, plus B/C/D sub-batches)
    - For each batch zip, fetch the zip central directory via Range requests:
-     a. GET last 64 KB to find EOCD (handle Zip64 EOCD locator if present)
+     a. GET last 64 KB to find EOCD (handle Zip64 EOCD locator if present). Assert `response.status_code == 206` AND `Content-Length <= 65536`; if server returns 200 (full body), abort — don't stream a 2.5 GB response into memory.
      b. Parse central directory to get member filename list
      c. Extract `object_id` from each `{oid}_public.xml` member name
    - Bulk UPDATE `filing_index SET xml_batch_id = :batch_id WHERE object_id IN (:oids) AND xml_batch_id IS NULL`
@@ -159,7 +170,9 @@ CREATE TABLE IF NOT EXISTS lava_corpus.index_refresh_log (
 - Create bucket `lavandula-990-corpus` via AWS console or CLI
 - Settings: us-east-1, SSE-S3, versioning enabled, all four BlockPublicAccess enabled, ACLs disabled
 - Lifecycle rule: `zips/` prefix → Standard-IA after 30 days
-- IAM: add `s3:GetObject`, `s3:PutObject`, `s3:ListBucket`, `s3:HeadObject` for `arn:aws:s3:::lavandula-990-corpus*` to `cloud2_lavandulagroup` role policy
+- IAM: add to `cloud2_lavandulagroup` role policy using two ARNs (not trailing wildcard on bucket name):
+    - `arn:aws:s3:::lavandula-990-corpus` — for `s3:ListBucket`
+    - `arn:aws:s3:::lavandula-990-corpus/*` — for `s3:GetObject`, `s3:PutObject`, `s3:HeadObject`
 
 **Files to create:**
 - `lavandula/nonprofits/s3_990.py` — S3 client for 990 corpus bucket
@@ -197,7 +210,7 @@ class S3990Archive:
 **Integrity storage:**
 - Multipart-upload ETags are NOT plain MD5 — they include a part suffix (e.g., `"abc123-5"`). Don't treat them as content checksums. Instead, use **S3 `ChecksumSHA256`**: pass `ChecksumAlgorithm='SHA256'` on `put_object`/`create_multipart_upload`, and S3 computes + stores a SHA-256 checksum. Store this in `filing_index.zip_checksum TEXT` (rename from `zip_checksum`).
 - Before reusing a cached zip, call `verify_zip_integrity()` which does a HEAD request and compares the stored `ChecksumSHA256` value. On mismatch, re-download from IRS.
-- Flow: `upload_zip()` returns `ChecksumSHA256` → store in DB → `verify_zip_integrity()` reads DB + HEAD → compare
+- Flow: `upload_zip()` returns `ChecksumSHA256` → store in DB → `verify_zip_integrity()` reads DB + HEAD → compare. If `upload_zip()` returns no checksum (e.g., network issue in response parsing), raise immediately — never store NULL. Column should be `NOT NULL` with no default.
 
 **Large zip handling:**
 - Zips up to 500 MB: hold in `BytesIO` (memory)
@@ -229,7 +242,7 @@ class S3990Archive:
 - `lavandula/nonprofits/teos_download.py` — refactor `_process_single_filing()` to accept XML bytes from S3 instead of local zip. Extract the parsing logic into a reusable function.
 
 **Implementation:**
-1. Acquire session-level advisory lock (`pg_advisory_lock(hashtext('990-family'))`) — session-level for the same reason as Phase 2: the command spans multiple transactions.
+1. Acquire session-level advisory lock: set `lock_timeout = '1h'` on the session, then `pg_advisory_lock(hashtext('990-family'))`. If lock acquisition times out (another job holding for >1h), log clearly and exit with non-zero so systemd reports a known failure. Session-level for the same reason as Phase 2: the command spans multiple transactions.
 2. Query filings to process (two passes):
    - **Pass 1 — Download**: `status = 'indexed' AND xml_batch_id IS NOT NULL` (need zip download + extraction)
    - **Pass 2 — Parse**: `status = 'downloaded'` (already extracted to S3, need parsing — catches prior failures)
@@ -239,23 +252,23 @@ class S3990Archive:
    - `--ein X`: additional `AND ein = :ein`
 3. Group results by `(filing_year, xml_batch_id)`
 4. For each batch group:
-   a. Check S3 for cached zip → if missing, download from IRS to S3 (validate hostname, TLS, size cap 5 GB, ETag integrity)
+   a. Check S3 for cached zip → if missing, download from IRS to S3 (`allow_redirects=False`, validate hostname + scheme on any redirect, block private IPs, TLS, size cap 5 GB, ChecksumSHA256 integrity)
    b. Open zip from S3 (via `SpooledTemporaryFile` for large zips). Pre-validate:
       - Check member count (`len(zf.namelist()) <= 200_000`)
       - Track cumulative extracted bytes (cap at 10 GB per batch)
       Iterate over target filings in the group:
-      - Validate member name against `_MEMBER_NAME_RE`
-      - Check compression ratio: `info.file_size / max(info.compress_size, 1) <= 100`
-      - Check file size: `info.file_size <= _MAX_MEMBER_SIZE` (50 MB)
+      - Validate member name against `_MEMBER_NAME_RE = re.compile(r'^([\w]+/)?\d+_public\.xml$', re.ASCII)` — anchored, ASCII-only, allows optional single directory prefix (for 2024 nested format). Rejects path traversal (`../`), absolute paths (`/`), null bytes, and Unicode tricks. Never call `zf.extract()` (writes to filesystem); only use `zf.read()` or `zf.open()` (reads into memory).
+      - Pre-check header ratio: `info.file_size / max(info.compress_size, 1) <= 100` (first pass — header values are attacker-controlled, so this is a fast reject, not a trust boundary)
+      - Stream extraction via `zf.open(member)`, reading in chunks, tracking actual `bytes_read`. Abort if `bytes_read > _MAX_MEMBER_SIZE` (50 MB) OR if `bytes_read / actual_compressed_consumed > 100`. This is the real bomb defense — it tracks actual decompressed bytes, not just header claims.
       - Extract XML bytes into memory
       - Upload to `s3://lavandula-990-corpus/xml/{ein}/{object_id}.xml`
       - Update `filing_index.status = 'downloaded'`, set `s3_xml_key`
    c. Parse each downloaded filing:
       - Read XML from S3 (or use in-memory bytes from step b if still available)
       - Parse with `defusedxml.ElementTree.fromstring()` which defends against XXE, entity expansion (billion-laughs), and quadratic blowup out of the box. For the 30-second timeout: isolate XML parsing in a `concurrent.futures.ProcessPoolExecutor` worker with `timeout=30`. This avoids `signal.alarm` pitfalls (main-thread-only, Unix-specific, interferes with surrounding code). If the subprocess times out, `TimeoutError` is caught, the worker is killed, and the filing is marked `error` with `XML_PARSE_TIMEOUT`.
-      - Extract people/compensation → insert into `people` table with `ON CONFLICT DO NOTHING`
+      - Extract people/compensation → normalize `person_name` to NFC (`unicodedata.normalize('NFC', name.strip())`) before insert → insert into `people` table with `ON CONFLICT DO NOTHING`
       - Update `filing_index.status = 'parsed'`
-   d. On error: mark filing as `error` with structured error code, continue to next filing
+   d. On error: call `record_filing_error(filing_id, ErrorCode.XXX, public_detail="...")` — a centralized helper that writes structured error codes (enum: `ZIP_MEMBER_MISSING`, `XML_PARSE_FAILED`, `XML_PARSE_TIMEOUT`, `S3_UPLOAD_FAILED`, `ZIP_BOMB_DETECTED`, etc.) to `error_message`. The helper MUST sanitize `public_detail` to strip hostnames, paths, connection strings, and stack traces. Continue to next filing.
 5. Log summary: filings processed, parsed, errored, skipped
 
 **Retry logic:**
@@ -295,9 +308,11 @@ python3 manage.py reset_990_status --ein 030440761          # all filings for EI
 python3 manage.py reset_990_status --object-id 20242319...  # specific filing
 python3 manage.py reset_990_status --status error           # all errored filings
 ```
-- **Allowed source states:** `error`, `downloaded`, `parsed`, `batch_unresolvable`. Refuses to reset `indexed` filings (already at target state).
+- **Allowed source states:** `error`, `downloaded`, `parsed`. Refuses to reset `indexed` filings (already at target state) and `batch_unresolvable` (terminal state by design — if an operator truly needs to un-resolve, they should re-run batch resolution instead).
 - Resets `status` to `indexed`, clears `error_message`, clears `s3_xml_key`
 - **S3 cleanup:** Does NOT delete cached XML from S3. The XML may be valid; the re-process step will re-upload (S3 PUT is idempotent) or reuse the existing object. Deleting would force unnecessary re-extraction from batch zips.
+- **Blast radius control:** Requires `--max-rows N` for bulk operations (`--status error`). Abort with clear message if matched rows exceed N. Single-EIN and single-object-id operations are exempt.
+- **Audit logging:** Every reset logged to `filing_status_audit` table: `(filing_id, old_status, new_status, reset_by, reset_at, command_args)`. `reset_by = os.environ.get('SUDO_USER', pwd.getpwuid(os.getuid()).pw_name)`.
 - Requires confirmation prompt showing affected filing count unless `--yes` flag passed
 
 **Systemd timer:**
@@ -361,7 +376,6 @@ SyslogIdentifier=990-nightly
 "990-index": {
     "cmd": ["python3", "manage.py", "load_990_index"],
     "params": {
-        "state": {"type": "choice", "choices": US_STATES, "flag": "--state"},
         "ein": {"type": "text", "pattern": r"^\d{9}$", "flag": "--ein"},
         "years": {"type": "text", "pattern": r"^\d{4}(\s*,\s*\d{4})*$", "flag": "--years"},
     },

--- a/locard/plans/0030-990-index-automation.md
+++ b/locard/plans/0030-990-index-automation.md
@@ -29,7 +29,7 @@ ALTER TABLE lava_corpus.filing_index
   ADD COLUMN IF NOT EXISTS first_indexed_at TIMESTAMPTZ,
   ADD COLUMN IF NOT EXISTS last_seen_at TIMESTAMPTZ,
   ADD COLUMN IF NOT EXISTS s3_xml_key TEXT,
-  ADD COLUMN IF NOT EXISTS zip_etag TEXT;
+  ADD COLUMN IF NOT EXISTS zip_checksum TEXT;
 
 -- Backfill: set first_indexed_at = NULL for existing rows so the first
 -- bulk load will set it properly. Don't default to now() on migration —
@@ -37,6 +37,12 @@ ALTER TABLE lava_corpus.filing_index
 -- window would process them all on the first nightly run.
 -- The bulk loader's INSERT...ON CONFLICT will set first_indexed_at = now()
 -- for genuinely new rows.
+--
+-- NOTE: The spec shows DEFAULT now() for these columns. This plan intentionally
+-- deviates: columns are added WITHOUT defaults so existing rows get NULL.
+-- The loader explicitly sets first_indexed_at = now() on INSERT, and
+-- last_seen_at = now() on both INSERT and UPDATE. This is safer for
+-- the incremental processing window. Update spec to match if approved.
 
 -- If filing_index.status has a CHECK constraint, extend it:
 -- (Check with: SELECT conname, consrc FROM pg_constraint
@@ -83,7 +89,7 @@ CREATE TABLE IF NOT EXISTS lava_corpus.index_refresh_log (
 - `lavandula/dashboard/pipeline/management/commands/load_990_index.py`
 
 **Implementation:**
-- Arguments: `--years` (comma-separated), `--current-year` (flag), `--ein` (single EIN for ad-hoc)
+- Arguments: `--years` (comma-separated), `--current-year` (flag), `--ein` (single EIN for ad-hoc — still downloads and streams the full CSV, but only inserts/updates rows matching this EIN; this preserves the bulk-load architecture while allowing targeted refreshes from the dashboard)
 - Default years: 2017 through current year (detect available years by probing HEAD on index URL)
 - For each year:
   1. Download CSV via `requests.get()` with streaming, byte counter capped at 200 MB
@@ -92,7 +98,7 @@ CREATE TABLE IF NOT EXISTS lava_corpus.index_refresh_log (
   4. For each `RETURN_TYPE == '990'` row, validate fields (EIN, OBJECT_ID, XML_BATCH_ID patterns)
   5. Bulk insert via `ON CONFLICT (object_id) DO UPDATE SET last_seen_at = now()`
   6. Record stats in `index_refresh_log`
-- Concurrency: acquire `pg_advisory_xact_lock(hashtext('990-family'))` for the duration
+- Concurrency: acquire session-level `pg_advisory_lock(hashtext('990-family'))` at command start, release at command end. Session-level (not transaction-scoped) because the command uses multiple transactions for batch inserts — a transaction-scoped lock would release between batches and fail to serialize against concurrent runs.
 
 **Key design decisions:**
 - Use SQLAlchemy engine (same as `teos_index.py`) for bulk inserts, not Django ORM — batch performance matters for 2.6M rows
@@ -106,6 +112,8 @@ CREATE TABLE IF NOT EXISTS lava_corpus.index_refresh_log (
 - Run twice → verify 0 new inserts on second run (idempotent)
 - `--current-year` → verify only fetches one year
 - `index_refresh_log` populated after run
+- `--ein` with specific EIN → verify only that EIN's rows inserted (full CSV still streamed)
+- Session-level advisory lock: start two concurrent `load_990_index` runs → verify second waits for first to complete
 
 ---
 
@@ -126,8 +134,7 @@ CREATE TABLE IF NOT EXISTS lava_corpus.index_refresh_log (
      c. Extract `object_id` from each `{oid}_public.xml` member name
    - Bulk UPDATE `filing_index SET xml_batch_id = :batch_id WHERE object_id IN (:oids) AND xml_batch_id IS NULL`
 3. If Range NOT supported:
-   - Download full zips to S3 (Phase 4 prerequisite anyway)
-   - Read manifests from S3-cached zips
+   - Download full zips to a local temp directory (`/tmp/990-batch-resolve/`), read central directories, then delete the temp files. This avoids a dependency on Phase 4 (S3) and preserves Phase 3's ability to ship independently of Phase 4. The zips will be re-downloaded to S3 later in Phase 5 — this is acceptable since it's a one-time operation.
 4. After scanning all batches for a year, mark remaining NULL `xml_batch_id` rows as `batch_unresolvable`
 
 **Batch zip enumeration:**
@@ -167,10 +174,10 @@ class S3990Archive:
         """HEAD check for zips/{year}/{batch_id}.zip"""
 
     def upload_zip(self, year: int, batch_id: str, stream: IO[bytes]) -> str:
-        """Multipart upload IRS zip to S3. Returns ETag for integrity storage."""
+        """Multipart upload IRS zip to S3 with ChecksumAlgorithm='SHA256'. Returns ChecksumSHA256 for integrity storage."""
 
-    def verify_zip_integrity(self, year: int, batch_id: str, expected_etag: str) -> bool:
-        """HEAD request, compare ETag. Mismatch → return False (caller re-downloads)."""
+    def verify_zip_integrity(self, year: int, batch_id: str, expected_checksum: str) -> bool:
+        """HEAD request, compare ChecksumSHA256. Mismatch → return False (caller re-downloads)."""
 
     def open_zip(self, year: int, batch_id: str) -> IO[bytes]:
         """Stream zip from S3 for extraction. For large zips (>500 MB), download to
@@ -187,10 +194,10 @@ class S3990Archive:
         """HEAD check for xml/{ein}/{object_id}.xml"""
 ```
 
-**ETag integrity storage:**
-- Store the upload ETag in `filing_index` alongside batch data: add column `zip_etag TEXT` to migration 011
-- Before reusing a cached zip, call `verify_zip_integrity()`. On mismatch, re-download from IRS.
-- Flow: `upload_zip()` returns ETag → store in DB → `verify_zip_integrity()` reads DB + HEAD → compare
+**Integrity storage:**
+- Multipart-upload ETags are NOT plain MD5 — they include a part suffix (e.g., `"abc123-5"`). Don't treat them as content checksums. Instead, use **S3 `ChecksumSHA256`**: pass `ChecksumAlgorithm='SHA256'` on `put_object`/`create_multipart_upload`, and S3 computes + stores a SHA-256 checksum. Store this in `filing_index.zip_checksum TEXT` (rename from `zip_checksum`).
+- Before reusing a cached zip, call `verify_zip_integrity()` which does a HEAD request and compares the stored `ChecksumSHA256` value. On mismatch, re-download from IRS.
+- Flow: `upload_zip()` returns `ChecksumSHA256` → store in DB → `verify_zip_integrity()` reads DB + HEAD → compare
 
 **Large zip handling:**
 - Zips up to 500 MB: hold in `BytesIO` (memory)
@@ -222,7 +229,7 @@ class S3990Archive:
 - `lavandula/nonprofits/teos_download.py` — refactor `_process_single_filing()` to accept XML bytes from S3 instead of local zip. Extract the parsing logic into a reusable function.
 
 **Implementation:**
-1. Acquire advisory lock (`pg_advisory_xact_lock(hashtext('990-family'))`)
+1. Acquire session-level advisory lock (`pg_advisory_lock(hashtext('990-family'))`) — session-level for the same reason as Phase 2: the command spans multiple transactions.
 2. Query filings to process (two passes):
    - **Pass 1 — Download**: `status = 'indexed' AND xml_batch_id IS NOT NULL` (need zip download + extraction)
    - **Pass 2 — Parse**: `status = 'downloaded'` (already extracted to S3, need parsing — catches prior failures)
@@ -245,7 +252,7 @@ class S3990Archive:
       - Update `filing_index.status = 'downloaded'`, set `s3_xml_key`
    c. Parse each downloaded filing:
       - Read XML from S3 (or use in-memory bytes from step b if still available)
-      - Parse with `defusedxml.ElementTree.fromstring()` which defends against XXE, entity expansion (billion-laughs), and quadratic blowup out of the box. For the 30-second timeout: wrap the parse call in `signal.alarm(30)` on Linux (SIGALRM). If timeout fires, mark filing as `error` with `XML_PARSE_TIMEOUT`.
+      - Parse with `defusedxml.ElementTree.fromstring()` which defends against XXE, entity expansion (billion-laughs), and quadratic blowup out of the box. For the 30-second timeout: isolate XML parsing in a `concurrent.futures.ProcessPoolExecutor` worker with `timeout=30`. This avoids `signal.alarm` pitfalls (main-thread-only, Unix-specific, interferes with surrounding code). If the subprocess times out, `TimeoutError` is caught, the worker is killed, and the filing is marked `error` with `XML_PARSE_TIMEOUT`.
       - Extract people/compensation → insert into `people` table with `ON CONFLICT DO NOTHING`
       - Update `filing_index.status = 'parsed'`
    d. On error: mark filing as `error` with structured error code, continue to next filing
@@ -288,8 +295,10 @@ python3 manage.py reset_990_status --ein 030440761          # all filings for EI
 python3 manage.py reset_990_status --object-id 20242319...  # specific filing
 python3 manage.py reset_990_status --status error           # all errored filings
 ```
+- **Allowed source states:** `error`, `downloaded`, `parsed`, `batch_unresolvable`. Refuses to reset `indexed` filings (already at target state).
 - Resets `status` to `indexed`, clears `error_message`, clears `s3_xml_key`
-- Requires confirmation prompt unless `--yes` flag passed
+- **S3 cleanup:** Does NOT delete cached XML from S3. The XML may be valid; the re-process step will re-upload (S3 PUT is idempotent) or reuse the existing object. Deleting would force unnecessary re-extraction from batch zips.
+- Requires confirmation prompt showing affected filing count unless `--yes` flag passed
 
 **Systemd timer:**
 ```ini
@@ -314,11 +323,10 @@ Description=990 index refresh and auto-process
 Type=oneshot
 User=ubuntu
 WorkingDirectory=/home/ubuntu/research/lavandula/dashboard
-# Two ExecStart lines: systemd runs them sequentially, but the second runs
-# even if the first fails (unlike shell &&). Index refresh failure should
-# not block processing of already-indexed filings.
-ExecStart=/usr/bin/python3 manage.py load_990_index --current-year
-ExecStart=/usr/bin/python3 manage.py process_990_auto
+# Use a shell wrapper to run both commands independently.
+# systemd Type=oneshot with multiple ExecStart= lines actually STOPS on first
+# failure, which is not what we want. Use a shell script instead.
+ExecStart=/bin/bash -c '/usr/bin/python3 manage.py load_990_index --current-year 2>&1 | logger -t 990-index; /usr/bin/python3 manage.py process_990_auto 2>&1 | logger -t 990-auto'
 StandardOutput=journal
 StandardError=journal
 SyslogIdentifier=990-nightly
@@ -329,7 +337,9 @@ SyslogIdentifier=990-nightly
 **Tests:**
 - `reset_990_status --ein X` → verify status reset to `indexed`
 - `reset_990_status --object-id X` → verify single filing reset
+- `reset_990_status` on `indexed` filing → verify refusal (already at target state)
 - Timer unit file validates with `systemd-analyze verify`
+- Systemd failure semantics: simulate `load_990_index` failure → verify `process_990_auto` still runs (shell `;` separator, not `&&`)
 
 ---
 
@@ -371,10 +381,10 @@ SyslogIdentifier=990-nightly
 - Show banner: "Last refreshed: {date} — {total} filings indexed"
 - Filing count breakdown by status
 
-**Index Maintenance admin view** (new URL: `/dashboard/990/maintenance/`):
+**Index Maintenance admin view** (new URL: `/dashboard/990/maintenance/`, `LoginRequiredMixin`):
 - Per-year table: year, last refresh date, total filings, filings by status (indexed/downloaded/parsed/error/batch_unresolvable)
 - Unresolved batch IDs count (NULL `xml_batch_id` rows)
-- Button to trigger manual refresh for a specific year
+- Button to trigger manual refresh for a specific year (authenticated operator-only action, consistent with Spec Security Requirement 11)
 
 **ACs covered:** AC23, AC24, AC25
 

--- a/locard/plans/0030-990-index-automation.md
+++ b/locard/plans/0030-990-index-automation.md
@@ -1,0 +1,425 @@
+# Plan 0030: 990 Filing Index Automation & S3 Archive
+
+**Spec**: `locard/specs/0030-990-index-automation.md`
+**Date**: 2026-05-01
+
+## Implementation Phases
+
+This plan has 8 phases. Phases 1–3 ship independently (index fixes + bulk loader). Phases 4–6 are the main body (S3 + auto-process). Phases 7–8 are integration + cleanup.
+
+---
+
+### Phase 1: Schema Migration + 9-Column Bug Fix
+
+**Goal:** Unblock 2017–2023 index loading. Add new columns to `filing_index`.
+
+**Files to modify:**
+- `lavandula/nonprofits/teos_index.py` — accept 9-column rows
+- New: `lavandula/migrations/rds/migration_011_990_index_automation.sql`
+- `lavandula/dashboard/pipeline/models.py` — add new fields to unmanaged `FilingIndex` model
+
+**Migration SQL:**
+```sql
+ALTER TABLE lava_corpus.filing_index
+  ALTER COLUMN xml_batch_id DROP NOT NULL;
+
+ALTER TABLE lava_corpus.filing_index
+  ADD COLUMN IF NOT EXISTS first_indexed_at TIMESTAMPTZ DEFAULT now(),
+  ADD COLUMN IF NOT EXISTS last_seen_at TIMESTAMPTZ DEFAULT now(),
+  ADD COLUMN IF NOT EXISTS s3_xml_key TEXT;
+
+CREATE TABLE IF NOT EXISTS lava_corpus.index_refresh_log (
+    id              SERIAL PRIMARY KEY,
+    filing_year     INTEGER NOT NULL,
+    refreshed_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+    rows_scanned    INTEGER NOT NULL DEFAULT 0,
+    rows_inserted   INTEGER NOT NULL DEFAULT 0,
+    rows_skipped    INTEGER NOT NULL DEFAULT 0,
+    duration_sec    NUMERIC(8,2)
+);
+```
+
+**teos_index.py changes:**
+- Line 119: Change `if len(row) < 10` to `if len(row) < 9`
+- Handle `xml_batch_id`: `row[_COL_XML_BATCH_ID].strip() if len(row) > 9 else None`
+- Add CSV field validation before insert: EIN matches `^\d{9}$`, OBJECT_ID matches `^\d+$`
+
+**Django model changes:**
+- Add `first_indexed_at`, `last_seen_at`, `s3_xml_key` to `FilingIndex` model (unmanaged)
+- Add `batch_unresolvable` to status choices if applicable
+
+**ACs covered:** AC2, AC3, AC7
+
+**Tests:**
+- Synthetic 9-column CSV → verify insert with `xml_batch_id=NULL`
+- Synthetic 10-column CSV → verify insert with `xml_batch_id` populated
+- CSV row with invalid EIN (letters) → verify row rejected
+
+---
+
+### Phase 2: Bulk Index Loader Management Command
+
+**Goal:** `manage.py load_990_index` that downloads IRS index CSVs and bulk-inserts into `filing_index`.
+
+**Files to create:**
+- `lavandula/dashboard/pipeline/management/commands/load_990_index.py`
+
+**Implementation:**
+- Arguments: `--years` (comma-separated), `--current-year` (flag), `--ein` (single EIN for ad-hoc)
+- Default years: 2017 through current year (detect available years by probing HEAD on index URL)
+- For each year:
+  1. Download CSV via `requests.get()` with streaming, byte counter capped at 200 MB
+  2. Verify hostname is `apps.irs.gov` (reject redirects to other hosts)
+  3. Parse with `csv.reader`, detect column count from header row
+  4. For each `RETURN_TYPE == '990'` row, validate fields (EIN, OBJECT_ID, XML_BATCH_ID patterns)
+  5. Bulk insert via `ON CONFLICT (object_id) DO UPDATE SET last_seen_at = now()`
+  6. Record stats in `index_refresh_log`
+- Concurrency: acquire `pg_advisory_xact_lock(hashtext('990-family'))` for the duration
+
+**Key design decisions:**
+- Use SQLAlchemy engine (same as `teos_index.py`) for bulk inserts, not Django ORM — batch performance matters for 2.6M rows
+- Stream CSV parsing — don't buffer entire 90 MB file in memory
+- The existing `download_and_filter_index()` in `teos_index.py` is NOT reused — it filters by EIN set, which we don't want for bulk load. New code path.
+
+**ACs covered:** AC1, AC4, AC5, AC6
+
+**Tests:**
+- Mock IRS CSV response with 9 and 10 columns → verify correct inserts
+- Run twice → verify 0 new inserts on second run (idempotent)
+- `--current-year` → verify only fetches one year
+- `index_refresh_log` populated after run
+
+---
+
+### Phase 3: Batch ID Resolution
+
+**Goal:** Resolve `xml_batch_id` for 2017–2023 filings where it's NULL.
+
+**Files to create:**
+- `lavandula/dashboard/pipeline/management/commands/resolve_990_batches.py`
+
+**Implementation:**
+1. Probe IRS server for HTTP Range support: `HEAD` + `Range: bytes=0-0` on a known 2022 zip
+2. If Range supported:
+   - For each year 2017–2023, enumerate batch zips (`{year}_TEOS_XML_{01A..12A}`, plus B/C/D sub-batches)
+   - For each batch zip, fetch the zip central directory via Range requests:
+     a. GET last 64 KB to find EOCD (handle Zip64 EOCD locator if present)
+     b. Parse central directory to get member filename list
+     c. Extract `object_id` from each `{oid}_public.xml` member name
+   - Bulk UPDATE `filing_index SET xml_batch_id = :batch_id WHERE object_id IN (:oids) AND xml_batch_id IS NULL`
+3. If Range NOT supported:
+   - Download full zips to S3 (Phase 4 prerequisite anyway)
+   - Read manifests from S3-cached zips
+4. After scanning all batches for a year, mark remaining NULL `xml_batch_id` rows as `batch_unresolvable`
+
+**Batch zip enumeration:**
+- Pattern: `{year}_TEOS_XML_{MM}{suffix}` where MM = 01–12, suffix = A, B, C, D
+- Probe each with HEAD request; 200 = exists, 302 = IRS 404 redirect
+- Already confirmed: 2022 has 01A–02A only, 2023 has 01A–12A, 2024+ has 01A–12A plus sub-batches
+
+**ACs covered:** AC20, AC21, AC22
+
+**Tests:**
+- Mock Range-supported server → verify central directory read + batch mapping
+- Mock Range-unsupported server → verify fallback to full download
+- Object ID in no batch → verify `batch_unresolvable` status
+
+---
+
+### Phase 4: S3 Bucket + Archive Module
+
+**Goal:** New S3 bucket and a module for uploading/downloading 990 zips and XMLs.
+
+**Infrastructure (manual operator step):**
+- Create bucket `lavandula-990-corpus` via AWS console or CLI
+- Settings: us-east-1, SSE-S3, versioning enabled, all four BlockPublicAccess enabled, ACLs disabled
+- Lifecycle rule: `zips/` prefix → Standard-IA after 30 days
+- IAM: add `s3:GetObject`, `s3:PutObject`, `s3:ListBucket`, `s3:HeadObject` for `arn:aws:s3:::lavandula-990-corpus*` to `cloud2_lavandulagroup` role policy
+
+**Files to create:**
+- `lavandula/nonprofits/s3_990.py` — S3 client for 990 corpus bucket
+
+**Module API:**
+```python
+class S3990Archive:
+    def __init__(self, bucket: str = "lavandula-990-corpus"):
+        ...
+
+    def zip_exists(self, year: int, batch_id: str) -> bool:
+        """HEAD check for zips/{year}/{batch_id}.zip"""
+
+    def upload_zip(self, year: int, batch_id: str, stream: IO[bytes]) -> str:
+        """Multipart upload IRS zip to S3. Returns ETag."""
+
+    def zip_etag(self, year: int, batch_id: str) -> str | None:
+        """Get stored ETag for integrity check."""
+
+    def open_zip(self, year: int, batch_id: str) -> IO[bytes]:
+        """Stream zip from S3 for extraction."""
+
+    def upload_xml(self, ein: str, object_id: str, data: bytes) -> str:
+        """PUT xml/{ein}/{object_id}.xml. Returns s3_xml_key."""
+
+    def read_xml(self, s3_key: str) -> bytes:
+        """GET XML from S3."""
+
+    def xml_exists(self, ein: str, object_id: str) -> bool:
+        """HEAD check for xml/{ein}/{object_id}.xml"""
+```
+
+**Security:**
+- All S3 keys validated: EIN `^\d{9}$`, object_id `^\d+$`, batch_id `^\d{4}_TEOS_XML_\w+$`
+- boto3 client with retry config (same pattern as `s3_archive.py`)
+- Multipart upload for zips > 100 MB
+
+**ACs covered:** AC8, AC9, AC10, AC11, AC13
+
+**Tests:**
+- Unit tests with moto mock S3
+- Upload zip → verify `zips/` key, get ETag
+- Upload XML → verify `xml/{ein}/{oid}.xml` key
+- Read back uploaded XML → verify round-trip
+
+---
+
+### Phase 5: Auto-Process Worker
+
+**Goal:** `manage.py process_990_auto` — download, extract, parse filings for tracked orgs.
+
+**Files to create:**
+- `lavandula/dashboard/pipeline/management/commands/process_990_auto.py`
+
+**Files to modify:**
+- `lavandula/nonprofits/teos_download.py` — refactor `_process_single_filing()` to accept XML bytes from S3 instead of local zip. Extract the parsing logic into a reusable function.
+
+**Implementation:**
+1. Acquire advisory lock (`pg_advisory_xact_lock(hashtext('990-family'))`)
+2. Query filings to process:
+   - `--backfill`: `SELECT * FROM filing_index WHERE ein IN (SELECT ein FROM nonprofits_seed) AND status = 'indexed' AND xml_batch_id IS NOT NULL`
+   - Default (incremental): same query + `AND first_indexed_at >= now() - interval '7 days'`
+   - `--ein X`: same query + `AND ein = :ein`
+3. Group results by `(filing_year, xml_batch_id)`
+4. For each batch group:
+   a. Check S3 for cached zip → if missing, download from IRS to S3 (validate hostname, TLS, size cap 5 GB, ETag integrity)
+   b. Open zip from S3, iterate over target filings in the group:
+      - Validate member name against `_MEMBER_NAME_RE`
+      - Check compression ratio (<100:1) and file size (<50 MB)
+      - Extract XML bytes into memory
+      - Upload to `s3://lavandula-990-corpus/xml/{ein}/{object_id}.xml`
+      - Update `filing_index.status = 'downloaded'`, set `s3_xml_key`
+   c. Parse each downloaded filing:
+      - Read XML from S3 (or use in-memory bytes from step b if still available)
+      - Parse with `defusedxml.ElementTree` (no XXE, no entities, 30s timeout)
+      - Extract people/compensation → insert into `people` table with `ON CONFLICT DO NOTHING`
+      - Update `filing_index.status = 'parsed'`
+   d. On error: mark filing as `error` with structured error code, continue to next filing
+5. Log summary: filings processed, parsed, errored, skipped
+
+**Retry logic:**
+- Zip download: 3 retries, exponential backoff (2s, 4s, 8s base)
+- S3 operations: boto3 built-in retry (3 retries)
+- Individual filing errors don't stop the batch
+
+**Reparse flag (`--reparse`):**
+- Additionally selects filings with `status = 'error'`
+- Resets to `indexed` before processing
+
+**ACs covered:** AC14, AC15, AC16, AC17, AC18, AC26, AC27, AC28, AC29, AC30, AC31
+
+**Tests:**
+- Mock S3 + mock IRS zip → full pipeline: indexed → downloaded → parsed
+- `--backfill` vs incremental: verify different query scopes
+- `--ein`: verify single-EIN processing
+- `--reparse`: verify error filings re-processed
+- Zip bomb rejection (high ratio)
+- XXE rejection
+- Missing member → error status, batch continues
+
+---
+
+### Phase 6: Status Reset Command + Nightly Cron
+
+**Goal:** Management command for operator status resets. Systemd timer for nightly automation.
+
+**Files to create:**
+- `lavandula/dashboard/pipeline/management/commands/reset_990_status.py`
+- `lavandula/systemd/990-nightly.service`
+- `lavandula/systemd/990-nightly.timer`
+
+**reset_990_status:**
+```
+python3 manage.py reset_990_status --ein 030440761          # all filings for EIN
+python3 manage.py reset_990_status --object-id 20242319...  # specific filing
+python3 manage.py reset_990_status --status error           # all errored filings
+```
+- Resets `status` to `indexed`, clears `error_message`, clears `s3_xml_key`
+- Requires confirmation prompt unless `--yes` flag passed
+
+**Systemd timer:**
+```ini
+# 990-nightly.timer
+[Unit]
+Description=Nightly 990 index refresh and auto-process
+
+[Timer]
+OnCalendar=*-*-* 03:00:00 UTC
+Persistent=true
+
+[Install]
+WantedBy=timers.target
+```
+
+```ini
+# 990-nightly.service
+[Unit]
+Description=990 index refresh and auto-process
+
+[Service]
+Type=oneshot
+User=ubuntu
+WorkingDirectory=/home/ubuntu/research/lavandula/dashboard
+ExecStart=/bin/bash -c 'python3 manage.py load_990_index --current-year && python3 manage.py process_990_auto'
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=990-nightly
+```
+
+**ACs covered:** AC19, AC32
+
+**Tests:**
+- `reset_990_status --ein X` → verify status reset to `indexed`
+- `reset_990_status --object-id X` → verify single filing reset
+- Timer unit file validates with `systemd-analyze verify`
+
+---
+
+### Phase 7: Orchestrator + Dashboard Integration
+
+**Goal:** Wire the new commands into the dashboard. Update orchestrator COMMAND_MAP.
+
+**Files to modify:**
+- `lavandula/dashboard/pipeline/orchestrator.py` — update `990-index` and `990-parse` COMMAND_MAP entries to use new commands
+- `lavandula/dashboard/pipeline/views.py` — update `EnrichIndexView`, `EnrichParseView`
+- `lavandula/dashboard/pipeline/templates/pipeline/990_index.html` — add index status banner
+- `lavandula/dashboard/pipeline/templates/pipeline/990_parse.html` — similar
+- `lavandula/dashboard/pipeline/templates/pipeline/org_detail.html` — filing list is pre-populated
+- `lavandula/dashboard/pipeline/models.py` — add `IndexRefreshLog` unmanaged model
+
+**Orchestrator changes:**
+```python
+# Replace old COMMAND_MAP entries:
+"990-index": {
+    "cmd": ["python3", "manage.py", "load_990_index"],
+    "params": {
+        "state": {"type": "choice", "choices": US_STATES, "flag": "--state"},
+        "ein": {"type": "text", "pattern": r"^\d{9}$", "flag": "--ein"},
+        "years": {"type": "text", "pattern": r"^\d{4}(\s*,\s*\d{4})*$", "flag": "--years"},
+    },
+},
+"990-parse": {
+    "cmd": ["python3", "manage.py", "process_990_auto"],
+    "params": {
+        "ein": {"type": "text", "pattern": r"^\d{9}$", "flag": "--ein"},
+        "reparse": {"type": "bool", "flag": "--reparse"},
+        "backfill": {"type": "bool", "flag": "--backfill"},
+    },
+},
+```
+
+**Dashboard 990 Index page:**
+- Query `IndexRefreshLog` for latest refresh per year
+- Show banner: "Last refreshed: {date} — {total} filings indexed"
+- Filing count breakdown by status
+
+**ACs covered:** AC23, AC24, AC25
+
+**Tests:**
+- Orchestrator builds correct argv for new commands
+- Dashboard views render with index status data
+- Manual form submission still creates jobs
+
+---
+
+### Phase 8: Retire Old Code Paths + Final Validation
+
+**Goal:** Remove EBS-based code paths once new infrastructure is proven.
+
+**Files to modify:**
+- `lavandula/nonprofits/teos_download.py` — remove local cache logic, use S3 exclusively
+- `lavandula/nonprofits/tools/enrich_990.py` — update to delegate to new management commands
+- `lavandula/dashboard/pipeline/forms.py` — simplify 990 forms (years no longer required for tracked orgs)
+
+**Retirement steps:**
+1. Verify all existing `parsed` filings have `s3_xml_key` set (run backfill for any gaps)
+2. Remove `--cache-dir` argument from `enrich_990.py`
+3. Remove `_log_cache_size()` function
+4. Update `process_filings()` to read from S3 instead of local zip
+5. Remove local zip download logic (or keep as fallback behind flag)
+
+**Live validation checklist:**
+- [ ] `load_990_index` bulk load for 2024 → ~363K 990 filings inserted
+- [ ] `resolve_990_batches` for 2022 → batch IDs resolved for both batch zips
+- [ ] `process_990_auto --ein 131624241` → UNCF filings across multiple years parsed
+- [ ] Nightly cron dry run → `index_refresh_log` populated
+- [ ] Dashboard org detail for UNCF → filing list pre-populated, people data visible
+- [ ] Manual parse from dashboard → still works via new code path
+
+**ACs covered:** AC12, AC13 (final verification)
+
+---
+
+## Phase Dependencies
+
+```
+Phase 1 (schema + bug fix)
+    ↓
+Phase 2 (bulk loader) ←→ Phase 3 (batch resolution) [can parallelize]
+    ↓
+Phase 4 (S3 module)
+    ↓
+Phase 5 (auto-process worker)
+    ↓
+Phase 6 (reset command + cron) ←→ Phase 7 (dashboard) [can parallelize]
+    ↓
+Phase 8 (retire old code)
+```
+
+## File Summary
+
+**New files (7):**
+- `lavandula/migrations/rds/migration_011_990_index_automation.sql`
+- `lavandula/nonprofits/s3_990.py`
+- `lavandula/dashboard/pipeline/management/commands/load_990_index.py`
+- `lavandula/dashboard/pipeline/management/commands/resolve_990_batches.py`
+- `lavandula/dashboard/pipeline/management/commands/process_990_auto.py`
+- `lavandula/dashboard/pipeline/management/commands/reset_990_status.py`
+- `lavandula/systemd/990-nightly.timer` + `990-nightly.service`
+
+**Modified files (8):**
+- `lavandula/nonprofits/teos_index.py` — 9-column support + field validation
+- `lavandula/nonprofits/teos_download.py` — refactor parse logic for S3 reuse, retire local cache
+- `lavandula/nonprofits/tools/enrich_990.py` — delegate to new commands
+- `lavandula/dashboard/pipeline/models.py` — new fields on FilingIndex, IndexRefreshLog model
+- `lavandula/dashboard/pipeline/orchestrator.py` — update COMMAND_MAP entries
+- `lavandula/dashboard/pipeline/views.py` — index status banner, pre-populated filings
+- `lavandula/dashboard/pipeline/templates/pipeline/990_index.html` — status banner
+- `lavandula/dashboard/pipeline/forms.py` — simplify forms
+
+## Operator Steps (Manual)
+
+These steps require the operator (not the builder):
+
+1. **Before Phase 1**: Run migration 011 via PGAdmin
+2. **Before Phase 4**: Create S3 bucket `lavandula-990-corpus` + IAM policy update
+3. **After Phase 5**: Run initial bulk load + backfill:
+   ```bash
+   python3 manage.py load_990_index
+   python3 manage.py resolve_990_batches
+   python3 manage.py process_990_auto --backfill
+   ```
+4. **After Phase 6**: Install and enable systemd timer:
+   ```bash
+   sudo cp lavandula/systemd/990-nightly.* /etc/systemd/system/
+   sudo systemctl daemon-reload
+   sudo systemctl enable --now 990-nightly.timer
+   ```

--- a/locard/plans/0030-990-index-automation.md
+++ b/locard/plans/0030-990-index-automation.md
@@ -20,13 +20,31 @@ This plan has 8 phases. Phases 1–3 ship independently (index fixes + bulk load
 
 **Migration SQL:**
 ```sql
+-- Allow NULL xml_batch_id for 2017-2023 filings
 ALTER TABLE lava_corpus.filing_index
   ALTER COLUMN xml_batch_id DROP NOT NULL;
 
+-- New columns for automation
 ALTER TABLE lava_corpus.filing_index
-  ADD COLUMN IF NOT EXISTS first_indexed_at TIMESTAMPTZ DEFAULT now(),
-  ADD COLUMN IF NOT EXISTS last_seen_at TIMESTAMPTZ DEFAULT now(),
-  ADD COLUMN IF NOT EXISTS s3_xml_key TEXT;
+  ADD COLUMN IF NOT EXISTS first_indexed_at TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS last_seen_at TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS s3_xml_key TEXT,
+  ADD COLUMN IF NOT EXISTS zip_etag TEXT;
+
+-- Backfill: set first_indexed_at = NULL for existing rows so the first
+-- bulk load will set it properly. Don't default to now() on migration —
+-- that would make all existing rows look "just indexed" and the incremental
+-- window would process them all on the first nightly run.
+-- The bulk loader's INSERT...ON CONFLICT will set first_indexed_at = now()
+-- for genuinely new rows.
+
+-- If filing_index.status has a CHECK constraint, extend it:
+-- (Check with: SELECT conname, consrc FROM pg_constraint
+--  WHERE conrelid = 'lava_corpus.filing_index'::regclass AND contype = 'c')
+-- If a CHECK exists, run:
+-- ALTER TABLE lava_corpus.filing_index DROP CONSTRAINT <name>;
+-- ALTER TABLE lava_corpus.filing_index ADD CONSTRAINT filing_index_status_check
+--   CHECK (status IN ('indexed','downloaded','parsed','error','batch_unresolvable'));
 
 CREATE TABLE IF NOT EXISTS lava_corpus.index_refresh_log (
     id              SERIAL PRIMARY KEY,
@@ -149,13 +167,15 @@ class S3990Archive:
         """HEAD check for zips/{year}/{batch_id}.zip"""
 
     def upload_zip(self, year: int, batch_id: str, stream: IO[bytes]) -> str:
-        """Multipart upload IRS zip to S3. Returns ETag."""
+        """Multipart upload IRS zip to S3. Returns ETag for integrity storage."""
 
-    def zip_etag(self, year: int, batch_id: str) -> str | None:
-        """Get stored ETag for integrity check."""
+    def verify_zip_integrity(self, year: int, batch_id: str, expected_etag: str) -> bool:
+        """HEAD request, compare ETag. Mismatch → return False (caller re-downloads)."""
 
     def open_zip(self, year: int, batch_id: str) -> IO[bytes]:
-        """Stream zip from S3 for extraction."""
+        """Stream zip from S3 for extraction. For large zips (>500 MB), download to
+        a temp file first rather than holding in memory. Use tempfile.SpooledTemporaryFile
+        with max_size=500MB — small zips stay in memory, large ones spill to /tmp."""
 
     def upload_xml(self, ein: str, object_id: str, data: bytes) -> str:
         """PUT xml/{ein}/{object_id}.xml. Returns s3_xml_key."""
@@ -166,6 +186,15 @@ class S3990Archive:
     def xml_exists(self, ein: str, object_id: str) -> bool:
         """HEAD check for xml/{ein}/{object_id}.xml"""
 ```
+
+**ETag integrity storage:**
+- Store the upload ETag in `filing_index` alongside batch data: add column `zip_etag TEXT` to migration 011
+- Before reusing a cached zip, call `verify_zip_integrity()`. On mismatch, re-download from IRS.
+- Flow: `upload_zip()` returns ETag → store in DB → `verify_zip_integrity()` reads DB + HEAD → compare
+
+**Large zip handling:**
+- Zips up to 500 MB: hold in `BytesIO` (memory)
+- Zips > 500 MB (e.g., 2.5 GB 2025 batches): `SpooledTemporaryFile` spills to `/tmp` on EBS. This is transient — deleted after batch processing. The 2.5 GB temp file is acceptable because it's short-lived and EBS has capacity for one zip at a time.
 
 **Security:**
 - All S3 keys validated: EIN `^\d{9}$`, object_id `^\d+$`, batch_id `^\d{4}_TEOS_XML_\w+$`
@@ -194,22 +223,29 @@ class S3990Archive:
 
 **Implementation:**
 1. Acquire advisory lock (`pg_advisory_xact_lock(hashtext('990-family'))`)
-2. Query filings to process:
-   - `--backfill`: `SELECT * FROM filing_index WHERE ein IN (SELECT ein FROM nonprofits_seed) AND status = 'indexed' AND xml_batch_id IS NOT NULL`
-   - Default (incremental): same query + `AND first_indexed_at >= now() - interval '7 days'`
-   - `--ein X`: same query + `AND ein = :ein`
+2. Query filings to process (two passes):
+   - **Pass 1 — Download**: `status = 'indexed' AND xml_batch_id IS NOT NULL` (need zip download + extraction)
+   - **Pass 2 — Parse**: `status = 'downloaded'` (already extracted to S3, need parsing — catches prior failures)
+   - Both passes filter: `ein IN (SELECT ein FROM nonprofits_seed)`
+   - `--backfill`: no time filter
+   - Default (incremental): `AND first_indexed_at >= now() - interval '7 days'` (Pass 1 only; Pass 2 always runs without time filter to recover stalled `downloaded` rows)
+   - `--ein X`: additional `AND ein = :ein`
 3. Group results by `(filing_year, xml_batch_id)`
 4. For each batch group:
    a. Check S3 for cached zip → if missing, download from IRS to S3 (validate hostname, TLS, size cap 5 GB, ETag integrity)
-   b. Open zip from S3, iterate over target filings in the group:
+   b. Open zip from S3 (via `SpooledTemporaryFile` for large zips). Pre-validate:
+      - Check member count (`len(zf.namelist()) <= 200_000`)
+      - Track cumulative extracted bytes (cap at 10 GB per batch)
+      Iterate over target filings in the group:
       - Validate member name against `_MEMBER_NAME_RE`
-      - Check compression ratio (<100:1) and file size (<50 MB)
+      - Check compression ratio: `info.file_size / max(info.compress_size, 1) <= 100`
+      - Check file size: `info.file_size <= _MAX_MEMBER_SIZE` (50 MB)
       - Extract XML bytes into memory
       - Upload to `s3://lavandula-990-corpus/xml/{ein}/{object_id}.xml`
       - Update `filing_index.status = 'downloaded'`, set `s3_xml_key`
    c. Parse each downloaded filing:
       - Read XML from S3 (or use in-memory bytes from step b if still available)
-      - Parse with `defusedxml.ElementTree` (no XXE, no entities, 30s timeout)
+      - Parse with `defusedxml.ElementTree.fromstring()` which defends against XXE, entity expansion (billion-laughs), and quadratic blowup out of the box. For the 30-second timeout: wrap the parse call in `signal.alarm(30)` on Linux (SIGALRM). If timeout fires, mark filing as `error` with `XML_PARSE_TIMEOUT`.
       - Extract people/compensation → insert into `people` table with `ON CONFLICT DO NOTHING`
       - Update `filing_index.status = 'parsed'`
    d. On error: mark filing as `error` with structured error code, continue to next filing
@@ -278,7 +314,11 @@ Description=990 index refresh and auto-process
 Type=oneshot
 User=ubuntu
 WorkingDirectory=/home/ubuntu/research/lavandula/dashboard
-ExecStart=/bin/bash -c 'python3 manage.py load_990_index --current-year && python3 manage.py process_990_auto'
+# Two ExecStart lines: systemd runs them sequentially, but the second runs
+# even if the first fails (unlike shell &&). Index refresh failure should
+# not block processing of already-indexed filings.
+ExecStart=/usr/bin/python3 manage.py load_990_index --current-year
+ExecStart=/usr/bin/python3 manage.py process_990_auto
 StandardOutput=journal
 StandardError=journal
 SyslogIdentifier=990-nightly
@@ -330,6 +370,11 @@ SyslogIdentifier=990-nightly
 - Query `IndexRefreshLog` for latest refresh per year
 - Show banner: "Last refreshed: {date} — {total} filings indexed"
 - Filing count breakdown by status
+
+**Index Maintenance admin view** (new URL: `/dashboard/990/maintenance/`):
+- Per-year table: year, last refresh date, total filings, filings by status (indexed/downloaded/parsed/error/batch_unresolvable)
+- Unresolved batch IDs count (NULL `xml_batch_id` rows)
+- Button to trigger manual refresh for a specific year
 
 **ACs covered:** AC23, AC24, AC25
 

--- a/locard/projectlist.md
+++ b/locard/projectlist.md
@@ -487,9 +487,22 @@ projects:
     tags: [classifier, cleanup, data-quality, dashboard]
     notes: "Identified 2026-05-01: gemma_client.py line 229 overwrites result['classification'] with material_type_to_legacy(mt), collapsing granular labels to 5 buckets. material_type column preserves the real data. Dashboard reports page already uses material_type; crawler/classifier views still show classification. Surfaces to clean: gemma_client.py, pipeline_classify.py log line, crawler.html, classifier.html, report_detail.html, taxonomy.py _MATERIAL_TYPE_TO_LEGACY dict."
 
+  - id: "0030"
+    title: "990 Filing Index Automation & S3 Archive"
+    summary: "Bulk-load the complete IRS TEOS 990 index (2017-2026, ~2.6M rows), store batch zips and per-org XMLs in S3 instead of EBS, and automatically maintain 990 data for all orgs in nonprofits_seed via nightly refresh and auto-process worker."
+    status: conceived
+    priority: high
+    files:
+      spec: locard/specs/0030-990-index-automation.md
+      plan: null
+      review: null
+    dependencies: ["0026", "0027"]
+    tags: [990, infrastructure, s3, automation, pipeline]
+    notes: "Motivated by 2026-05-01 investigation: 2017-2023 index CSVs silently dropped (9-col vs 10-col bug), 70-90 MB CSV re-downloaded on every manual request, zip cache on expensive EBS. Full index is trivially small for Postgres. S3 bucket: lavandula-990-corpus (separate from collaterals)."
+
 ## Next Available Number
 
-**0030** - Reserve this number for your next project
+**0031** - Reserve this number for your next project
 
 ---
 

--- a/locard/projectlist.md
+++ b/locard/projectlist.md
@@ -490,15 +490,15 @@ projects:
   - id: "0030"
     title: "990 Filing Index Automation & S3 Archive"
     summary: "Bulk-load the complete IRS TEOS 990 index (2017-2026, ~2.6M rows), store batch zips and per-org XMLs in S3 instead of EBS, and automatically maintain 990 data for all orgs in nonprofits_seed via nightly refresh and auto-process worker."
-    status: conceived
+    status: specified
     priority: high
     files:
       spec: locard/specs/0030-990-index-automation.md
-      plan: null
+      plan: locard/plans/0030-990-index-automation.md
       review: null
     dependencies: ["0026", "0027"]
     tags: [990, infrastructure, s3, automation, pipeline]
-    notes: "Motivated by 2026-05-01 investigation: 2017-2023 index CSVs silently dropped (9-col vs 10-col bug), 70-90 MB CSV re-downloaded on every manual request, zip cache on expensive EBS. Full index is trivially small for Postgres. S3 bucket: lavandula-990-corpus (separate from collaterals)."
+    notes: "Spec approved 2026-05-01 after 4 review rounds (Codex spec + red-team, Claude spec + red-team). 32 ACs, 7 phases. S3 bucket: lavandula-990-corpus. Unified codebase — manual controls reuse new infrastructure."
 
 ## Next Available Number
 

--- a/locard/projectlist.md
+++ b/locard/projectlist.md
@@ -490,7 +490,7 @@ projects:
   - id: "0030"
     title: "990 Filing Index Automation & S3 Archive"
     summary: "Bulk-load the complete IRS TEOS 990 index (2017-2026, ~2.6M rows), store batch zips and per-org XMLs in S3 instead of EBS, and automatically maintain 990 data for all orgs in nonprofits_seed via nightly refresh and auto-process worker."
-    status: specified
+    status: implementing
     priority: high
     files:
       spec: locard/specs/0030-990-index-automation.md
@@ -498,7 +498,7 @@ projects:
       review: null
     dependencies: ["0026", "0027"]
     tags: [990, infrastructure, s3, automation, pipeline]
-    notes: "Spec approved 2026-05-01 after 4 review rounds (Codex spec + red-team, Claude spec + red-team). 32 ACs, 7 phases. S3 bucket: lavandula-990-corpus. Unified codebase — manual controls reuse new infrastructure."
+    notes: "Spec approved 2026-05-01 after 4 review rounds (Codex spec + red-team, Claude spec + red-team). Plan approved 2026-05-01 after 4 review rounds (Codex plan + red-team, Claude plan + red-team). 32 ACs, 8 phases. S3 bucket: lavandula-990-corpus. Unified codebase — manual controls reuse new infrastructure. Builder spawned 2026-05-01."
 
 ## Next Available Number
 

--- a/locard/projectlist.md
+++ b/locard/projectlist.md
@@ -451,7 +451,7 @@ projects:
   - id: "0027"
     title: "990 Dashboard: Org Detail View & Pipeline Controls"
     summary: "Enhance the dashboard org detail page with 990 leadership data (officers, directors, compensation, Schedule J) and add two pipeline control forms for TEOS Index Download and 990 XML Parse/Import."
-    status: implementing
+    status: committed
     priority: high
     files:
       spec: locard/specs/0027-990-dashboard-org-detail.md
@@ -459,7 +459,7 @@ projects:
       review: null
     dependencies: ["0019", "0026"]
     tags: [dashboard, django, ui, 990, pipeline-controls]
-    notes: "Spec approved 2026-05-01 after Codex spec-review + red-team. Plan approved 2026-05-01 after Codex plan-review + red-team + Claude plan-review + red-team (0 CRITICAL, 0 HIGH). 47 ACs, 8 phases, 17 files."
+    notes: "Spec approved 2026-05-01. Plan approved 2026-05-01 after Codex + Claude plan-review + red-team. PR #23 merged 2026-05-01 after 2 integration review rounds (Codex + Claude). 47 ACs, 19 files, 74 tests. Awaiting operator: Django migration + live validation."
 
   - id: "0028"
     title: "Contractor Intelligence Resolver"

--- a/locard/specs/0030-990-index-automation.md
+++ b/locard/specs/0030-990-index-automation.md
@@ -36,9 +36,9 @@ A background worker that keeps 990 data current for every org in `nonprofits_see
 2. **Nightly schedule** — Runs after index refresh. The reconciliation query naturally picks up: (a) new filings added by the index refresh, (b) filings for orgs added to the seed list since the last run.
 3. **Backfill** — On first run with `--backfill`, processes all existing `nonprofits_seed` EINs that have indexed but unprocessed filings. Without `--backfill`, limits to filings with `first_indexed_at` within the last 7 days (recent index additions only).
 
-### Goal 4: Manual Controls Remain
+### Goal 4: Unified Codebase — Manual Controls Reuse New Infrastructure
 
-The dashboard 990 Index and 990 Parse forms stay available for ad-hoc use (e.g., one-off EINs not in the seed list). But for tracked orgs, the pipeline is fully automatic.
+The dashboard 990 Index and 990 Parse forms stay available for ad-hoc use (e.g., one-off EINs not in the seed list). But they are **refactored to call the same new code** — the orchestrator invokes `load_990_index --ein X` and `process_990_auto --ein X` instead of the old `teos_index.py` / `teos_download.py` EBS-based paths. One codebase, two entry points (nightly cron and dashboard button). The old EBS cache code paths (`~/.lavandula/990-cache/`, per-request CSV download) are retired after the new infrastructure is proven.
 
 ## Non-Goals
 

--- a/locard/specs/0030-990-index-automation.md
+++ b/locard/specs/0030-990-index-automation.md
@@ -1,0 +1,285 @@
+# Spec 0030: 990 Filing Index Automation & S3 Archive
+
+**Status**: Draft
+**Author**: Architect
+**Date**: 2026-05-01
+
+## Problem
+
+The current 990 pipeline requires a human to manually trigger index downloads for specific EINs and years. Each request re-downloads a 70–90 MB IRS index CSV, scans 700K+ rows, and discards the result after extracting one match. This is slow (~12 seconds per year), wasteful, and doesn't scale.
+
+Additionally:
+- **2017–2023 indexes are silently ignored** — the IRS added an `XML_BATCH_ID` column in 2024; our indexer requires 10 columns and silently skips all 9-column rows from older years, losing 8 years of filing history.
+- **Zip downloads sit on expensive EBS** — the local cache at `~/.lavandula/990-cache/` already holds 1.4 GB from 3 zips. A full backfill across ~120 batch zips would be 50–80 GB on EBS.
+- **No automatic maintenance** — when new orgs are added to `nonprofits_seed` or new filings appear in the IRS index, nothing happens until a human notices and clicks buttons.
+
+## Goals
+
+### Goal 1: Bulk Index Load & Maintenance
+
+Pre-load the complete IRS TEOS filing index for all available years (2017–2026) into `filing_index`. Maintain it with a nightly job that refreshes the current year's index to pick up new filings.
+
+**Why all EINs, not just ours?** The full 990 index is ~2.6M rows — trivially small for Postgres. Pre-loading everything means:
+- Instant lookup when a new org is added to our seed list
+- No per-request CSV downloads
+- No filtering logic at index time (filter at query time instead)
+
+### Goal 2: S3-Backed 990 Archive
+
+Replace local EBS zip cache with a dedicated S3 bucket. Download IRS batch zips to S3 once, extract individual per-org XML files to a structured prefix (`990-xml/{ein}/{object_id}.xml`). Parse from S3, not local disk.
+
+### Goal 3: Automatic 990 Processing for Tracked Orgs
+
+A background worker that keeps 990 data current for every org in `nonprofits_seed`:
+
+1. **New org trigger** — When an EIN is added to `nonprofits_seed`, check `filing_index` for matching filings and queue them for download/parse.
+2. **New filing trigger** — After the nightly index refresh, identify new `filing_index` rows where the EIN exists in `nonprofits_seed` and queue them for download/parse.
+3. **Backfill** — On first run, process all existing `nonprofits_seed` EINs that have indexed but unprocessed filings.
+
+### Goal 4: Manual Controls Remain
+
+The dashboard 990 Index and 990 Parse forms stay available for ad-hoc use (e.g., one-off EINs not in the seed list). But for tracked orgs, the pipeline is fully automatic.
+
+## Non-Goals
+
+- Parsing 990-EZ, 990-PF, or 990-T. Continue filtering to `RETURN_TYPE = '990'` only.
+- Real-time streaming from IRS. The IRS updates indexes daily/weekly; nightly refresh is sufficient.
+- Deleting the dashboard manual controls. They remain for ad-hoc use.
+- Migrating existing parsed data. Already-parsed filings (`status = 'parsed'`) are untouched.
+
+## Data Source Analysis
+
+### IRS TEOS Index CSVs
+
+| Year | Rows | ~990s (50%) | Size | Columns |
+|------|------|-------------|------|---------|
+| 2017 | 489K | ~245K | 62 MB | 9 (no XML_BATCH_ID) |
+| 2018 | 457K | ~229K | 58 MB | 9 |
+| 2019 | 417K | ~209K | 53 MB | 9 |
+| 2020 | 399K | ~200K | 51 MB | 9 |
+| 2021 | 590K | ~295K | 75 MB | 9 |
+| 2022 | 657K | ~329K | 72 MB | 9 |
+| 2023 | 705K | ~353K | 78 MB | 9 |
+| 2024 | 729K | 363K | 91 MB | 10 (has XML_BATCH_ID) |
+| 2025 | 749K | ~375K | 93 MB | 10 |
+| 2026 | 99K | ~50K | 12 MB | 10 |
+| **Total** | **~5.3M** | **~2.6M** | **~645 MB** | |
+
+### Column Format Change
+
+- **2017–2023**: 9 columns — `RETURN_ID, FILING_TYPE, EIN, TAX_PERIOD, SUB_DATE, TAXPAYER_NAME, RETURN_TYPE, DLN, OBJECT_ID`
+- **2024–2026**: 10 columns — same + `XML_BATCH_ID`
+
+### IRS Batch Zip Structure
+
+- URL pattern: `https://apps.irs.gov/pub/epostcard/990/xml/{year}/{batch_id}.zip`
+- Batch IDs: `{year}_TEOS_XML_{01A..12A}` (monthly batches, some months have B/C/D sub-batches)
+- 2024 has 12 batches, 2025 has ~16 (with sub-batches), 2022 has only 2
+- Zip sizes: 100 MB – 2.5 GB each
+- Member paths: nested `{batch_id}/{object_id}_public.xml` (2024) or flat `{object_id}_public.xml` (2025) — already handled by the fix in commit c092ce8
+- Total estimated zip storage: 50–80 GB across all years
+
+### Scale for Our Orgs
+
+- `nonprofits_seed` has ~38K EINs
+- 2024 index has 334K unique 990-filing EINs
+- Our orgs represent ~10-15% of all 990 filers
+- Estimated filings to process: 100–200K across 10 years
+
+## Technical Design
+
+### Phase 1: Fix the 9-Column Bug
+
+Change `teos_index.py` to accept 9-column rows. When `XML_BATCH_ID` is missing (2017–2023 indexes), store `NULL` in `filing_index.xml_batch_id`.
+
+### Phase 2: Bulk Index Loader
+
+New management command: `manage.py load_990_index`
+
+```
+# Load all available years
+python3 manage.py load_990_index
+
+# Load specific years
+python3 manage.py load_990_index --years 2024,2025
+
+# Refresh current year only (for nightly cron)
+python3 manage.py load_990_index --current-year
+```
+
+Behavior:
+- Downloads each year's index CSV
+- Inserts all `RETURN_TYPE = '990'` rows into `filing_index` via `ON CONFLICT (object_id) DO NOTHING`
+- For 9-column years, `xml_batch_id` = NULL
+- Reports: rows scanned, matched (990), inserted, skipped per year
+- Idempotent — safe to re-run
+
+### Phase 3: Resolve Missing Batch IDs
+
+For 2017–2023 filings where `xml_batch_id IS NULL`, we need to determine which batch zip contains each filing's XML.
+
+Approach: **Batch manifest scan** — for each year, download each batch zip's file listing (not the full zip), build an `object_id → batch_id` mapping, and update `filing_index`.
+
+```sql
+UPDATE filing_index SET xml_batch_id = :batch_id
+WHERE object_id = :object_id AND xml_batch_id IS NULL;
+```
+
+This is a one-time backfill. New filings (2024+) always have `xml_batch_id` in the index.
+
+Implementation note: Python's `zipfile` module can read the central directory from a remote zip via HTTP Range requests without downloading the entire file. If the IRS server supports Range (likely), we can resolve batch membership for ~2M filings by downloading only the central directories (~1-5 MB each vs 100 MB–2.5 GB for the full zip). If Range isn't supported, fall back to downloading full zips.
+
+### Phase 4: S3 Bucket & Archive
+
+New S3 bucket: `lavandula-990-corpus` (us-east-1, SSE-S3, versioned, private)
+
+Prefix structure:
+```
+s3://lavandula-990-corpus/
+  zips/{year}/{batch_id}.zip          # IRS batch zips (cached, Glacier-eligible)
+  xml/{ein}/{object_id}.xml           # Extracted per-org XMLs (working set)
+```
+
+Download flow:
+1. Check if `zips/{year}/{batch_id}.zip` exists in S3
+2. If not, download from IRS → stream to S3
+3. Extract target filing's XML member → upload to `xml/{ein}/{object_id}.xml`
+4. Parse from S3 (stream XML through memory, same as current `teos_download.py` logic)
+
+The `xml/` prefix is organized by EIN for easy per-org access and lifecycle management.
+
+### Phase 5: Auto-Process Worker
+
+New management command: `manage.py process_990_auto`
+
+Behavior:
+1. Query `filing_index` for filings where:
+   - `ein IN (SELECT ein FROM nonprofits_seed)`
+   - `status = 'indexed'` (not yet downloaded/parsed)
+   - `xml_batch_id IS NOT NULL` (batch resolved)
+2. Group by `(filing_year, xml_batch_id)` for efficient batch zip reuse
+3. For each batch: download zip (or use S3 cache), extract matching XMLs, parse, update status
+4. Concurrency: single worker, processes one batch at a time (same advisory lock pattern as existing 990 jobs)
+
+Run modes:
+- **Backfill**: `manage.py process_990_auto --backfill` — process all unprocessed filings for tracked orgs
+- **Incremental**: `manage.py process_990_auto` — process only filings indexed since last run
+- **Single EIN**: `manage.py process_990_auto --ein 030440761` — process one org (useful for testing)
+
+### Phase 6: Nightly Cron
+
+A cron job (or systemd timer) that runs:
+```bash
+# 1. Refresh the current year's index
+python3 manage.py load_990_index --current-year
+
+# 2. Process any new filings for tracked orgs
+python3 manage.py process_990_auto
+```
+
+Schedule: nightly at 03:00 UTC (IRS updates are infrequent, daily is more than enough).
+
+### Phase 7: Dashboard Changes
+
+- **990 Index page**: Add status banner showing last index refresh time and total indexed filings. The "Queue Index Job" form remains for ad-hoc use but is no longer the primary path.
+- **Org Detail page**: Filing list is now pre-populated. No manual indexing needed for tracked orgs.
+- **New admin view**: Index maintenance status — last refresh per year, total filings by year, unresolved batch IDs count.
+
+## Schema Changes
+
+### filing_index modifications
+
+```sql
+-- Allow NULL xml_batch_id for 2017-2023 filings
+ALTER TABLE lava_corpus.filing_index
+  ALTER COLUMN xml_batch_id DROP NOT NULL;
+
+-- Add column to track when filing was indexed
+ALTER TABLE lava_corpus.filing_index
+  ADD COLUMN indexed_at TIMESTAMPTZ DEFAULT now();
+
+-- Add column for S3 XML location (set after extraction)
+ALTER TABLE lava_corpus.filing_index
+  ADD COLUMN s3_xml_key TEXT;
+```
+
+### New table: index_refresh_log
+
+```sql
+CREATE TABLE lava_corpus.index_refresh_log (
+    id              SERIAL PRIMARY KEY,
+    filing_year     INTEGER NOT NULL,
+    refreshed_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+    rows_scanned    INTEGER NOT NULL DEFAULT 0,
+    rows_inserted   INTEGER NOT NULL DEFAULT 0,
+    rows_skipped    INTEGER NOT NULL DEFAULT 0,
+    duration_sec    NUMERIC(8,2)
+);
+```
+
+## Acceptance Criteria
+
+### Goal 1: Bulk Index
+- AC1: `load_990_index` downloads and inserts all 990 rows from years 2017–2026
+- AC2: 9-column CSVs (2017–2023) are processed correctly with `xml_batch_id = NULL`
+- AC3: 10-column CSVs (2024–2026) are processed with `xml_batch_id` populated
+- AC4: Idempotent — re-running inserts 0 new rows
+- AC5: `--current-year` flag only fetches the current year
+- AC6: `index_refresh_log` records stats for each run
+- AC7: Existing `teos_index.py` is updated to accept 9-column rows (fixes current silent-skip bug)
+
+### Goal 2: S3 Archive
+- AC8: New S3 bucket `lavandula-990-corpus` created with SSE-S3, versioning, private ACL
+- AC9: Batch zips download from IRS to `s3://lavandula-990-corpus/zips/`
+- AC10: Per-org XMLs extracted to `s3://lavandula-990-corpus/xml/{ein}/{object_id}.xml`
+- AC11: `filing_index.s3_xml_key` populated after extraction
+- AC12: Parse reads XML from S3, not local disk
+- AC13: Local EBS cache (`~/.lavandula/990-cache/`) no longer used for new downloads
+
+### Goal 3: Auto-Process
+- AC14: `process_990_auto` processes all unprocessed filings for `nonprofits_seed` EINs
+- AC15: `--backfill` mode processes historical filings
+- AC16: Incremental mode processes only newly indexed filings
+- AC17: Batch zip reuse — multiple filings from same zip don't re-download
+- AC18: Advisory lock prevents concurrent auto-process runs
+- AC19: After nightly cron, new IRS filings for tracked orgs are automatically parsed
+
+### Goal 4: Batch ID Resolution
+- AC20: Filings from 2017–2023 have `xml_batch_id` resolved via batch manifest scan
+- AC21: HTTP Range requests used if supported by IRS server; full download fallback otherwise
+- AC22: Resolution is idempotent and only targets `xml_batch_id IS NULL` rows
+
+### Goal 5: Dashboard
+- AC23: 990 Index page shows last refresh time and total indexed filings
+- AC24: Manual index/parse forms still work for ad-hoc use
+- AC25: Org Detail filing list is pre-populated for tracked orgs
+
+## Migration Path
+
+1. Fix 9-column bug in existing `teos_index.py` (immediate, unblocks 2017–2023)
+2. Run `load_990_index` to bulk-load all years (~2.6M rows, ~10 minutes)
+3. Resolve batch IDs for 2017–2023 filings
+4. Create S3 bucket and migrate download path
+5. Run `process_990_auto --backfill` for initial processing
+6. Enable nightly cron
+7. Update dashboard
+
+Steps 1–3 can ship independently. Steps 4–6 are the main body. Step 7 is polish.
+
+## Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|-----------|--------|------------|
+| IRS changes CSV format again | Low | Medium | Column count detection already handles 9 vs 10; header parsing would be more robust |
+| IRS rate-limits bulk zip downloads | Medium | Medium | Download one zip at a time with 5s delay; cache in S3 so we only download once |
+| HTTP Range not supported for batch manifest scan | Medium | Low | Fall back to full zip download; still one-time cost |
+| 50-80 GB S3 storage cost | Low | Low | ~$1-2/month at S3 standard; zips can move to Glacier after extraction |
+| Backfill takes too long | Low | Medium | Process in priority order (recent years first); can run over multiple nights |
+
+## Traps to Avoid
+
+1. **Don't filter by EIN at index time** — load all 990s, filter at query time. The full index is tiny for Postgres.
+2. **Don't assume 10 columns** — 2017–2023 have 9. Check `len(row) >= 9`, not `< 10`.
+3. **Don't download full zips for batch ID resolution** — use HTTP Range to read zip central directories first.
+4. **Don't store extracted XMLs on EBS** — S3 only. EBS is for hot data (DB, code, logs).
+5. **Zip member paths vary** — 2024 uses nested `{batch}/{oid}_public.xml`, 2025 uses flat `{oid}_public.xml`. Already fixed in commit c092ce8.

--- a/locard/specs/0030-990-index-automation.md
+++ b/locard/specs/0030-990-index-automation.md
@@ -34,7 +34,7 @@ A background worker that keeps 990 data current for every org in `nonprofits_see
 
 1. **Reconciliation-based trigger** — `process_990_auto` runs a JOIN query: `filing_index.ein IN (SELECT ein FROM nonprofits_seed) AND status = 'indexed' AND xml_batch_id IS NOT NULL`. This catches both new orgs and new filings in one pass — no DB triggers or app-layer hooks needed.
 2. **Nightly schedule** — Runs after index refresh. The reconciliation query naturally picks up: (a) new filings added by the index refresh, (b) filings for orgs added to the seed list since the last run.
-3. **Backfill** — On first run with `--backfill`, processes all existing `nonprofits_seed` EINs that have indexed but unprocessed filings. Without `--backfill`, limits to filings with `indexed_at` within the last 7 days (recent index additions only).
+3. **Backfill** — On first run with `--backfill`, processes all existing `nonprofits_seed` EINs that have indexed but unprocessed filings. Without `--backfill`, limits to filings with `first_indexed_at` within the last 7 days (recent index additions only).
 
 ### Goal 4: Manual Controls Remain
 
@@ -47,6 +47,7 @@ The dashboard 990 Index and 990 Parse forms stay available for ad-hoc use (e.g.,
 - Deleting the dashboard manual controls. They remain for ad-hoc use.
 - Migrating existing parsed data. Already-parsed filings (`status = 'parsed'`) are untouched.
 - SSE-KMS encryption. SSE-S3 (AES-256) is sufficient — this is public IRS data, not PII. KMS adds cost and complexity for no security benefit here.
+- Pre-2017 filing data. IRS TEOS indexes return 404 for years before 2017. If older e-file data becomes available in the future, add those years to the loader.
 
 ## Filing Status Lifecycle
 
@@ -142,10 +143,11 @@ python3 manage.py load_990_index --current-year
 
 Behavior:
 - Downloads each year's index CSV
-- Inserts all `RETURN_TYPE = '990'` rows into `filing_index` via `ON CONFLICT (object_id) DO UPDATE SET indexed_at = now()` — this updates `indexed_at` on re-runs so the incremental window stays accurate even if an existing filing re-appears in a refreshed index.
+- Inserts all `RETURN_TYPE = '990'` rows into `filing_index` via `ON CONFLICT (object_id) DO UPDATE SET last_seen_at = now()` — `first_indexed_at` is immutable (set on insert only), `last_seen_at` refreshes on every re-run. The incremental window in Phase 5 uses `first_indexed_at` so re-runs don't re-trigger processing of old filings.
 - For 9-column years, `xml_batch_id` = NULL
 - Reports: rows scanned, matched (990), inserted, skipped per year
-- Idempotent — safe to re-run (data columns unchanged, only `indexed_at` refreshed)
+- Idempotent — safe to re-run (data columns unchanged, only `last_seen_at` refreshed)
+- **Concurrency:** Acquires `pg_advisory_xact_lock` (same lock family as 990 jobs) to prevent concurrent loader runs. If a manual index job is running, the loader waits.
 
 ### Phase 3: Resolve Missing Batch IDs
 
@@ -164,7 +166,7 @@ Implementation note: Python's `zipfile` module can read the central directory fr
 
 **Feasibility strategy:**
 1. First, issue a HEAD + Range probe on a single 2022 batch zip.
-2. If Range is supported: read central directories only (~50 MB total across all old batches).
+2. If Range is supported: read central directories only (~50 MB total across all old batches). **Zip64 handling required** — the 2025 batches (2.5 GB) almost certainly use Zip64 format, which has a different End-of-Central-Directory (EOCD64) structure. The implementation must: (a) fetch the last 64 KB to find the EOCD, (b) detect the Zip64 EOCD locator if present, (c) fetch the Zip64 EOCD to get the true central directory offset. Python's `zipfile` module handles Zip64 natively when reading from a file-like object.
 3. If Range is NOT supported: download full zips to S3 and read manifests locally. This costs 10-20 GB of one-time transfer for 2017–2023 (the zips we'd download eventually anyway for parsing). Since S3 caches them, this is not wasted work.
 4. **Stop condition**: If any year has zero resolvable batch zips (404s for all batch patterns), log a warning and mark those year's filings as `batch_unresolvable`. They won't block the rest of the pipeline.
 
@@ -176,7 +178,7 @@ New S3 bucket: `lavandula-990-corpus` (us-east-1, SSE-S3, versioned, private)
 - `BlockPublicAccess`: all four settings enabled (BlockPublicAcls, IgnorePublicAcls, BlockPublicPolicy, RestrictPublicBuckets)
 - IAM: same `cloud2_lavandulagroup` role used by the existing `lavandula-nonprofit-collaterals` bucket. Scoped to `s3:GetObject`, `s3:PutObject`, `s3:ListBucket`, `s3:HeadObject` on this bucket only.
 - Encryption: SSE-S3 (AES-256). Not SSE-KMS — this is public IRS data, KMS adds cost for no benefit.
-- Lifecycle: `zips/` prefix transitions to Glacier after 30 days (one-time downloads, re-downloadable from IRS). `xml/` prefix stays Standard (active working set).
+- Lifecycle: `zips/` prefix transitions to Standard-IA after 30 days (cheaper than Standard, but no retrieval delay — Glacier would block new-org backfills for hours). `xml/` prefix stays Standard (active working set).
 - Object keys contain EINs — these are public identifiers (IRS publishes them), not PII.
 
 Prefix structure:
@@ -209,7 +211,7 @@ Behavior:
 
 Run modes:
 - **Backfill**: `manage.py process_990_auto --backfill` — process all unprocessed filings for tracked orgs (no time filter)
-- **Incremental** (default): `manage.py process_990_auto` — process filings with `indexed_at` within the last 7 days AND `status = 'indexed'`. The 7-day window provides overlap to catch filings that were indexed but not yet batch-resolved during the previous run. Safe to run repeatedly — already-processed filings are skipped.
+- **Incremental** (default): `manage.py process_990_auto` — process filings with `first_indexed_at` within the last 7 days AND `status = 'indexed'`. Uses `first_indexed_at` (immutable, set on initial insert) so nightly index refreshes don't re-trigger old filings. The 7-day window provides overlap to catch filings that were indexed but not yet batch-resolved during the previous run. Safe to run repeatedly — already-processed filings are skipped.
 - **Single EIN**: `manage.py process_990_auto --ein 030440761` — process one org (useful for testing)
 
 **Failure handling:**
@@ -255,13 +257,18 @@ Schedule: nightly at 03:00 UTC. Logs to journald via `logger` (queryable with `j
 ALTER TABLE lava_corpus.filing_index
   ALTER COLUMN xml_batch_id DROP NOT NULL;
 
--- Add column to track when filing was indexed
+-- Track when filing was first indexed (immutable) and last seen in IRS index
 ALTER TABLE lava_corpus.filing_index
-  ADD COLUMN indexed_at TIMESTAMPTZ DEFAULT now();
+  ADD COLUMN first_indexed_at TIMESTAMPTZ DEFAULT now(),
+  ADD COLUMN last_seen_at TIMESTAMPTZ DEFAULT now();
 
 -- Add column for S3 XML location (set after extraction)
 ALTER TABLE lava_corpus.filing_index
   ADD COLUMN s3_xml_key TEXT;
+
+-- error_message column already exists (migration 010, Spec 0026)
+-- Verify: SELECT column_name FROM information_schema.columns
+--         WHERE table_name = 'filing_index' AND column_name = 'error_message';
 ```
 
 ### New table: index_refresh_log
@@ -306,8 +313,8 @@ CREATE TABLE lava_corpus.index_refresh_log (
 - AC19: After nightly cron, new IRS filings for tracked orgs are automatically parsed
 
 ### Goal 4: Batch ID Resolution
-- AC20: Filings from 2017–2023 have `xml_batch_id` resolved via batch manifest scan
-- AC21: HTTP Range requests used if supported by IRS server; full download fallback otherwise
+- AC20: Filings from 2017–2023 have `xml_batch_id` resolved OR status set to `batch_unresolvable`
+- AC21: HTTP Range requests used if supported by IRS server; full download fallback otherwise. Zip64 central directories handled for large (>2 GB) archives.
 - AC22: Resolution is idempotent and only targets `xml_batch_id IS NULL` rows
 
 ### Goal 5: Dashboard
@@ -315,13 +322,22 @@ CREATE TABLE lava_corpus.index_refresh_log (
 - AC24: Manual index/parse forms still work for ad-hoc use
 - AC25: Org Detail filing list is pre-populated for tracked orgs
 
+### Goal 6: Security
+- AC26: CSV fields validated against allowlist patterns before use in URLs or S3 keys
+- AC27: XML parser defends against XXE, billion-laughs, quadratic blowup, and depth attacks
+- AC28: Zip extraction checks compression ratio (reject >100:1) and total extracted size (cap 10 GB)
+- AC29: All IRS downloads use HTTPS with TLS verification; hostname restricted to `apps.irs.gov`
+- AC30: `--ein` flag processes a single EIN (for testing and ad-hoc use)
+- AC31: `--reparse` flag re-processes filings in `error` state
+- AC32: `manage.py reset_990_status` command resets `error` → `indexed` for specified EINs or object_ids
+
 ## Testing Strategy
 
 ### Unit Tests
 - **9-column vs 10-column CSV parsing**: Synthetic CSV fixtures with 9 and 10 columns. Verify both produce correct `filing_index` rows (9-col has `xml_batch_id=NULL`).
 - **Idempotent re-run**: Insert rows, re-run loader, assert 0 new inserts.
 - **Batch ID resolution logic**: Mock zip central directory responses, verify `object_id → batch_id` mapping.
-- **Status transitions**: Verify each transition (`indexed → downloaded → parsed`, `any → error`, `error �� indexed` reset).
+- **Status transitions**: Verify each transition (`indexed → downloaded → parsed`, `any → error`, `error → indexed` reset).
 - **Incremental selection**: Verify 7-day window filter, verify `--backfill` ignores the window.
 
 ### Integration Tests
@@ -332,8 +348,12 @@ CREATE TABLE lava_corpus.index_refresh_log (
 
 ### Security Tests
 - **XXE prevention**: Feed an XML with external entity declarations, verify parser rejects it.
+- **Billion-laughs defense**: Feed an XML with exponentially expanding entities, verify parser rejects or times out.
 - **Oversized XML member**: Zip with a 60 MB member, verify extraction is blocked by `_MAX_MEMBER_SIZE`.
+- **Zip bomb**: Zip with 1000:1 compression ratio, verify rejected before full decompression.
 - **Malicious zip member name**: Zip with path traversal (`../../etc/passwd`), verify `_MEMBER_NAME_RE` rejects it.
+- **CSV field injection**: CSV row with EIN containing path-traversal characters (`../`), verify row rejected by validation.
+- **TLS verification**: Mock a non-IRS redirect, verify download aborted.
 
 ### Edge Case Tests
 - **Parsed-data idempotency**: Parse the same filing twice, verify no duplicate `people` rows.
@@ -359,6 +379,8 @@ CREATE TABLE lava_corpus.index_refresh_log (
 
 Steps 1–3 can ship independently. Steps 4–6 are the main body. Step 7 is polish.
 
+**Backfill time estimate:** ~100–200K filings across ~120 batch zips. Each batch zip download takes 1–5 minutes (100 MB–2.5 GB). XML extraction + parse is ~10ms per filing. Bottleneck is zip downloads. With 5-second delay between downloads: ~120 zips × 3 min avg = ~6 hours. Can run overnight; if split across 2 nights, process recent years (2024–2026) first for immediate value.
+
 ## Risks & Mitigations
 
 | Risk | Likelihood | Impact | Mitigation |
@@ -366,16 +388,22 @@ Steps 1–3 can ship independently. Steps 4–6 are the main body. Step 7 is pol
 | IRS changes CSV format again | Low | Medium | Column count detection already handles 9 vs 10; header parsing would be more robust |
 | IRS rate-limits bulk zip downloads | Medium | Medium | Download one zip at a time with 5s delay; cache in S3 so we only download once |
 | HTTP Range not supported for batch manifest scan | Medium | Low | Fall back to full zip download; still one-time cost |
-| 50-80 GB S3 storage cost | Low | Low | ~$1-2/month at S3 standard; zips can move to Glacier after extraction |
+| 50-80 GB S3 storage cost | Low | Low | ~$1-2/month at Standard-IA; PUT/GET for 200K objects ~$1 one-time |
 | Backfill takes too long | Low | Medium | Process in priority order (recent years first); can run over multiple nights |
 
 ## Security Requirements
 
-1. **Safe XML parsing**: Use `defusedxml` or `lxml` with `resolve_entities=False`, `no_network=True`. No external entity resolution. No DTD loading.
+1. **Safe XML parsing**: Use `defusedxml` or `lxml` with `resolve_entities=False`, `no_network=True`. Defend against XXE, billion-laughs, quadratic blowup, and excessive depth. Set parse timeout of 30 seconds per filing. No DTD loading.
 2. **Zip extraction by exact name only**: Only extract members matching `{object_id}_public.xml` pattern. Never extract arbitrary members or trust archive paths. Validate member name against `_MEMBER_NAME_RE` before extraction (already implemented in `teos_download.py`).
-3. **Size limits**: Max 50 MB per extracted XML member (already enforced by `_MAX_MEMBER_SIZE`). Max 3 GB per batch zip download. Reject oversized responses before buffering.
-4. **S3 bucket**: All four `BlockPublicAccess` settings enabled. ACLs disabled (bucket-owner-enforced). IAM scoped to this bucket only.
-5. **Error messages**: Use structured error codes in `error_message` (e.g., `ZIP_MEMBER_MISSING`, `XML_PARSE_FAILED`, `S3_UPLOAD_FAILED`), not raw exception strings that could leak environment details.
+3. **Zip-bomb protection**: Check `compress_size` vs `file_size` ratio (reject if ratio > 100:1). Cap total extracted size per batch at 10 GB. Cap member count at 200K per zip. These bounds are well above normal IRS batches (~75K members, ~2.5 GB compressed).
+4. **Size limits**: Max 50 MB per extracted XML member (already enforced by `_MAX_MEMBER_SIZE`). Max 5 GB per batch zip download (2025 batches are already 2.5 GB; allows headroom). Max 200 MB per index CSV download. Reject oversized responses via streaming with byte counter, not Content-Length alone.
+5. **CSV field validation**: Before interpolating CSV-derived values into URLs or S3 keys, validate: `EIN` matches `^\d{9}$`, `OBJECT_ID` matches `^\d+$`, `XML_BATCH_ID` matches `^\d{4}_TEOS_XML_\w+$`. Reject rows with non-conforming values. This prevents SSRF via crafted URLs and S3 key traversal via crafted batch IDs.
+6. **TLS and hostname allowlist**: All IRS downloads use HTTPS with TLS verification enabled (default `requests` behavior — never set `verify=False`). Hostname allowlist: `apps.irs.gov` only. Reject redirects to other hosts.
+7. **S3 integrity**: After uploading a zip to S3, store the `ETag` (MD5) returned by PutObject. Before reading from the cached zip, compare the stored ETag with a HeadObject call. Mismatch → re-download from IRS.
+8. **S3 bucket**: All four `BlockPublicAccess` settings enabled. ACLs disabled (bucket-owner-enforced). IAM scoped to this bucket only.
+9. **Error messages**: Use structured error codes in `error_message` (e.g., `ZIP_MEMBER_MISSING`, `XML_PARSE_FAILED`, `S3_UPLOAD_FAILED`), not raw exception strings that could leak environment details.
+10. **Dashboard auto-escape**: All CSV-sourced fields (`taxpayer_name`, `ein`, etc.) rendered in templates via Django's default auto-escape. No `|safe` filter on IRS-derived data. Already enforced by Spec 0027 convention.
+11. **Authorization**: The `--reparse` flag and `error → indexed` status reset are operator-only actions. Dashboard exposes them only to authenticated (`LoginRequiredMixin`) users. No public API for status manipulation.
 
 ## Traps to Avoid
 

--- a/locard/specs/0030-990-index-automation.md
+++ b/locard/specs/0030-990-index-automation.md
@@ -32,9 +32,9 @@ Replace local EBS zip cache with a dedicated S3 bucket. Download IRS batch zips 
 
 A background worker that keeps 990 data current for every org in `nonprofits_seed`:
 
-1. **New org trigger** — When an EIN is added to `nonprofits_seed`, check `filing_index` for matching filings and queue them for download/parse.
-2. **New filing trigger** — After the nightly index refresh, identify new `filing_index` rows where the EIN exists in `nonprofits_seed` and queue them for download/parse.
-3. **Backfill** — On first run, process all existing `nonprofits_seed` EINs that have indexed but unprocessed filings.
+1. **Reconciliation-based trigger** — `process_990_auto` runs a JOIN query: `filing_index.ein IN (SELECT ein FROM nonprofits_seed) AND status = 'indexed' AND xml_batch_id IS NOT NULL`. This catches both new orgs and new filings in one pass — no DB triggers or app-layer hooks needed.
+2. **Nightly schedule** — Runs after index refresh. The reconciliation query naturally picks up: (a) new filings added by the index refresh, (b) filings for orgs added to the seed list since the last run.
+3. **Backfill** — On first run with `--backfill`, processes all existing `nonprofits_seed` EINs that have indexed but unprocessed filings. Without `--backfill`, limits to filings with `indexed_at` within the last 7 days (recent index additions only).
 
 ### Goal 4: Manual Controls Remain
 
@@ -46,6 +46,31 @@ The dashboard 990 Index and 990 Parse forms stay available for ad-hoc use (e.g.,
 - Real-time streaming from IRS. The IRS updates indexes daily/weekly; nightly refresh is sufficient.
 - Deleting the dashboard manual controls. They remain for ad-hoc use.
 - Migrating existing parsed data. Already-parsed filings (`status = 'parsed'`) are untouched.
+- SSE-KMS encryption. SSE-S3 (AES-256) is sufficient — this is public IRS data, not PII. KMS adds cost and complexity for no security benefit here.
+
+## Filing Status Lifecycle
+
+`filing_index.status` tracks each filing through a linear pipeline. The `status` column already exists (Spec 0026, migration 010).
+
+```
+indexed → downloaded → parsed
+    ↘        ↘          ↘
+    error    error      error
+```
+
+**States:**
+- `indexed` — Filing appears in the IRS TEOS index. Metadata stored. No XML yet.
+- `downloaded` — XML extracted from batch zip and uploaded to S3. Ready for parsing.
+- `parsed` — XML parsed, people/compensation data written to `people` table.
+- `error` — Processing failed at any stage. `error_message` column has details.
+
+**Transition rules:**
+- `indexed → downloaded`: Batch zip downloaded (or cached in S3), XML member extracted and uploaded to `s3://lavandula-990-corpus/xml/{ein}/{object_id}.xml`.
+- `downloaded → parsed`: XML parsed successfully, people rows inserted.
+- `Any → error`: Failure at any stage. `error_message` records the cause.
+- `error → indexed`: Manual reset (via Django admin or management command) to retry from scratch.
+
+**Idempotency:** Each transition checks current status before acting. A filing already at `parsed` is skipped. A filing at `error` is skipped unless `--reparse` is passed. Re-running `process_990_auto` on an already-processed corpus inserts 0 rows.
 
 ## Data Source Analysis
 
@@ -127,11 +152,24 @@ WHERE object_id = :object_id AND xml_batch_id IS NULL;
 
 This is a one-time backfill. New filings (2024+) always have `xml_batch_id` in the index.
 
-Implementation note: Python's `zipfile` module can read the central directory from a remote zip via HTTP Range requests without downloading the entire file. If the IRS server supports Range (likely), we can resolve batch membership for ~2M filings by downloading only the central directories (~1-5 MB each vs 100 MB–2.5 GB for the full zip). If Range isn't supported, fall back to downloading full zips.
+Implementation note: Python's `zipfile` module can read the central directory from a remote zip via HTTP Range requests without downloading the entire file. If the IRS server supports Range, we can resolve batch membership for ~2M filings by downloading only the central directories (~1-5 MB each vs 100 MB–2.5 GB for the full zip).
+
+**Feasibility strategy:**
+1. First, issue a HEAD + Range probe on a single 2022 batch zip.
+2. If Range is supported: read central directories only (~50 MB total across all old batches).
+3. If Range is NOT supported: download full zips to S3 and read manifests locally. This costs 10-20 GB of one-time transfer for 2017–2023 (the zips we'd download eventually anyway for parsing). Since S3 caches them, this is not wasted work.
+4. **Stop condition**: If any year has zero resolvable batch zips (404s for all batch patterns), log a warning and mark those year's filings as `batch_unresolvable`. They won't block the rest of the pipeline.
 
 ### Phase 4: S3 Bucket & Archive
 
 New S3 bucket: `lavandula-990-corpus` (us-east-1, SSE-S3, versioned, private)
+
+**Bucket security:**
+- `BlockPublicAccess`: all four settings enabled (BlockPublicAcls, IgnorePublicAcls, BlockPublicPolicy, RestrictPublicBuckets)
+- IAM: same `cloud2_lavandulagroup` role used by the existing `lavandula-nonprofit-collaterals` bucket. Scoped to `s3:GetObject`, `s3:PutObject`, `s3:ListBucket`, `s3:HeadObject` on this bucket only.
+- Encryption: SSE-S3 (AES-256). Not SSE-KMS — this is public IRS data, KMS adds cost for no benefit.
+- Lifecycle: `zips/` prefix transitions to Glacier after 30 days (one-time downloads, re-downloadable from IRS). `xml/` prefix stays Standard (active working set).
+- Object keys contain EINs — these are public identifiers (IRS publishes them), not PII.
 
 Prefix structure:
 ```
@@ -141,8 +179,8 @@ s3://lavandula-990-corpus/
 ```
 
 Download flow:
-1. Check if `zips/{year}/{batch_id}.zip` exists in S3
-2. If not, download from IRS → stream to S3
+1. Check if `zips/{year}/{batch_id}.zip` exists in S3 (HEAD request)
+2. If not, download from IRS → stream to S3 (multipart upload for large zips)
 3. Extract target filing's XML member → upload to `xml/{ein}/{object_id}.xml`
 4. Parse from S3 (stream XML through memory, same as current `teos_download.py` logic)
 
@@ -162,22 +200,37 @@ Behavior:
 4. Concurrency: single worker, processes one batch at a time (same advisory lock pattern as existing 990 jobs)
 
 Run modes:
-- **Backfill**: `manage.py process_990_auto --backfill` — process all unprocessed filings for tracked orgs
-- **Incremental**: `manage.py process_990_auto` — process only filings indexed since last run
+- **Backfill**: `manage.py process_990_auto --backfill` — process all unprocessed filings for tracked orgs (no time filter)
+- **Incremental** (default): `manage.py process_990_auto` — process filings with `indexed_at` within the last 7 days AND `status = 'indexed'`. The 7-day window provides overlap to catch filings that were indexed but not yet batch-resolved during the previous run. Safe to run repeatedly — already-processed filings are skipped.
 - **Single EIN**: `manage.py process_990_auto --ein 030440761` — process one org (useful for testing)
+
+**Failure handling:**
+- **Missing XML member in zip**: Mark filing as `error` with message "XML member not found in batch zip". Do not stop the batch — continue processing remaining filings.
+- **Zip download interrupted**: Retry up to 3 times with exponential backoff. On final failure, log error and skip that batch. Filings remain `indexed` for the next run.
+- **Malformed XML**: Mark filing as `error` with parse exception message. Continue processing.
+- **S3 upload succeeds but DB update fails**: Filing stays at `indexed`. Next run re-extracts the XML (S3 PUT is idempotent) and retries the DB update.
+- **DB update succeeds but parse fails**: Filing is at `downloaded`. Next run picks it up for parsing. Already-uploaded S3 XML is reused.
 
 ### Phase 6: Nightly Cron
 
-A cron job (or systemd timer) that runs:
+A systemd timer (preferred over cron for logging and failure visibility) that runs:
 ```bash
+#!/bin/bash
+set -euo pipefail
+cd /home/ubuntu/research/lavandula/dashboard
+
 # 1. Refresh the current year's index
-python3 manage.py load_990_index --current-year
+python3 manage.py load_990_index --current-year 2>&1 | logger -t 990-index
 
 # 2. Process any new filings for tracked orgs
-python3 manage.py process_990_auto
+python3 manage.py process_990_auto 2>&1 | logger -t 990-auto
 ```
 
-Schedule: nightly at 03:00 UTC (IRS updates are infrequent, daily is more than enough).
+Schedule: nightly at 03:00 UTC. Logs to journald via `logger` (queryable with `journalctl -t 990-index`).
+
+**Locking:** `process_990_auto` acquires the same `pg_advisory_xact_lock` used by the existing 990 job family. If a manual job is running, the auto worker waits (advisory lock is blocking). This prevents the auto worker and manual dashboard jobs from colliding — they share the same lock family, same status columns, same `filing_index` table. No deduplication needed beyond the status check (`WHERE status = 'indexed'`).
+
+**"Current year" semantics:** `--current-year` means `datetime.date.today().year` at runtime. When the calendar year rolls over on Jan 1, the cron automatically starts fetching the new year's index. The previous year's index is already fully loaded from the bulk import and doesn't need refresh (IRS rarely adds to old years).
 
 ### Phase 7: Dashboard Changes
 
@@ -253,6 +306,26 @@ CREATE TABLE lava_corpus.index_refresh_log (
 - AC23: 990 Index page shows last refresh time and total indexed filings
 - AC24: Manual index/parse forms still work for ad-hoc use
 - AC25: Org Detail filing list is pre-populated for tracked orgs
+
+## Testing Strategy
+
+### Unit Tests
+- **9-column vs 10-column CSV parsing**: Synthetic CSV fixtures with 9 and 10 columns. Verify both produce correct `filing_index` rows (9-col has `xml_batch_id=NULL`).
+- **Idempotent re-run**: Insert rows, re-run loader, assert 0 new inserts.
+- **Batch ID resolution logic**: Mock zip central directory responses, verify `object_id → batch_id` mapping.
+- **Status transitions**: Verify each transition (`indexed → downloaded → parsed`, `any → error`, `error �� indexed` reset).
+- **Incremental selection**: Verify 7-day window filter, verify `--backfill` ignores the window.
+
+### Integration Tests
+- **S3 round-trip**: Upload XML to localstack/moto S3, parse from S3, verify output matches local parse.
+- **Advisory lock**: Start two `process_990_auto` processes concurrently, verify only one runs at a time.
+- **Failure recovery**: Simulate interrupted zip download, verify filing stays at `indexed` and is picked up on retry.
+- **Manual + auto interaction**: Queue a manual parse job, run auto worker concurrently, verify advisory lock prevents collision.
+
+### Live Validation
+- **Bulk load smoke test**: Run `load_990_index --years 2024` on a single year, verify row count matches expected ~363K 990 filings.
+- **End-to-end for one EIN**: Run full pipeline for a known EIN (e.g., 131624241 UNCF), verify filings from 2017–2025 are indexed, downloaded, and parsed.
+- **Nightly cron dry run**: Run the cron script manually, verify `index_refresh_log` is populated and new filings are processed.
 
 ## Migration Path
 

--- a/locard/specs/0030-990-index-automation.md
+++ b/locard/specs/0030-990-index-automation.md
@@ -56,6 +56,8 @@ The dashboard 990 Index and 990 Parse forms stay available for ad-hoc use (e.g.,
 indexed → downloaded → parsed
     ↘        ↘          ↘
     error    error      error
+
+indexed → batch_unresolvable  (terminal: no batch zip found for 2017–2023 filing)
 ```
 
 **States:**
@@ -63,14 +65,20 @@ indexed → downloaded → parsed
 - `downloaded` — XML extracted from batch zip and uploaded to S3. Ready for parsing.
 - `parsed` — XML parsed, people/compensation data written to `people` table.
 - `error` — Processing failed at any stage. `error_message` column has details.
+- `batch_unresolvable` — Filing from 2017–2023 where no batch zip contains this `object_id`. Terminal state — visible in dashboard as "known but unavailable."
 
 **Transition rules:**
 - `indexed → downloaded`: Batch zip downloaded (or cached in S3), XML member extracted and uploaded to `s3://lavandula-990-corpus/xml/{ein}/{object_id}.xml`.
 - `downloaded → parsed`: XML parsed successfully, people rows inserted.
-- `Any → error`: Failure at any stage. `error_message` records the cause.
+- `Any → error`: Failure at any stage. `error_message` records the cause (structured error code, not raw exception string, to avoid leaking environment details).
 - `error → indexed`: Manual reset (via Django admin or management command) to retry from scratch.
+- `indexed → batch_unresolvable`: Batch resolution scanned all batch zips for the filing year and this `object_id` was not found in any.
 
 **Idempotency:** Each transition checks current status before acting. A filing already at `parsed` is skipped. A filing at `error` is skipped unless `--reparse` is passed. Re-running `process_990_auto` on an already-processed corpus inserts 0 rows.
+
+**Parsed-data idempotency:** The `people` table uses `(ein, object_id, person_name, person_type)` as the natural key. Re-parsing the same filing uses `ON CONFLICT DO NOTHING` — no duplicate people rows.
+
+**S3/DB consistency:** The download step uploads XML to S3 first, then updates `filing_index.status` to `downloaded` and sets `s3_xml_key`. If the DB update fails, the filing stays at `indexed`; the next run re-uploads (S3 PUT is idempotent) and retries the DB update. If a filing is at `downloaded` but the S3 object is missing (corruption/manual deletion), the parse step detects the missing object and transitions to `error` with message "S3 object missing".
 
 ## Data Source Analysis
 
@@ -134,10 +142,10 @@ python3 manage.py load_990_index --current-year
 
 Behavior:
 - Downloads each year's index CSV
-- Inserts all `RETURN_TYPE = '990'` rows into `filing_index` via `ON CONFLICT (object_id) DO NOTHING`
+- Inserts all `RETURN_TYPE = '990'` rows into `filing_index` via `ON CONFLICT (object_id) DO UPDATE SET indexed_at = now()` — this updates `indexed_at` on re-runs so the incremental window stays accurate even if an existing filing re-appears in a refreshed index.
 - For 9-column years, `xml_batch_id` = NULL
 - Reports: rows scanned, matched (990), inserted, skipped per year
-- Idempotent — safe to re-run
+- Idempotent — safe to re-run (data columns unchanged, only `indexed_at` refreshed)
 
 ### Phase 3: Resolve Missing Batch IDs
 
@@ -322,6 +330,18 @@ CREATE TABLE lava_corpus.index_refresh_log (
 - **Failure recovery**: Simulate interrupted zip download, verify filing stays at `indexed` and is picked up on retry.
 - **Manual + auto interaction**: Queue a manual parse job, run auto worker concurrently, verify advisory lock prevents collision.
 
+### Security Tests
+- **XXE prevention**: Feed an XML with external entity declarations, verify parser rejects it.
+- **Oversized XML member**: Zip with a 60 MB member, verify extraction is blocked by `_MAX_MEMBER_SIZE`.
+- **Malicious zip member name**: Zip with path traversal (`../../etc/passwd`), verify `_MEMBER_NAME_RE` rejects it.
+
+### Edge Case Tests
+- **Parsed-data idempotency**: Parse the same filing twice, verify no duplicate `people` rows.
+- **Missing S3 object at parse time**: Filing at `downloaded` but S3 object deleted — verify transition to `error`.
+- **Batch resolution with absent member**: Batch zip exists but `object_id` not in any zip — verify `batch_unresolvable` status.
+- **Manual + auto collision**: Queue a manual parse job while auto worker is running — verify advisory lock serializes them.
+- **IRS metadata correction**: Re-run index loader after IRS updates a filing's metadata — verify `indexed_at` refreshed, data columns unchanged.
+
 ### Live Validation
 - **Bulk load smoke test**: Run `load_990_index --years 2024` on a single year, verify row count matches expected ~363K 990 filings.
 - **End-to-end for one EIN**: Run full pipeline for a known EIN (e.g., 131624241 UNCF), verify filings from 2017–2025 are indexed, downloaded, and parsed.
@@ -349,6 +369,14 @@ Steps 1–3 can ship independently. Steps 4–6 are the main body. Step 7 is pol
 | 50-80 GB S3 storage cost | Low | Low | ~$1-2/month at S3 standard; zips can move to Glacier after extraction |
 | Backfill takes too long | Low | Medium | Process in priority order (recent years first); can run over multiple nights |
 
+## Security Requirements
+
+1. **Safe XML parsing**: Use `defusedxml` or `lxml` with `resolve_entities=False`, `no_network=True`. No external entity resolution. No DTD loading.
+2. **Zip extraction by exact name only**: Only extract members matching `{object_id}_public.xml` pattern. Never extract arbitrary members or trust archive paths. Validate member name against `_MEMBER_NAME_RE` before extraction (already implemented in `teos_download.py`).
+3. **Size limits**: Max 50 MB per extracted XML member (already enforced by `_MAX_MEMBER_SIZE`). Max 3 GB per batch zip download. Reject oversized responses before buffering.
+4. **S3 bucket**: All four `BlockPublicAccess` settings enabled. ACLs disabled (bucket-owner-enforced). IAM scoped to this bucket only.
+5. **Error messages**: Use structured error codes in `error_message` (e.g., `ZIP_MEMBER_MISSING`, `XML_PARSE_FAILED`, `S3_UPLOAD_FAILED`), not raw exception strings that could leak environment details.
+
 ## Traps to Avoid
 
 1. **Don't filter by EIN at index time** — load all 990s, filter at query time. The full index is tiny for Postgres.
@@ -356,3 +384,4 @@ Steps 1–3 can ship independently. Steps 4–6 are the main body. Step 7 is pol
 3. **Don't download full zips for batch ID resolution** — use HTTP Range to read zip central directories first.
 4. **Don't store extracted XMLs on EBS** — S3 only. EBS is for hot data (DB, code, logs).
 5. **Zip member paths vary** — 2024 uses nested `{batch}/{oid}_public.xml`, 2025 uses flat `{oid}_public.xml`. Already fixed in commit c092ce8.
+6. **Don't trust zip member paths blindly** — validate against expected pattern before extraction. Never extract to filesystem; read into memory only.


### PR DESCRIPTION
## Summary

- **Bulk index loader** (`load_990_index`): Downloads IRS TEOS CSV indexes for all years (2017-2026), inserts ~2.6M 990 filings into `filing_index`. Fixes the 9-column bug that silently skipped 2017-2023 data.
- **Batch ID resolution** (`resolve_990_batches`): Resolves `xml_batch_id` for pre-2024 filings using HTTP Range requests to read zip central directories without downloading full archives.
- **S3 archive module** (`s3_990.py`): Manages batch zips and per-org XMLs in `lavandula-990-corpus` with ChecksumSHA256 integrity, validated keys, and spillable temp files for large archives.
- **Auto-process worker** (`process_990_auto`): Two-pass pipeline (download + parse) for tracked orgs with zip-bomb protection, defusedxml parsing with 30s timeout, and structured error codes.
- **Status reset** (`reset_990_status`): Operator recovery command with audit logging and blast-radius controls.
- **Nightly automation**: systemd timer at 03:00 UTC runs index refresh + auto-process.
- **Dashboard integration**: Updated orchestrator COMMAND_MAP, simplified forms, added index refresh history banner.
- **Code retirement**: `enrich_990.py` now delegates to the new management commands.

## Security

- CSV field validation (EIN, OBJECT_ID, XML_BATCH_ID regex)
- SSRF defense: hostname allowlist (apps.irs.gov), private IP rejection, redirect validation
- Zip extraction: member name regex, bomb ratio check, size caps, member count limit
- XML: defusedxml with process-level 30s timeout
- S3 keys validated before construction
- Structured error codes (no raw exceptions in DB)
- All SQL uses parameterized queries

## Operator Steps Required

1. Run `migration_011_990_index_automation.sql` via PGAdmin
2. Create S3 bucket `lavandula-990-corpus` (us-east-1, SSE-S3, versioning, BlockPublicAccess)
3. Run initial bulk load: `python3 manage.py load_990_index`
4. Install systemd timer: `sudo cp lavandula/systemd/990-nightly.* /etc/systemd/system/ && sudo systemctl enable --now 990-nightly.timer`

## Test plan

- [ ] Verify `teos_index.py` accepts 9-column CSV rows (unit test with synthetic fixture)
- [ ] Run `load_990_index --years 2024` on single year, verify ~363K filings inserted
- [ ] Re-run same command, verify 0 new inserts (idempotent)
- [ ] Test `process_990_auto --ein 131624241` end-to-end for UNCF
- [ ] Verify advisory lock serializes concurrent runs
- [ ] Verify `reset_990_status` audit logging
- [ ] Run systemd timer dry-run, confirm journal output
- [ ] Dashboard 990 Index page shows refresh history

🤖 Generated with [Claude Code](https://claude.com/claude-code)