### PR TITLE
[Spec 0031] Serpex search adapter with multi-engine support

### DIFF
--- a/lavandula/common/secrets.py
+++ b/lavandula/common/secrets.py
@@ -96,6 +96,11 @@ def get_brave_api_key() -> str:
     return get_secret("brave-api-key")
 
 
+def get_serpex_api_key() -> str:
+    """Convenience accessor. Used by the Serpex search adapter."""
+    return get_secret("serpex-api-key")
+
+
 def clear_cache() -> None:
     """Invalidate the per-process cache (test helper)."""
     get_secret.cache_clear()
@@ -105,5 +110,6 @@ __all__ = [
     "SecretUnavailable",
     "get_secret",
     "get_brave_api_key",
+    "get_serpex_api_key",
     "clear_cache",
 ]

--- a/lavandula/dashboard/pipeline/forms.py
+++ b/lavandula/dashboard/pipeline/forms.py
@@ -28,6 +28,13 @@ LLM_PRESET_CHOICES = [
     ("local-ollama", "Local Ollama (gemma4)"),
 ]
 
+SEARCH_ENGINE_CHOICES = [
+    ("brave", "Brave (default)"),
+    ("google", "Google"),
+    ("brave_google", "Brave + Google"),
+    ("auto", "Auto (Serpex routing)"),
+]
+
 
 ALL_NTEE_MAJORS = "A,B,C,D,E,F,G,H,I,J,K,L,M,N,O,P,Q,R,S,T,U,V,W,X,Y,Z"
 
@@ -114,9 +121,15 @@ class ResolverForm(forms.Form):
         widget=forms.Select(attrs={"class": _SELECT}),
         label="LLM",
     )
+    search_engines = forms.ChoiceField(
+        choices=SEARCH_ENGINE_CHOICES,
+        initial="brave",
+        widget=forms.Select(attrs={"class": _SELECT}),
+        label="Search Engine",
+    )
     brave_qps = forms.FloatField(initial=10.0, required=False, min_value=0.1, max_value=50.0, widget=forms.NumberInput(
         attrs={"class": _SELECT, "step": "0.1"}
-    ))
+    ), label="Search QPS")
     search_parallelism = forms.IntegerField(initial=12, required=False, min_value=1, max_value=32, widget=forms.NumberInput(
         attrs={"class": _SELECT}
     ))
@@ -226,3 +239,18 @@ class EnrichParseForm(forms.Form):
 
     def clean(self):
         return _clean_990_common(super().clean())
+
+
+class PhoneEnrichForm(forms.Form):
+    state = forms.ChoiceField(
+        choices=[("", "All resolved")] + STATE_CHOICES,
+        required=False,
+        widget=forms.Select(attrs={"class": _SELECT}),
+    )
+    limit = forms.IntegerField(required=False, min_value=0, max_value=999999,
+        widget=forms.NumberInput(attrs={"class": _SELECT}))
+    search_engines = forms.ChoiceField(
+        choices=SEARCH_ENGINE_CHOICES, initial="brave",
+        widget=forms.Select(attrs={"class": _SELECT}),
+        label="Search Engine",
+    )

--- a/lavandula/dashboard/pipeline/forms.py
+++ b/lavandula/dashboard/pipeline/forms.py
@@ -186,7 +186,7 @@ def _clean_990_common(cleaned_data):
     ein = cleaned_data.get("ein")
     if ein and not re.match(r"^\d{9}$", ein):
         raise forms.ValidationError("EIN must be exactly 9 digits.")
-    years_str = cleaned_data.get("years", "")
+    years_str = cleaned_data.get("years", "").strip()
     if years_str:
         if not re.match(r"^\d{4}(\s*,\s*\d{4})*$", years_str):
             raise forms.ValidationError("Years must be comma-separated 4-digit years.")

--- a/lavandula/dashboard/pipeline/orchestrator.py
+++ b/lavandula/dashboard/pipeline/orchestrator.py
@@ -42,7 +42,8 @@ COMMAND_MAP: dict[str, dict[str, Any]] = {
             "llm_url": {"type": "text", "pattern": r"^https?://", "flag": "--llm-url"},
             "llm_model": {"type": "text", "flag": "--llm-model"},
             "llm_api_key_ssm": {"type": "text", "flag": "--llm-api-key-ssm"},
-            "brave_qps": {"type": "float", "min": 0.1, "max": 50.0, "flag": "--brave-qps"},
+            "brave_qps": {"type": "float", "min": 0.1, "max": 50.0, "flag": "--search-qps"},
+            "search_engines": {"type": "text", "pattern": r"^[a-z,]+$", "flag": "--search-engines"},
             "search_parallelism": {"type": "int", "min": 1, "max": 32, "flag": "--search-parallelism"},
             "consumer_threads": {"type": "int", "min": 1, "max": 16, "flag": "--consumer-threads"},
             "limit": {"type": "int", "min": 0, "max": 999999, "flag": "--limit"},
@@ -95,6 +96,14 @@ COMMAND_MAP: dict[str, dict[str, Any]] = {
             "ein": {"type": "text", "pattern": r"^\d{9}$", "flag": "--ein"},
             "reparse": {"type": "bool", "flag": "--reparse"},
             "backfill": {"type": "bool", "flag": "--backfill"},
+        },
+    },
+    "enrich-phone": {
+        "cmd": ["python3", "-m", "lavandula.nonprofits.tools.pipeline_enrich_phone"],
+        "params": {
+            "state": {"type": "choice", "choices": US_STATES, "flag": "--state"},
+            "limit": {"type": "int", "min": 0, "max": 999999, "flag": "--limit"},
+            "search_engines": {"type": "text", "pattern": r"^[a-z,]+$", "flag": "--search-engines"},
         },
     },
 }
@@ -391,6 +400,32 @@ def create_990_parse_job(config_overrides: dict, host: str) -> Job:
             )
         except IntegrityError:
             raise DuplicateJobError("Duplicate 990-parse job (constraint violation)")
+
+
+def create_phone_enrich_job(config_overrides: dict, host: str) -> Job:
+    """Create a phone enrichment job."""
+    state = config_overrides.get("state") or None
+    with transaction.atomic():
+        existing = (
+            Job.objects.select_for_update()
+            .filter(phase="enrich-phone", status__in=["pending", "running"])
+            .first()
+        )
+        if existing:
+            raise DuplicateJobError(
+                f"Active phone enrich job already exists: Job #{existing.pk}"
+            )
+
+        try:
+            return Job.objects.create(
+                state_code=state,
+                phase="enrich-phone",
+                status="pending",
+                host=host,
+                config_json=config_overrides,
+            )
+        except IntegrityError:
+            raise DuplicateJobError("Duplicate phone enrich job (constraint violation)")
 
 
 def retry_job(job: Job) -> Job:

--- a/lavandula/dashboard/pipeline/templates/pipeline/org_detail.html
+++ b/lavandula/dashboard/pipeline/templates/pipeline/org_detail.html
@@ -16,6 +16,9 @@
       <div class="flex"><dt class="w-40 text-gray-500">City</dt><dd>{{ org.city|default:"-" }}</dd></div>
       <div class="flex"><dt class="w-40 text-gray-500">State</dt><dd>{{ org.state|default:"-" }}</dd></div>
       <div class="flex"><dt class="w-40 text-gray-500">Website URL</dt><dd class="break-all">{{ org.website_url|default:"-" }}</dd></div>
+      {% if org.phone %}
+      <div class="flex"><dt class="w-40 text-gray-500">Phone</dt><dd>{{ org.phone }} <span class="text-xs text-gray-400">({{ org.phone_source }})</span></dd></div>
+      {% endif %}
       <div class="flex"><dt class="w-40 text-gray-500">Resolver Status</dt><dd>
         {% if org.resolver_status == "resolved" %}<span class="text-green-600">{{ org.resolver_status }}</span>
         {% else %}{{ org.resolver_status|default:"-" }}{% endif %}

--- a/lavandula/dashboard/pipeline/templates/pipeline/orgs.html
+++ b/lavandula/dashboard/pipeline/templates/pipeline/orgs.html
@@ -7,6 +7,10 @@
 <div class="bg-white rounded-lg shadow p-4 mb-6">
   <form method="get" class="flex flex-wrap gap-4 items-end">
     <div>
+      <label class="block text-xs font-medium text-gray-600 mb-1">EIN</label>
+      <input type="text" name="ein" value="{{ filter_ein }}" placeholder="e.g. 030440761" class="border border-gray-300 rounded px-3 py-1.5 text-sm w-32">
+    </div>
+    <div>
       <label class="block text-xs font-medium text-gray-600 mb-1">State</label>
       <input type="text" name="state" value="{{ filter_state }}" placeholder="e.g. NY" class="border border-gray-300 rounded px-3 py-1.5 text-sm w-20">
     </div>
@@ -57,10 +61,10 @@
     <span>Page {{ page_obj.number }} of {{ page_obj.paginator.num_pages }} ({{ page_obj.paginator.count }} orgs)</span>
     <div class="flex gap-2">
       {% if page_obj.has_previous %}
-      <a href="?page={{ page_obj.previous_page_number }}&state={{ filter_state }}&resolver_status={{ filter_status }}&resolver_method={{ filter_method }}" class="px-3 py-1 bg-gray-100 rounded hover:bg-gray-200">Previous</a>
+      <a href="?page={{ page_obj.previous_page_number }}&ein={{ filter_ein }}&state={{ filter_state }}&resolver_status={{ filter_status }}&resolver_method={{ filter_method }}" class="px-3 py-1 bg-gray-100 rounded hover:bg-gray-200">Previous</a>
       {% endif %}
       {% if page_obj.has_next %}
-      <a href="?page={{ page_obj.next_page_number }}&state={{ filter_state }}&resolver_status={{ filter_status }}&resolver_method={{ filter_method }}" class="px-3 py-1 bg-gray-100 rounded hover:bg-gray-200">Next</a>
+      <a href="?page={{ page_obj.next_page_number }}&ein={{ filter_ein }}&state={{ filter_state }}&resolver_status={{ filter_status }}&resolver_method={{ filter_method }}" class="px-3 py-1 bg-gray-100 rounded hover:bg-gray-200">Next</a>
       {% endif %}
     </div>
   </div>

--- a/lavandula/dashboard/pipeline/templates/pipeline/phone_enrich.html
+++ b/lavandula/dashboard/pipeline/templates/pipeline/phone_enrich.html
@@ -1,0 +1,58 @@
+{% extends "pipeline/base.html" %}
+{% load pipeline_tags %}
+{% block title %}Phone Enrichment — Lavandula Pipeline{% endblock %}
+{% block content %}
+<h1 class="text-2xl font-bold text-gray-900 mb-6">Phone Enrichment</h1>
+
+<div class="grid grid-cols-1 lg:grid-cols-3 gap-6">
+  <div class="space-y-4">
+    <!-- Status -->
+    <div class="bg-white rounded-lg shadow p-5">
+      <h2 class="text-sm font-semibold text-gray-500 uppercase mb-3">Status</h2>
+      {% if running_job %}
+      <div class="flex items-center gap-2 mb-2">
+        <span class="w-3 h-3 rounded-full bg-blue-500 animate-pulse"></span>
+        <span class="font-medium">Job #{{ running_job.pk }} running</span>
+      </div>
+      <div class="text-sm text-gray-500">PID: {{ running_job.pid|default:"-" }} | Started: {{ running_job.started_at|elapsed_since }} ago</div>
+      {% else %}
+      <div class="flex items-center gap-2">
+        <span class="w-3 h-3 rounded-full bg-gray-400"></span>
+        <span class="text-gray-600">Stopped</span>
+      </div>
+      {% endif %}
+      <div class="mt-3 text-sm text-gray-600">
+        <p>Orgs with phone: <strong>{{ phone_count }}</strong></p>
+        <p>Resolved without phone: <strong>{{ resolved_no_phone }}</strong></p>
+      </div>
+    </div>
+
+    <!-- Enrich Phone Job Form -->
+    <div class="bg-white rounded-lg shadow p-5">
+      <h2 class="text-sm font-semibold text-gray-500 uppercase mb-3">Enrich Phones</h2>
+      <form method="post" action="{% url 'phone_enrich_job_create' %}">
+        {% csrf_token %}
+        {% for field in form %}
+        <div class="mb-3">
+          <label class="block text-xs font-medium text-gray-600 mb-1">{{ field.label }}</label>
+          {{ field }}
+        </div>
+        {% endfor %}
+        <div class="flex gap-2">
+          <button type="submit" class="flex-1 bg-green-600 text-white py-2 rounded text-sm hover:bg-green-700">Start Job</button>
+        </div>
+      </form>
+    </div>
+  </div>
+
+  <div class="lg:col-span-2 bg-white rounded-lg shadow p-5">
+    <h2 class="text-lg font-semibold text-gray-900 mb-3">About</h2>
+    <p class="text-sm text-gray-600">
+      The phone enrichment pipeline finds phone numbers for resolved orgs by searching for
+      "{org name} {city} {state} phone number" and extracting US phone numbers from search
+      snippets. If no phone is found in snippets, it falls back to fetching the org's website
+      contact/about page.
+    </p>
+  </div>
+</div>
+{% endblock %}

--- a/lavandula/dashboard/pipeline/urls.py
+++ b/lavandula/dashboard/pipeline/urls.py
@@ -27,6 +27,10 @@ urlpatterns = [
     path("classifier/", views.ClassifierView.as_view(), name="classifier"),
     path("classifier/queue/", views.ClassifyJobCreateView.as_view(), name="classify_job_create"),
 
+    # Phone Enrichment
+    path("phone-enrich/", views.PhoneEnrichView.as_view(), name="phone_enrich"),
+    path("phone-enrich/queue/", views.PhoneEnrichJobCreateView.as_view(), name="phone_enrich_job_create"),
+
     # 990 Pipeline Controls
     path("990-index/", views.EnrichIndexView.as_view(), name="enrich_index"),
     path("990-index/queue/", views.EnrichIndexJobCreateView.as_view(), name="enrich_index_job_create"),

--- a/lavandula/dashboard/pipeline/views.py
+++ b/lavandula/dashboard/pipeline/views.py
@@ -476,9 +476,12 @@ class OrgListView(LoginRequiredMixin, ListView):
 
     def get_queryset(self):
         qs = NonprofitSeed.objects.all().order_by("ein")
+        ein = self.request.GET.get("ein")
         state = self.request.GET.get("state")
         status = self.request.GET.get("resolver_status")
         method = self.request.GET.get("resolver_method")
+        if ein:
+            qs = qs.filter(ein=ein.strip())
         if state:
             qs = qs.filter(state=state)
         if status:
@@ -489,6 +492,7 @@ class OrgListView(LoginRequiredMixin, ListView):
 
     def get_context_data(self, **kwargs):
         ctx = super().get_context_data(**kwargs)
+        ctx["filter_ein"] = self.request.GET.get("ein", "")
         ctx["filter_state"] = self.request.GET.get("state", "")
         ctx["filter_status"] = self.request.GET.get("resolver_status", "")
         ctx["filter_method"] = self.request.GET.get("resolver_method", "")

--- a/lavandula/dashboard/pipeline/views.py
+++ b/lavandula/dashboard/pipeline/views.py
@@ -40,6 +40,7 @@ from .orchestrator import (
     create_990_parse_job,
     create_classify_job,
     create_crawl_job,
+    create_phone_enrich_job,
     create_resolve_job,
     create_state_jobs,
     retry_job,
@@ -249,6 +250,9 @@ class ResolveJobCreateView(LoginRequiredMixin, View):
 
         config = {k: v for k, v in form.cleaned_data.items() if v not in (None, "", False)}
         config = _expand_llm_preset(config)
+        # Map form search_engines value: "brave_google" → "brave,google"
+        raw_engines = config.get("search_engines", "brave")
+        config["search_engines"] = raw_engines.replace("_", ",")
         try:
             job = create_resolve_job(config, _get_hostname())
             _log_audit(request, "job_create", "resolve", {"job_id": job.pk})
@@ -676,6 +680,48 @@ class EnrichParseJobCreateView(LoginRequiredMixin, View):
             from urllib.parse import urlencode
             return redirect(f"{reverse('enrich_parse')}?{urlencode(params)}")
         return redirect("enrich_parse")
+
+
+# ---------------------------------------------------------------------------
+# Phone Enrichment
+# ---------------------------------------------------------------------------
+
+
+class PhoneEnrichView(LoginRequiredMixin, TemplateView):
+    template_name = "pipeline/phone_enrich.html"
+
+    def get_context_data(self, **kwargs):
+        ctx = super().get_context_data(**kwargs)
+        ctx["running_job"] = Job.objects.filter(phase="enrich-phone", status="running").first()
+        ctx["pending_job"] = Job.objects.filter(phase="enrich-phone", status="pending").first()
+        from .forms import PhoneEnrichForm
+        ctx["form"] = PhoneEnrichForm()
+        ctx["phone_count"] = NonprofitSeed.objects.exclude(phone__isnull=True).exclude(phone="").count()
+        ctx["resolved_no_phone"] = NonprofitSeed.objects.filter(
+            resolver_status="resolved", phone__isnull=True,
+        ).count()
+        return ctx
+
+
+class PhoneEnrichJobCreateView(LoginRequiredMixin, View):
+    def post(self, request):
+        from .forms import PhoneEnrichForm
+        form = PhoneEnrichForm(request.POST)
+        if not form.is_valid():
+            messages.error(request, f"Invalid form: {form.errors.as_text()}")
+            return redirect("phone_enrich")
+
+        config = {k: v for k, v in form.cleaned_data.items() if v not in (None, "", False)}
+        raw_engines = config.get("search_engines", "brave")
+        config["search_engines"] = raw_engines.replace("_", ",")
+        try:
+            job = create_phone_enrich_job(config, _get_hostname())
+            _log_audit(request, "job_create", "enrich-phone", {"job_id": job.pk})
+            messages.success(request, f"Created phone enrich job #{job.pk}")
+        except DuplicateJobError as e:
+            messages.error(request, str(e))
+
+        return redirect("phone_enrich")
 
 
 # ---------------------------------------------------------------------------

--- a/lavandula/migrations/rds/migration_012_phone_enrichment.sql
+++ b/lavandula/migrations/rds/migration_012_phone_enrichment.sql
@@ -1,0 +1,3 @@
+-- Migration 012: Phone enrichment columns (Spec 0031)
+ALTER TABLE lava_corpus.nonprofits_seed ADD COLUMN IF NOT EXISTS phone TEXT;
+ALTER TABLE lava_corpus.nonprofits_seed ADD COLUMN IF NOT EXISTS phone_source TEXT;

--- a/lavandula/nonprofits/phone_extract.py
+++ b/lavandula/nonprofits/phone_extract.py
@@ -1,0 +1,85 @@
+"""Phone number extraction from text (Spec 0031).
+
+Extracts US phone numbers from search snippets and web page text,
+filtering out fax numbers and toll-free numbers.
+"""
+from __future__ import annotations
+
+import re
+
+_US_PHONE_RE = re.compile(
+    r'(?:\+?1[-.\s]?)?'
+    r'\(?(\d{3})\)?[-.\s]'
+    r'(\d{3})[-.\s]'
+    r'(\d{4})'
+    r'(?!\d)'
+)
+
+_FAX_CONTEXT_RE = re.compile(r'\bfax\b', re.I)
+
+_TOLLFREE_PREFIXES = frozenset({"800", "888", "877", "866", "855", "844", "833"})
+
+
+def extract_phone(
+    text: str,
+    *,
+    allow_tollfree: bool = False,
+    org_name: str = "",
+) -> str | None:
+    """Extract best valid US phone number from text.
+
+    Returns normalized (XXX) XXX-XXXX string, or None if no valid phone found.
+    """
+    if not text:
+        return None
+
+    candidates: list[tuple[str, int]] = []
+
+    for match in _US_PHONE_RE.finditer(text):
+        area, exchange, subscriber = match.groups()
+        pos = match.start()
+
+        # Reject fax numbers: check 20-char window before match
+        window_start = max(0, pos - 20)
+        before_text = text[window_start:pos]
+        if _FAX_CONTEXT_RE.search(before_text):
+            continue
+
+        # Reject toll-free unless allowed
+        if area in _TOLLFREE_PREFIXES and not allow_tollfree:
+            continue
+
+        formatted = f"({area}) {exchange}-{subscriber}"
+        candidates.append((formatted, pos))
+
+    if not candidates:
+        return None
+
+    if len(candidates) == 1 or not org_name:
+        return candidates[0][0]
+
+    # Prefer phone closest to org name in text
+    org_lower = org_name.lower()
+    text_lower = text.lower()
+    org_positions = []
+    start = 0
+    while True:
+        idx = text_lower.find(org_lower, start)
+        if idx == -1:
+            break
+        org_positions.append(idx)
+        start = idx + 1
+
+    if not org_positions:
+        return candidates[0][0]
+
+    def distance_to_org(phone_pos: int) -> int:
+        return min(abs(phone_pos - op) for op in org_positions)
+
+    candidates.sort(key=lambda c: distance_to_org(c[1]))
+    return candidates[0][0]
+
+
+__all__ = [
+    "extract_phone",
+]

--- a/lavandula/nonprofits/pipeline_resolver.py
+++ b/lavandula/nonprofits/pipeline_resolver.py
@@ -25,11 +25,11 @@ import requests as http_requests
 from sqlalchemy import text
 from sqlalchemy.engine import Engine
 
-from .brave_search import (
-    BraveRateLimiter,
-    BraveSearchError,
-    search,
-    search_and_filter,
+from .web_search import (
+    RateLimiter,
+    SearchConfig,
+    SearchError,
+    search_and_filter as ws_search_and_filter,
 )
 from .gemma_client import (
     LLMClient,
@@ -111,7 +111,7 @@ class ProducerStats:
     skipped_no_results: int = 0
     skipped_all_blocked: int = 0
     skipped_no_live: int = 0
-    brave_errors: int = 0
+    search_errors: int = 0
 
 
 @dataclass
@@ -254,8 +254,8 @@ def producer(
     *,
     pq: PipelineQueue,
     engine: Engine,
-    api_key: str,
-    rate_limiter: BraveRateLimiter,
+    search_config: SearchConfig,
+    rate_limiter: RateLimiter,
     search_parallelism: int = 4,
     fetch_parallelism: int = 8,
     shutdown: ShutdownFlag,
@@ -277,44 +277,28 @@ def producer(
 
             stats.searched += 1
 
-            # Stage 1: Search — unquoted, legal suffix stripped
-            clean_name = _LEGAL_SUFFIX_RE.sub("", name).strip()
+            # Stage 1+2: Search + blocklist filter (Spec 0031)
             try:
-                raw_results = search(
-                    f'{clean_name} {city} {state}',
-                    api_key=api_key,
-                    count=20,
-                    rate_limiter=rate_limiter,
+                filter_result = ws_search_and_filter(
+                    name, city, state,
+                    config=search_config, rate_limiter=rate_limiter,
+                    max_results=3,
                 )
-            except BraveSearchError as exc:
-                stats.brave_errors += 1
+            except SearchError as exc:
+                stats.search_errors += 1
                 reason_match = re.search(r"(\d{3})", str(exc))
                 status_code = reason_match.group(1) if reason_match else "unknown"
-                _write_unresolved(engine, ein, f"brave_error:{status_code}", method=method)
+                _write_unresolved(engine, ein, f"search_error:{status_code}", method=method)
                 continue
 
-            if not raw_results:
-                stats.skipped_no_results += 1
-                _write_unresolved(engine, ein, "no_search_results", method=method)
-                continue
-
-            # Stage 2: Filter blocklist
-            from .brave_search import is_blocked
-            from urllib.parse import urlsplit as _urlsplit
-            results = []
-            for r in raw_results:
-                try:
-                    host = _urlsplit(r.url).hostname or ""
-                except Exception:
-                    continue
-                if not is_blocked(host, name):
-                    results.append(r)
-                    if len(results) >= 3:
-                        break
-
+            results = filter_result.results
             if not results:
-                stats.skipped_all_blocked += 1
-                _write_unresolved(engine, ein, "all_blocked", method=method)
+                if filter_result.had_raw_results:
+                    stats.skipped_all_blocked += 1
+                    _write_unresolved(engine, ein, "all_blocked", method=method)
+                else:
+                    stats.skipped_no_results += 1
+                    _write_unresolved(engine, ein, "no_search_results", method=method)
                 continue
 
             # Stage 3: Fetch candidates in parallel
@@ -325,10 +309,10 @@ def producer(
                     for r in results
                 }
                 for future in as_completed(futures):
-                    brave_result = futures[future]
+                    search_result = futures[future]
                     cand = future.result()
-                    cand["title"] = brave_result.title
-                    cand["snippet"] = brave_result.snippet
+                    cand["title"] = search_result.title
+                    cand["snippet"] = search_result.snippet
                     candidates.append(cand)
 
             live = [c for c in candidates if c["live"]]
@@ -576,8 +560,8 @@ def load_unresolved_orgs(
 def run_dry(
     orgs: list[dict],
     *,
-    api_key: str,
-    rate_limiter: BraveRateLimiter,
+    search_config: SearchConfig,
+    rate_limiter: RateLimiter,
     search_parallelism: int = 4,
     fetch_parallelism: int = 8,
 ) -> None:
@@ -589,15 +573,16 @@ def run_dry(
         state = org.get("state", "")
 
         try:
-            results = search_and_filter(
+            filter_result = ws_search_and_filter(
                 name, city, state,
-                api_key=api_key,
+                config=search_config,
                 rate_limiter=rate_limiter,
             )
-        except BraveSearchError as exc:
+        except SearchError as exc:
             print(f"SEARCH ERROR ein={ein}: {exc}")
             continue
 
+        results = filter_result.results
         if not results:
             print(f"NO RESULTS ein={ein} name={name}")
             continue
@@ -609,10 +594,10 @@ def run_dry(
                 for r in results
             }
             for future in as_completed(futures):
-                brave_result = futures[future]
+                search_result = futures[future]
                 cand = future.result()
-                cand["title"] = brave_result.title
-                cand["snippet"] = brave_result.snippet
+                cand["title"] = search_result.title
+                cand["snippet"] = search_result.snippet
                 candidates.append(cand)
 
         live = [c for c in candidates if c["live"]]
@@ -628,6 +613,7 @@ __all__ = [
     "ConsumerStats",
     "PipelineQueue",
     "ProducerStats",
+    "SearchConfig",
     "ShutdownFlag",
     "consumer",
     "install_sigint_handler",

--- a/lavandula/nonprofits/tests/unit/test_phone_extract.py
+++ b/lavandula/nonprofits/tests/unit/test_phone_extract.py
@@ -1,0 +1,75 @@
+"""Unit tests for phone_extract.py (Spec 0031)."""
+from __future__ import annotations
+
+import pytest
+
+from lavandula.nonprofits.phone_extract import extract_phone
+
+
+class TestExtractPhone:
+    def test_standard_format(self):
+        assert extract_phone("Call us at (555) 123-4567") == "(555) 123-4567"
+
+    def test_dashed_format(self):
+        assert extract_phone("Phone: 555-123-4567") == "(555) 123-4567"
+
+    def test_dotted_format(self):
+        assert extract_phone("555.123.4567") == "(555) 123-4567"
+
+    def test_with_country_code(self):
+        assert extract_phone("+1 555 123 4567") == "(555) 123-4567"
+
+    def test_with_one_prefix_dash(self):
+        assert extract_phone("1-555-123-4567") == "(555) 123-4567"
+
+    def test_fax_rejected(self):
+        assert extract_phone("Fax: (555) 123-4567") is None
+
+    def test_fax_case_insensitive(self):
+        assert extract_phone("fax number: 555-123-4567") is None
+
+    def test_fax_within_20_chars(self):
+        assert extract_phone("Send fax to this num 555-123-4567") is None
+
+    def test_fax_beyond_20_chars_allowed(self):
+        assert extract_phone("Our fax is available at the front desk. Call us at 555-123-4567") == "(555) 123-4567"
+
+    def test_tollfree_rejected_default(self):
+        assert extract_phone("Call 800-555-1234") is None
+        assert extract_phone("Call 888-555-1234") is None
+        assert extract_phone("Call 877-555-1234") is None
+
+    def test_tollfree_allowed(self):
+        assert extract_phone("Call 800-555-1234", allow_tollfree=True) == "(800) 555-1234"
+
+    def test_ein_not_matched(self):
+        """9-digit EINs without separators should not be matched."""
+        assert extract_phone("EIN: 123456789") is None
+
+    def test_zipcode_not_matched(self):
+        """ZIP+4 codes should not be matched."""
+        assert extract_phone("ZIP: 12345-6789") is None
+
+    def test_multiple_phones_first_returned(self):
+        text = "Main: 555-111-2222, Sales: 555-333-4444"
+        assert extract_phone(text) == "(555) 111-2222"
+
+    def test_no_phone_returns_none(self):
+        assert extract_phone("No phone number here") is None
+
+    def test_empty_text(self):
+        assert extract_phone("") is None
+
+    def test_none_text(self):
+        assert extract_phone("") is None
+
+    def test_org_name_proximity(self):
+        """When org_name provided, prefer phone closest to org name."""
+        text = "General info: 555-111-2222. For other inquiries contact the main office. Acme Foundation: 555-333-4444."
+        result = extract_phone(text, org_name="Acme Foundation")
+        assert result == "(555) 333-4444"
+
+    def test_fax_skipped_real_phone_found(self):
+        """Fax number skipped, real phone returned."""
+        text = "Fax: 555-111-2222, Phone: 555-333-4444"
+        assert extract_phone(text) == "(555) 333-4444"

--- a/lavandula/nonprofits/tests/unit/test_pipeline_enrich_phone.py
+++ b/lavandula/nonprofits/tests/unit/test_pipeline_enrich_phone.py
@@ -1,0 +1,48 @@
+"""Integration test for phone enrichment pipeline (Spec 0031, AC 50)."""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from lavandula.nonprofits.phone_extract import extract_phone
+
+
+class TestPhoneEnrichmentFlow:
+    """Test the phone enrichment logic without a real DB."""
+
+    def test_phone_from_snippet(self):
+        """Phone extracted from search snippet."""
+        snippet = "Acme Nonprofit — Call us at (512) 555-1234 for more info."
+        phone = extract_phone(snippet, org_name="Acme Nonprofit")
+        assert phone == "(512) 555-1234"
+
+    def test_phone_from_snippet_with_fax(self):
+        """Fax skipped, phone extracted."""
+        snippet = "Fax: (512) 555-0000 | Phone: (512) 555-1234"
+        phone = extract_phone(snippet, org_name="Test Org")
+        assert phone == "(512) 555-1234"
+
+    def test_no_phone_in_snippet(self):
+        """No phone in snippet returns None, would trigger website fallback."""
+        snippet = "Acme Nonprofit is a 501(c)(3) organization."
+        phone = extract_phone(snippet, org_name="Acme Nonprofit")
+        assert phone is None
+
+    def test_phone_from_website_text(self):
+        """Phone extracted from website contact page text."""
+        page_text = "Contact us at our office: 214-555-6789 or email info@acme.org"
+        phone = extract_phone(page_text, org_name="Acme Nonprofit")
+        assert phone == "(214) 555-6789"
+
+    def test_tollfree_rejected_in_enrichment(self):
+        """Toll-free numbers rejected by default."""
+        snippet = "Call us at 800-555-1234"
+        phone = extract_phone(snippet, org_name="Test Org")
+        assert phone is None
+
+    def test_tollfree_allowed_with_flag(self):
+        """Toll-free allowed when flag is set."""
+        snippet = "Call us at 800-555-1234"
+        phone = extract_phone(snippet, org_name="Test Org", allow_tollfree=True)
+        assert phone == "(800) 555-1234"

--- a/lavandula/nonprofits/tests/unit/test_pipeline_resolver.py
+++ b/lavandula/nonprofits/tests/unit/test_pipeline_resolver.py
@@ -1,4 +1,4 @@
-"""Unit tests for pipeline_resolver.py (Spec 0018)."""
+"""Unit tests for pipeline_resolver.py (Spec 0018, updated for Spec 0031)."""
 from __future__ import annotations
 
 import json
@@ -18,6 +18,13 @@ from lavandula.nonprofits.pipeline_resolver import (
     consumer,
     install_sigint_handler,
     producer,
+)
+from lavandula.nonprofits.web_search import (
+    RateLimiter,
+    SearchConfig,
+    SearchError,
+    SearchFilterResult,
+    SearchResult,
 )
 
 
@@ -74,9 +81,22 @@ def _make_mock_engine():
     return engine
 
 
+def _make_search_config():
+    return SearchConfig(
+        backend="serpex",
+        engines=["brave"],
+        api_key="test-key",
+        qps=100.0,
+    )
+
+
+def _fast_rl():
+    return RateLimiter(100.0)
+
+
 class TestProducer:
     def test_producer_enqueues_packets(self):
-        """Mock Brave + fetch → packets appear in queue."""
+        """Mock search_and_filter + fetch → packets appear in queue."""
         pq = PipelineQueue(maxsize=32)
         engine = _make_mock_engine()
         shutdown = ShutdownFlag()
@@ -86,12 +106,14 @@ class TestProducer:
             {"ein": "222222222", "name": "Org B", "city": "Austin", "state": "TX"},
         ]
 
-        from lavandula.nonprofits.brave_search import BraveRateLimiter, BraveSearchResult
+        rl = _fast_rl()
+        config = _make_search_config()
 
-        rl = BraveRateLimiter(100.0)
-
-        def mock_search(query, *, api_key, rate_limiter, count=10):
-            return [BraveSearchResult(title="Org Site", url="https://orgsite.org", snippet="...")]
+        def mock_search_and_filter(name, city, state, *, config, rate_limiter, max_results=3):
+            return SearchFilterResult(
+                results=[SearchResult(title="Org Site", url="https://orgsite.org", snippet="...", engines=("brave",))],
+                had_raw_results=True,
+            )
 
         def mock_fetch(url):
             return {
@@ -100,10 +122,10 @@ class TestProducer:
                 "status_code": 200,
             }
 
-        with patch("lavandula.nonprofits.pipeline_resolver.search", side_effect=mock_search):
+        with patch("lavandula.nonprofits.pipeline_resolver.ws_search_and_filter", side_effect=mock_search_and_filter):
             with patch("lavandula.nonprofits.pipeline_resolver._fetch_candidate", side_effect=mock_fetch):
                 stats = producer(
-                    orgs, pq=pq, engine=engine, api_key="key",
+                    orgs, pq=pq, engine=engine, search_config=config,
                     rate_limiter=rl, shutdown=shutdown,
                 )
 
@@ -124,13 +146,15 @@ class TestProducer:
         shutdown = ShutdownFlag()
         orgs = [{"ein": "111111111", "name": "Ghost Org", "city": "Nowhere", "state": "TX"}]
 
-        from lavandula.nonprofits.brave_search import BraveRateLimiter
+        rl = _fast_rl()
+        config = _make_search_config()
 
-        rl = BraveRateLimiter(100.0)
+        def mock_search_and_filter(*args, **kwargs):
+            return SearchFilterResult(results=[], had_raw_results=False)
 
-        with patch("lavandula.nonprofits.pipeline_resolver.search", return_value=[]):
+        with patch("lavandula.nonprofits.pipeline_resolver.ws_search_and_filter", side_effect=mock_search_and_filter):
             stats = producer(
-                orgs, pq=pq, engine=engine, api_key="key",
+                orgs, pq=pq, engine=engine, search_config=config,
                 rate_limiter=rl, shutdown=shutdown,
             )
 
@@ -143,68 +167,66 @@ class TestProducer:
         shutdown = ShutdownFlag()
         orgs = [{"ein": "111111111", "name": "Dead Org", "city": "X", "state": "TX"}]
 
-        from lavandula.nonprofits.brave_search import BraveRateLimiter, BraveSearchResult
+        rl = _fast_rl()
+        config = _make_search_config()
 
-        rl = BraveRateLimiter(100.0)
-
-        def mock_search(*args, **kwargs):
-            return [BraveSearchResult(title="Dead", url="https://dead.org", snippet="...")]
+        def mock_search_and_filter(*args, **kwargs):
+            return SearchFilterResult(
+                results=[SearchResult(title="Dead", url="https://dead.org", snippet="...", engines=("brave",))],
+                had_raw_results=True,
+            )
 
         def mock_fetch(url):
             return {"url": url, "final_url": url, "live": False, "title": "", "snippet": "", "excerpt": "", "status_code": 404}
 
-        with patch("lavandula.nonprofits.pipeline_resolver.search", side_effect=mock_search):
+        with patch("lavandula.nonprofits.pipeline_resolver.ws_search_and_filter", side_effect=mock_search_and_filter):
             with patch("lavandula.nonprofits.pipeline_resolver._fetch_candidate", side_effect=mock_fetch):
                 stats = producer(
-                    orgs, pq=pq, engine=engine, api_key="key",
+                    orgs, pq=pq, engine=engine, search_config=config,
                     rate_limiter=rl, shutdown=shutdown,
                 )
 
         assert stats.skipped_no_live == 1
 
     def test_producer_skips_all_blocked(self):
-        """All search results are blocked domains → skipped_all_blocked incremented."""
+        """All search results are blocked → skipped_all_blocked incremented."""
         pq = PipelineQueue(maxsize=32)
         engine = _make_mock_engine()
         shutdown = ShutdownFlag()
         orgs = [{"ein": "111111111", "name": "Test Org", "city": "X", "state": "TX"}]
 
-        from lavandula.nonprofits.brave_search import BraveRateLimiter, BraveSearchResult
+        rl = _fast_rl()
+        config = _make_search_config()
 
-        rl = BraveRateLimiter(100.0)
+        def mock_search_and_filter(*args, **kwargs):
+            return SearchFilterResult(results=[], had_raw_results=True)
 
-        def mock_search(query, *, api_key, rate_limiter, count=10):
-            return [
-                BraveSearchResult(title="LinkedIn", url="https://www.linkedin.com/company/test", snippet="..."),
-                BraveSearchResult(title="Facebook", url="https://www.facebook.com/test", snippet="..."),
-            ]
-
-        with patch("lavandula.nonprofits.pipeline_resolver.search", side_effect=mock_search):
+        with patch("lavandula.nonprofits.pipeline_resolver.ws_search_and_filter", side_effect=mock_search_and_filter):
             stats = producer(
-                orgs, pq=pq, engine=engine, api_key="key",
+                orgs, pq=pq, engine=engine, search_config=config,
                 rate_limiter=rl, shutdown=shutdown,
             )
 
         assert stats.skipped_all_blocked == 1
         assert stats.enqueued == 0
 
-    def test_producer_brave_error_reason(self):
+    def test_producer_search_error_reason(self):
         pq = PipelineQueue(maxsize=32)
         engine = _make_mock_engine()
         shutdown = ShutdownFlag()
         orgs = [{"ein": "111111111", "name": "Err Org", "city": "X", "state": "TX"}]
 
-        from lavandula.nonprofits.brave_search import BraveRateLimiter, BraveSearchError
+        rl = _fast_rl()
+        config = _make_search_config()
 
-        rl = BraveRateLimiter(100.0)
-
-        with patch("lavandula.nonprofits.pipeline_resolver.search", side_effect=BraveSearchError("Brave API returned 500")):
+        with patch("lavandula.nonprofits.pipeline_resolver.ws_search_and_filter",
+                    side_effect=SearchError("Serpex API returned 500")):
             stats = producer(
-                orgs, pq=pq, engine=engine, api_key="key",
+                orgs, pq=pq, engine=engine, search_config=config,
                 rate_limiter=rl, shutdown=shutdown,
             )
 
-        assert stats.brave_errors == 1
+        assert stats.search_errors == 1
 
     def test_producer_shutdown_stops_early(self):
         pq = PipelineQueue(maxsize=32)
@@ -212,25 +234,27 @@ class TestProducer:
         shutdown = ShutdownFlag()
         orgs = [{"ein": f"{i:09d}", "name": f"Org {i}", "city": "X", "state": "TX"} for i in range(10)]
 
-        from lavandula.nonprofits.brave_search import BraveRateLimiter, BraveSearchResult
-
-        rl = BraveRateLimiter(100.0)
+        rl = _fast_rl()
+        config = _make_search_config()
         call_count = 0
 
-        def mock_search(*args, **kwargs):
+        def mock_search_and_filter(*args, **kwargs):
             nonlocal call_count
             call_count += 1
             if call_count >= 3:
                 shutdown.set()
-            return [BraveSearchResult(title="Site", url="https://site.org", snippet="...")]
+            return SearchFilterResult(
+                results=[SearchResult(title="Site", url="https://site.org", snippet="...", engines=("brave",))],
+                had_raw_results=True,
+            )
 
         def mock_fetch(url):
             return {"url": url, "final_url": url, "live": True, "title": "", "snippet": "", "excerpt": "ok", "status_code": 200}
 
-        with patch("lavandula.nonprofits.pipeline_resolver.search", side_effect=mock_search):
+        with patch("lavandula.nonprofits.pipeline_resolver.ws_search_and_filter", side_effect=mock_search_and_filter):
             with patch("lavandula.nonprofits.pipeline_resolver._fetch_candidate", side_effect=mock_fetch):
                 stats = producer(
-                    orgs, pq=pq, engine=engine, api_key="key",
+                    orgs, pq=pq, engine=engine, search_config=config,
                     rate_limiter=rl, shutdown=shutdown,
                 )
 
@@ -410,13 +434,15 @@ class TestQueueDepth:
         engine = _make_mock_engine()
         shutdown = ShutdownFlag()
 
-        from lavandula.nonprofits.brave_search import BraveRateLimiter, BraveSearchResult
-
-        rl = BraveRateLimiter(1000.0)
+        rl = RateLimiter(1000.0)
+        config = _make_search_config()
         orgs = [{"ein": f"{i:09d}", "name": f"Org {i}", "city": "X", "state": "TX"} for i in range(20)]
 
-        def mock_search(*args, **kwargs):
-            return [BraveSearchResult(title="Site", url="https://site.org", snippet="...")]
+        def mock_search_and_filter(*args, **kwargs):
+            return SearchFilterResult(
+                results=[SearchResult(title="Site", url="https://site.org", snippet="...", engines=("brave",))],
+                had_raw_results=True,
+            )
 
         def mock_fetch(url):
             return {"url": url, "final_url": url, "live": True, "title": "", "snippet": "", "excerpt": "ok", "status_code": 200}
@@ -429,13 +455,13 @@ class TestQueueDepth:
 
         mock_gemma.disambiguate.side_effect = slow_disambiguate
 
-        with patch("lavandula.nonprofits.pipeline_resolver.search", side_effect=mock_search):
+        with patch("lavandula.nonprofits.pipeline_resolver.ws_search_and_filter", side_effect=mock_search_and_filter):
             with patch("lavandula.nonprofits.pipeline_resolver._fetch_candidate", side_effect=mock_fetch):
                 producer_thread = threading.Thread(
                     target=producer,
                     kwargs={
                         "orgs": orgs, "pq": pq, "engine": engine,
-                        "api_key": "key", "rate_limiter": rl, "shutdown": shutdown,
+                        "search_config": config, "rate_limiter": rl, "shutdown": shutdown,
                     },
                     daemon=True,
                 )

--- a/lavandula/nonprofits/tests/unit/test_web_search.py
+++ b/lavandula/nonprofits/tests/unit/test_web_search.py
@@ -1,0 +1,455 @@
+"""Unit tests for web_search.py (Spec 0031)."""
+from __future__ import annotations
+
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from lavandula.nonprofits.web_search import (
+    RateLimiter,
+    SearchConfig,
+    SearchError,
+    SearchFilterResult,
+    SearchResult,
+    SearchStats,
+    _merge_results,
+    _normalize_url,
+    _serpex_search,
+    reset_search_stats,
+    search,
+    search_and_filter,
+    validate_engines,
+)
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+
+def _mock_serpex_response(results: list[dict], status_code: int = 200) -> MagicMock:
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.json.return_value = {"results": results}
+    return resp
+
+
+def _mock_serpex_error(status_code: int) -> MagicMock:
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.json.return_value = {}
+    return resp
+
+
+def _make_config(**overrides) -> SearchConfig:
+    defaults = {
+        "backend": "serpex",
+        "engines": ["brave"],
+        "api_key": "test-key",
+        "qps": 100.0,
+        "count": 10,
+    }
+    defaults.update(overrides)
+    return SearchConfig(**defaults)
+
+
+def _fast_rl() -> RateLimiter:
+    return RateLimiter(1000.0)
+
+
+# ── URL Normalization (AC 44) ────────────────────────────────────────────────
+
+
+class TestNormalizeUrl:
+    def test_strip_www(self):
+        key, _ = _normalize_url("https://www.example.com/page")
+        assert key == "example.com/page"
+
+    def test_strip_trailing_slash(self):
+        key, _ = _normalize_url("https://example.com/page/")
+        assert key == "example.com/page"
+
+    def test_root_path_stripped(self):
+        key, _ = _normalize_url("https://example.com/")
+        assert key == "example.com"
+
+    def test_strip_fragment(self):
+        key, _ = _normalize_url("https://example.com/page#section")
+        assert key == "example.com/page"
+
+    def test_preserve_query_string(self):
+        key, _ = _normalize_url("https://example.com/page?id=1&sort=asc")
+        assert key == "example.com/page?id=1&sort=asc"
+
+    def test_preserve_path_case(self):
+        key1, _ = _normalize_url("https://example.com/About")
+        key2, _ = _normalize_url("https://example.com/about")
+        assert key1 != key2
+
+    def test_scheme_collapsed(self):
+        key_http, _ = _normalize_url("http://example.com/page")
+        key_https, _ = _normalize_url("https://example.com/page")
+        assert key_http == key_https
+
+    def test_lowercase_hostname(self):
+        key, _ = _normalize_url("https://EXAMPLE.COM/Page")
+        assert key == "example.com/Page"
+
+    def test_remove_default_port_80(self):
+        key, _ = _normalize_url("http://example.com:80/page")
+        assert key == "example.com/page"
+
+    def test_remove_default_port_443(self):
+        key, _ = _normalize_url("https://example.com:443/page")
+        assert key == "example.com/page"
+
+    def test_preserve_non_default_port(self):
+        key, _ = _normalize_url("https://example.com:8080/page")
+        assert key == "example.com:8080/page"
+
+
+# ── Engine Validation (AC 46) ────────────────────────────────────────────────
+
+
+class TestValidateEngines:
+    def test_valid_single(self):
+        assert validate_engines(["brave"]) == ["brave"]
+
+    def test_valid_multi(self):
+        assert validate_engines(["brave", "google"]) == ["brave", "google"]
+
+    def test_auto_alone(self):
+        assert validate_engines(["auto"]) == ["auto"]
+
+    def test_auto_combined_rejected(self):
+        with pytest.raises(ValueError, match="auto"):
+            validate_engines(["auto", "brave"])
+
+    def test_unknown_engine_rejected(self):
+        with pytest.raises(ValueError, match="potato"):
+            validate_engines(["potato"])
+
+    def test_duplicates_deduped(self):
+        assert validate_engines(["brave", "brave"]) == ["brave"]
+
+    def test_empty_rejected(self):
+        with pytest.raises(ValueError, match="At least one"):
+            validate_engines([])
+
+    def test_whitespace_stripped(self):
+        assert validate_engines([" brave ", " google "]) == ["brave", "google"]
+
+
+# ── Serpex API Call (AC 42) ──────────────────────────────────────────────────
+
+
+class TestSerpexSearch:
+    def test_api_call_construction(self):
+        results = [
+            {"title": "Example", "url": "https://example.org", "snippet": "A nonprofit"},
+        ]
+        rl = _fast_rl()
+        with patch("lavandula.nonprofits.web_search.requests.get") as mock_get:
+            mock_get.return_value = _mock_serpex_response(results)
+            out = _serpex_search("test query", "brave", api_key="key123", count=10, rate_limiter=rl)
+
+        mock_get.assert_called_once()
+        call_kwargs = mock_get.call_args
+        assert call_kwargs.kwargs["headers"] == {"X-API-Key": "key123"}
+        assert call_kwargs.kwargs["params"]["q"] == "test query"
+        assert call_kwargs.kwargs["params"]["engine"] == "brave"
+        assert call_kwargs.kwargs["params"]["category"] == "web"
+        assert len(out) == 1
+        assert out[0].title == "Example"
+        assert out[0].engines == ("brave",)
+
+    def test_response_parsing(self):
+        results = [
+            {"title": "T1", "url": "https://a.org", "snippet": "S1"},
+            {"title": "T2", "url": "https://b.org", "snippet": "S2"},
+        ]
+        rl = _fast_rl()
+        with patch("lavandula.nonprofits.web_search.requests.get") as mock_get:
+            mock_get.return_value = _mock_serpex_response(results)
+            out = _serpex_search("q", "brave", api_key="k", count=10, rate_limiter=rl)
+
+        assert len(out) == 2
+        assert out[0].url == "https://a.org"
+        assert out[1].snippet == "S2"
+
+
+# ── Error Handling (AC 45) ──────────────────────────────────────────────────
+
+
+class TestErrorHandling:
+    def test_402_no_retry(self):
+        rl = _fast_rl()
+        with patch("lavandula.nonprofits.web_search.requests.get") as mock_get:
+            mock_get.return_value = _mock_serpex_error(402)
+            with pytest.raises(SearchError, match="402"):
+                _serpex_search("q", "brave", api_key="k", count=10, rate_limiter=rl)
+        assert mock_get.call_count == 1
+
+    def test_429_retried(self):
+        rl = _fast_rl()
+        ok_resp = _mock_serpex_response([{"title": "OK", "url": "https://ok.org", "snippet": "ok"}])
+        with patch("lavandula.nonprofits.web_search.requests.get") as mock_get:
+            mock_get.side_effect = [_mock_serpex_error(429), _mock_serpex_error(429), ok_resp]
+            with patch("lavandula.nonprofits.web_search.time.sleep"):
+                out = _serpex_search("q", "brave", api_key="k", count=10, rate_limiter=rl)
+        assert len(out) == 1
+
+    def test_5xx_retried(self):
+        rl = _fast_rl()
+        ok_resp = _mock_serpex_response([{"title": "OK", "url": "https://ok.org", "snippet": "ok"}])
+        with patch("lavandula.nonprofits.web_search.requests.get") as mock_get:
+            mock_get.side_effect = [_mock_serpex_error(500), ok_resp]
+            with patch("lavandula.nonprofits.web_search.time.sleep"):
+                out = _serpex_search("q", "brave", api_key="k", count=10, rate_limiter=rl)
+        assert len(out) == 1
+
+    def test_network_error_retried(self):
+        import requests
+        rl = _fast_rl()
+        ok_resp = _mock_serpex_response([{"title": "OK", "url": "https://ok.org", "snippet": "ok"}])
+        with patch("lavandula.nonprofits.web_search.requests.get") as mock_get:
+            mock_get.side_effect = [requests.Timeout("timeout"), ok_resp]
+            with patch("lavandula.nonprofits.web_search.time.sleep"):
+                out = _serpex_search("q", "brave", api_key="k", count=10, rate_limiter=rl)
+        assert len(out) == 1
+
+    def test_exhaustion_raises(self):
+        rl = _fast_rl()
+        with patch("lavandula.nonprofits.web_search.requests.get") as mock_get:
+            mock_get.return_value = _mock_serpex_error(500)
+            with patch("lavandula.nonprofits.web_search.time.sleep"):
+                with pytest.raises(SearchError):
+                    _serpex_search("q", "brave", api_key="k", count=10, rate_limiter=rl)
+
+    def test_multi_engine_partial_failure(self):
+        reset_search_stats()
+        rl = _fast_rl()
+        ok_resp = _mock_serpex_response([{"title": "OK", "url": "https://ok.org", "snippet": "ok"}])
+        config = _make_config(engines=["brave", "google"])
+
+        with patch("lavandula.nonprofits.web_search.requests.get") as mock_get:
+            # brave fails, google succeeds
+            mock_get.side_effect = [_mock_serpex_error(500)] * 4 + [ok_resp]
+            with patch("lavandula.nonprofits.web_search.time.sleep"):
+                out = search("test", config=config, rate_limiter=rl)
+
+        assert len(out) == 1
+        assert "google" in out[0].engines
+
+    def test_multi_engine_all_fail(self):
+        reset_search_stats()
+        rl = _fast_rl()
+        config = _make_config(engines=["brave", "google"])
+
+        with patch("lavandula.nonprofits.web_search.requests.get") as mock_get:
+            mock_get.return_value = _mock_serpex_error(500)
+            with patch("lavandula.nonprofits.web_search.time.sleep"):
+                with pytest.raises(SearchError, match="All engines failed"):
+                    search("test", config=config, rate_limiter=rl)
+
+
+# ── Multi-Engine Merge (AC 43) ──────────────────────────────────────────────
+
+
+class TestMergeResults:
+    def test_same_url_merged(self):
+        results_by_engine = {
+            "brave": [
+                SearchResult("T1", "https://example.org", "S1", ("brave",)),
+            ],
+            "google": [
+                SearchResult("T1b", "https://example.org", "S1b", ("google",)),
+            ],
+        }
+        merged = _merge_results(results_by_engine)
+        assert len(merged) == 1
+        assert set(merged[0].engines) == {"brave", "google"}
+
+    def test_multi_engine_sorts_first(self):
+        results_by_engine = {
+            "brave": [
+                SearchResult("Brave Only", "https://brave-only.org", "S", ("brave",)),
+                SearchResult("Both", "https://both.org", "S", ("brave",)),
+            ],
+            "google": [
+                SearchResult("Both", "https://both.org", "S", ("google",)),
+            ],
+        }
+        merged = _merge_results(results_by_engine)
+        assert merged[0].url == "https://both.org"
+        assert len(merged[0].engines) == 2
+
+    def test_tiebreaker_by_rank(self):
+        results_by_engine = {
+            "brave": [
+                SearchResult("A", "https://a.org", "S", ("brave",)),
+                SearchResult("B", "https://b.org", "S", ("brave",)),
+            ],
+        }
+        merged = _merge_results(results_by_engine)
+        assert merged[0].url == "https://a.org"
+        assert merged[1].url == "https://b.org"
+
+    def test_tiebreaker_insertion_order(self):
+        results_by_engine = {
+            "brave": [
+                SearchResult("A", "https://a.org", "S", ("brave",)),
+            ],
+            "google": [
+                SearchResult("B", "https://b.org", "S", ("google",)),
+            ],
+        }
+        merged = _merge_results(results_by_engine)
+        # Both single-engine, rank 0. Brave inserted first (dict order).
+        assert merged[0].url == "https://a.org"
+        assert merged[1].url == "https://b.org"
+
+    def test_https_preferred_over_http(self):
+        results_by_engine = {
+            "brave": [
+                SearchResult("T1", "http://example.org", "S", ("brave",)),
+            ],
+            "google": [
+                SearchResult("T1", "https://example.org", "S", ("google",)),
+            ],
+        }
+        merged = _merge_results(results_by_engine)
+        assert len(merged) == 1
+        assert merged[0].url == "https://example.org"
+
+    def test_www_deduped(self):
+        results_by_engine = {
+            "brave": [
+                SearchResult("T1", "https://www.example.org/page", "S", ("brave",)),
+            ],
+            "google": [
+                SearchResult("T1", "https://example.org/page", "S", ("google",)),
+            ],
+        }
+        merged = _merge_results(results_by_engine)
+        assert len(merged) == 1
+        assert len(merged[0].engines) == 2
+
+
+# ── search() Public API ─────────────────────────────────────────────────────
+
+
+class TestSearch:
+    def test_single_engine(self):
+        reset_search_stats()
+        rl = _fast_rl()
+        config = _make_config(engines=["brave"])
+        results = [{"title": "T", "url": "https://t.org", "snippet": "S"}]
+
+        with patch("lavandula.nonprofits.web_search.requests.get") as mock_get:
+            mock_get.return_value = _mock_serpex_response(results)
+            out = search("q", config=config, rate_limiter=rl)
+
+        assert len(out) == 1
+        assert out[0].engines == ("brave",)
+
+    def test_brave_direct_backend(self):
+        rl = _fast_rl()
+        config = _make_config(backend="brave-direct")
+
+        with patch("lavandula.nonprofits.brave_search.requests.get") as mock_get:
+            resp = MagicMock()
+            resp.status_code = 200
+            resp.json.return_value = {"web": {"results": [
+                {"title": "T", "url": "https://t.org", "description": "S"},
+            ]}}
+            mock_get.return_value = resp
+            out = search("q", config=config, rate_limiter=rl)
+
+        assert len(out) == 1
+        assert out[0].engines == ("brave",)
+
+
+# ── search_and_filter() (AC 47) ─────────────────────────────────────────────
+
+
+class TestSearchAndFilter:
+    def test_blocklist_applied(self):
+        reset_search_stats()
+        rl = _fast_rl()
+        config = _make_config()
+        results = [
+            {"title": "LinkedIn", "url": "https://www.linkedin.com/company/test", "snippet": "..."},
+            {"title": "Official", "url": "https://testorg.org", "snippet": "..."},
+            {"title": "Propublica", "url": "https://propublica.org/test", "snippet": "..."},
+            {"title": "Other", "url": "https://other.org", "snippet": "..."},
+            {"title": "Third", "url": "https://third.org", "snippet": "..."},
+        ]
+
+        with patch("lavandula.nonprofits.web_search.requests.get") as mock_get:
+            mock_get.return_value = _mock_serpex_response(results)
+            result = search_and_filter(
+                "Test Org", "Dallas", "TX",
+                config=config, rate_limiter=rl,
+            )
+
+        assert result.had_raw_results is True
+        assert len(result.results) == 3
+        assert result.results[0].url == "https://testorg.org"
+        assert result.results[1].url == "https://other.org"
+        assert result.results[2].url == "https://third.org"
+
+    def test_empty_results(self):
+        reset_search_stats()
+        rl = _fast_rl()
+        config = _make_config()
+
+        with patch("lavandula.nonprofits.web_search.requests.get") as mock_get:
+            mock_get.return_value = _mock_serpex_response([])
+            result = search_and_filter("Test", "City", "ST", config=config, rate_limiter=rl)
+
+        assert result.results == []
+        assert result.had_raw_results is False
+
+    def test_all_blocked(self):
+        reset_search_stats()
+        rl = _fast_rl()
+        config = _make_config()
+        results = [
+            {"title": "LinkedIn", "url": "https://linkedin.com/test", "snippet": "..."},
+            {"title": "Propublica", "url": "https://propublica.org/test", "snippet": "..."},
+        ]
+
+        with patch("lavandula.nonprofits.web_search.requests.get") as mock_get:
+            mock_get.return_value = _mock_serpex_response(results)
+            result = search_and_filter("Test", "City", "ST", config=config, rate_limiter=rl)
+
+        assert result.results == []
+        assert result.had_raw_results is True
+
+
+# ── SearchConfig repr (key not leaked) ───────────────────────────────────────
+
+
+class TestSearchConfigRepr:
+    def test_api_key_masked(self):
+        config = _make_config(api_key="super_secret_key_12345")
+        r = repr(config)
+        assert "super_secret_key_12345" not in r
+        assert "***" in r
+
+
+# ── RateLimiter ──────────────────────────────────────────────────────────────
+
+
+class TestRateLimiter:
+    def test_rate_limiter_enforced(self):
+        rl = RateLimiter(2.0)
+        t0 = time.monotonic()
+        for _ in range(10):
+            rl.acquire()
+        elapsed = time.monotonic() - t0
+        assert elapsed >= 4.0
+
+    def test_rate_limiter_invalid_qps(self):
+        with pytest.raises(ValueError):
+            RateLimiter(0.0)

--- a/lavandula/nonprofits/tools/pipeline_enrich_phone.py
+++ b/lavandula/nonprofits/tools/pipeline_enrich_phone.py
@@ -1,0 +1,225 @@
+"""CLI entry point for phone number enrichment (Spec 0031).
+
+Usage:
+    python -m lavandula.nonprofits.tools.pipeline_enrich_phone --state TX [OPTIONS]
+
+Finds phone numbers for resolved orgs that lack one, using search snippets
+and website contact pages.
+"""
+from __future__ import annotations
+
+import argparse
+import logging
+import re
+import sys
+import time
+
+from lavandula.common.db import make_app_engine
+from lavandula.common.secrets import SecretUnavailable, get_serpex_api_key
+from lavandula.nonprofits.phone_extract import extract_phone
+from lavandula.nonprofits.web_search import (
+    RateLimiter,
+    SearchConfig,
+    SearchError,
+    get_search_stats,
+    reset_search_stats,
+    search,
+    validate_engines,
+)
+
+log = logging.getLogger(__name__)
+
+_SCHEMA = "lava_corpus"
+
+_CONTACT_PATHS = ["/contact", "/about", "/about-us"]
+
+
+def _fetch_contact_page(base_url: str) -> str | None:
+    """Fetch contact/about page from org website, return text or None."""
+    import requests as http_requests
+
+    base_url = base_url.rstrip("/")
+    for path in _CONTACT_PATHS:
+        url = base_url + path
+        try:
+            resp = http_requests.get(url, timeout=15, allow_redirects=True)
+            if resp.status_code == 200 and len(resp.content) < 2_000_000:
+                text = resp.text
+                text = re.sub(r"<script[^>]*>.*?</script>", " ", text, flags=re.DOTALL | re.I)
+                text = re.sub(r"<style[^>]*>.*?</style>", " ", text, flags=re.DOTALL | re.I)
+                text = re.sub(r"<[^>]+>", " ", text)
+                text = re.sub(r"\s+", " ", text).strip()
+                return text[:10000]
+        except Exception:
+            continue
+    return None
+
+
+def main(argv: list[str] | None = None) -> None:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+    parser = argparse.ArgumentParser(
+        prog="pipeline_enrich_phone",
+        description="Enrich resolved orgs with phone numbers via search.",
+    )
+    parser.add_argument("--state", default=None, help="Filter to orgs in this state")
+    parser.add_argument("--limit", type=int, default=0, help="Max orgs to process (0 = no limit)")
+    parser.add_argument("--search-engines", default="brave", help="Comma-separated engines")
+    parser.add_argument("--allow-tollfree", action="store_true", help="Allow toll-free numbers")
+    parser.add_argument("--serpex-api-key", default=None, help="Serpex API key (literal)")
+    parser.add_argument("--search-qps", type=float, default=1.0, help="Search queries per second")
+    args = parser.parse_args(argv)
+
+    try:
+        engines = validate_engines(args.search_engines.split(","))
+    except ValueError as exc:
+        parser.error(str(exc))
+
+    try:
+        if args.serpex_api_key:
+            api_key = args.serpex_api_key
+        else:
+            api_key = get_serpex_api_key()
+    except SecretUnavailable as exc:
+        print(f"ERROR: Serpex API key unavailable: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    search_config = SearchConfig(
+        backend="serpex",
+        engines=engines,
+        api_key=api_key,
+        qps=args.search_qps,
+    )
+    rate_limiter = RateLimiter(args.search_qps)
+
+    from sqlalchemy import text
+
+    engine = make_app_engine()
+    reset_search_stats()
+
+    try:
+        # Load resolved orgs without phone
+        sql = (
+            f"SELECT ein, name, city, state, website_url "
+            f"FROM {_SCHEMA}.nonprofits_seed "
+            f"WHERE resolver_status = 'resolved' AND phone IS NULL"
+        )
+        params: dict = {}
+        if args.state:
+            sql += " AND state = :state"
+            params["state"] = args.state
+        sql += " ORDER BY ein"
+        if args.limit > 0:
+            sql += " LIMIT :lim"
+            params["lim"] = args.limit
+
+        with engine.connect() as conn:
+            rows = conn.execute(text(sql), params).fetchall()
+
+        orgs = [
+            {
+                "ein": row[0],
+                "name": row[1] or "",
+                "city": row[2] or "",
+                "state": row[3] or "",
+                "website_url": row[4] or "",
+            }
+            for row in rows
+        ]
+
+        log.info("Loaded %d orgs for phone enrichment", len(orgs))
+        if not orgs:
+            print("No orgs to process.")
+            return
+
+        t_start = time.monotonic()
+        found_snippet = 0
+        found_website = 0
+        not_found = 0
+
+        for i, org in enumerate(orgs, 1):
+            ein = org["ein"]
+            name = org["name"]
+            city = org["city"]
+            state = org["state"]
+            website_url = org["website_url"]
+
+            # Search for phone
+            sanitized_name = re.sub(r'"', "", name).strip()
+            query = f'"{sanitized_name}" {city} {state} phone number'
+
+            phone = None
+            phone_source = None
+
+            try:
+                results = search(query, config=search_config, rate_limiter=rate_limiter)
+            except SearchError as exc:
+                log.warning("Search error for ein=%s: %s", ein, exc)
+                not_found += 1
+                continue
+
+            # Priority 1: extract from snippets
+            all_snippets = " ".join(r.snippet for r in results if r.snippet)
+            phone = extract_phone(
+                all_snippets,
+                allow_tollfree=args.allow_tollfree,
+                org_name=name,
+            )
+            if phone:
+                phone_source = "search_snippet"
+
+            # Priority 2: fetch website contact page
+            if not phone and website_url:
+                page_text = _fetch_contact_page(website_url)
+                if page_text:
+                    phone = extract_phone(
+                        page_text,
+                        allow_tollfree=args.allow_tollfree,
+                        org_name=name,
+                    )
+                    if phone:
+                        phone_source = "website_extract"
+
+            if phone:
+                with engine.begin() as conn:
+                    conn.execute(
+                        text(
+                            f"UPDATE {_SCHEMA}.nonprofits_seed "
+                            f"SET phone = :phone, phone_source = :source "
+                            f"WHERE ein = :ein"
+                        ),
+                        {"phone": phone, "source": phone_source, "ein": ein},
+                    )
+                if phone_source == "search_snippet":
+                    found_snippet += 1
+                else:
+                    found_website += 1
+                log.info("[%d] ein=%s phone=%s source=%s", i, ein, phone, phone_source)
+            else:
+                not_found += 1
+                log.debug("[%d] ein=%s no phone found", i, ein)
+
+        wall_time = time.monotonic() - t_start
+        total = found_snippet + found_website + not_found
+
+        print(f"\n--- Phone Enrichment Summary ---")
+        print(f"Wall time: {wall_time:.1f}s")
+        print(f"Processed: {total}")
+        print(f"Found (snippet): {found_snippet}")
+        print(f"Found (website): {found_website}")
+        print(f"Not found: {not_found}")
+        if total > 0:
+            print(f"Hit rate: {(found_snippet + found_website) / total * 100:.1f}%")
+
+        s_stats = get_search_stats()
+        if s_stats.estimated_credits > 0:
+            print(f"Estimated credits: {s_stats.estimated_credits}")
+
+    finally:
+        engine.dispose()
+
+
+if __name__ == "__main__":
+    main()

--- a/lavandula/nonprofits/tools/pipeline_resolve.py
+++ b/lavandula/nonprofits/tools/pipeline_resolve.py
@@ -1,16 +1,19 @@
-"""CLI entry point for pipeline URL resolution (Spec 0018).
+"""CLI entry point for pipeline URL resolution (Spec 0018, 0031).
 
 Usage:
     python -m lavandula.nonprofits.tools.pipeline_resolve --state TX [OPTIONS]
 
-    # Local Ollama (default):
-    python -m lavandula.nonprofits.tools.pipeline_resolve --state TX
-
-    # DeepSeek API:
+    # Serpex backend (default, Spec 0031):
     python -m lavandula.nonprofits.tools.pipeline_resolve --state TX \
-        --llm-url https://api.deepseek.com/v1 \
-        --llm-model deepseek-v4-flash \
-        --llm-api-key-ssm lavandula/deepseek/api_key
+        --search-backend serpex --search-engines brave
+
+    # Multi-engine:
+    python -m lavandula.nonprofits.tools.pipeline_resolve --state TX \
+        --search-engines brave,google
+
+    # Brave direct (legacy):
+    python -m lavandula.nonprofits.tools.pipeline_resolve --state TX \
+        --search-backend brave-direct
 """
 from __future__ import annotations
 
@@ -21,8 +24,7 @@ import threading
 import time
 
 from lavandula.common.db import MIN_SCHEMA_VERSION, assert_schema_at_least, make_app_engine
-from lavandula.common.secrets import SecretUnavailable, get_brave_api_key
-from lavandula.nonprofits.brave_search import BraveRateLimiter
+from lavandula.common.secrets import SecretUnavailable, get_brave_api_key, get_serpex_api_key
 from lavandula.nonprofits.gemma_client import LLMClient
 from lavandula.nonprofits.pipeline_resolver import (
     PipelineQueue,
@@ -33,6 +35,13 @@ from lavandula.nonprofits.pipeline_resolver import (
     producer,
     run_dry,
 )
+from lavandula.nonprofits.web_search import (
+    RateLimiter,
+    SearchConfig,
+    get_search_stats,
+    reset_search_stats,
+    validate_engines,
+)
 
 log = logging.getLogger(__name__)
 
@@ -40,14 +49,27 @@ log = logging.getLogger(__name__)
 def _build_parser() -> argparse.ArgumentParser:
     p = argparse.ArgumentParser(
         prog="pipeline_resolve",
-        description="Resolve nonprofit website URLs via Brave Search + LLM.",
+        description="Resolve nonprofit website URLs via search + LLM.",
     )
     p.add_argument("--state", required=True, help="Filter to orgs in this state")
     p.add_argument("--limit", type=int, default=0, help="Max orgs to process (0 = no limit)")
     p.add_argument("--status-filter", default="unresolved", help="Which resolver_status to re-process")
     p.add_argument("--fresh-only", action="store_true", help="Only process orgs with resolver_status IS NULL (skip previously attempted)")
-    p.add_argument("--brave-qps", type=float, default=1.0, help="Brave API queries per second")
-    p.add_argument("--search-parallelism", type=int, default=4, help="Concurrent Brave search requests")
+
+    # Search backend (Spec 0031)
+    p.add_argument("--search-backend", choices=["serpex", "brave-direct"], default="serpex",
+                    help="Search backend (default: serpex)")
+    p.add_argument("--search-engines", default="brave",
+                    help="Comma-separated engines: brave,google,bing,auto (default: brave)")
+    p.add_argument("--search-qps", type=float, default=None, help="Search queries per second")
+    p.add_argument("--brave-qps", type=float, default=None,
+                    help="(deprecated, use --search-qps) Brave API queries per second")
+
+    serpex_key_group = p.add_mutually_exclusive_group()
+    serpex_key_group.add_argument("--serpex-api-key", default=None, help="Serpex API key (literal)")
+    serpex_key_group.add_argument("--serpex-ssm-key", default=None, help="SSM path for Serpex API key")
+
+    p.add_argument("--search-parallelism", type=int, default=4, help="Concurrent search requests")
     p.add_argument("--fetch-parallelism", type=int, default=8, help="Concurrent HTTP fetch requests")
     p.add_argument("--queue-size", type=int, default=32, help="Bounded queue capacity")
     p.add_argument("--llm-url", default="http://localhost:11434/v1", help="OpenAI-compatible endpoint")
@@ -66,9 +88,21 @@ def main(argv: list[str] | None = None) -> None:
     parser = _build_parser()
     args = parser.parse_args(argv)
 
-    if args.brave_qps <= 0:
-        parser.error("--brave-qps must be > 0")
+    # QPS: --search-qps takes priority, --brave-qps is deprecated alias
+    qps = args.search_qps or args.brave_qps or 1.0
+    if qps <= 0:
+        parser.error("--search-qps must be > 0")
 
+    # Engine validation
+    if args.search_backend == "brave-direct":
+        engines = ["brave"]
+    else:
+        try:
+            engines = validate_engines(args.search_engines.split(","))
+        except ValueError as exc:
+            parser.error(str(exc))
+
+    # LLM setup
     api_key_value = None
     if args.llm_api_key_ssm:
         from lavandula.common.secrets import get_secret
@@ -85,17 +119,41 @@ def main(argv: list[str] | None = None) -> None:
         )
         sys.exit(1)
 
+    # Search API key
     try:
-        api_key = get_brave_api_key()
+        if args.search_backend == "serpex":
+            if args.serpex_api_key:
+                search_api_key = args.serpex_api_key
+            elif args.serpex_ssm_key:
+                from lavandula.common.secrets import get_secret
+                search_api_key = get_secret(args.serpex_ssm_key)
+            else:
+                search_api_key = get_serpex_api_key()
+        else:
+            search_api_key = get_brave_api_key()
     except SecretUnavailable as exc:
-        print(f"ERROR: Brave API key unavailable: {exc}", file=sys.stderr)
+        print(f"ERROR: Search API key unavailable: {exc}", file=sys.stderr)
         sys.exit(1)
+
+    search_config = SearchConfig(
+        backend=args.search_backend,
+        engines=engines,
+        api_key=search_api_key,
+        qps=qps,
+    )
+    rate_limiter = RateLimiter(qps)
+
+    log.info(
+        "Search: backend=%s engines=%s qps=%.1f",
+        args.search_backend, ",".join(engines), qps,
+    )
 
     engine = make_app_engine()
     assert_schema_at_least(engine, MIN_SCHEMA_VERSION)
 
+    reset_search_stats()
+
     try:
-        rate_limiter = BraveRateLimiter(args.brave_qps)
         limit = args.limit if args.limit > 0 else None
 
         orgs = load_unresolved_orgs(
@@ -114,7 +172,7 @@ def main(argv: list[str] | None = None) -> None:
         if args.dry_run:
             run_dry(
                 orgs,
-                api_key=api_key,
+                search_config=search_config,
                 rate_limiter=rate_limiter,
                 search_parallelism=args.search_parallelism,
                 fetch_parallelism=args.fetch_parallelism,
@@ -135,7 +193,7 @@ def main(argv: list[str] | None = None) -> None:
                 orgs,
                 pq=pq,
                 engine=engine,
-                api_key=api_key,
+                search_config=search_config,
                 rate_limiter=rate_limiter,
                 search_parallelism=args.search_parallelism,
                 fetch_parallelism=args.fetch_parallelism,
@@ -185,12 +243,12 @@ def main(argv: list[str] | None = None) -> None:
         print(f"Wall time: {wall_time:.1f}s")
         print(f"Consumer threads: {n_consumers}")
         if p_stats:
-            print(f"Brave queries: {p_stats.searched}")
+            print(f"Search queries: {p_stats.searched}")
             print(f"Enqueued: {p_stats.enqueued}")
             print(f"Skipped (no results): {p_stats.skipped_no_results}")
             print(f"Skipped (all blocked): {p_stats.skipped_all_blocked}")
             print(f"Skipped (no live): {p_stats.skipped_no_live}")
-            print(f"Brave errors: {p_stats.brave_errors}")
+            print(f"Search errors: {p_stats.search_errors}")
         print(f"Resolved: {resolved}")
         print(f"Ambiguous: {ambiguous}")
         print(f"Unresolved: {unresolved}")
@@ -198,6 +256,18 @@ def main(argv: list[str] | None = None) -> None:
         total = resolved + ambiguous + unresolved
         if wall_time > 0 and total > 0:
             print(f"Rate: {total / wall_time * 60:.1f} orgs/minute")
+
+        # Search stats (Spec 0031)
+        s_stats = get_search_stats()
+        if s_stats.estimated_credits > 0:
+            print("\n--- Search Summary ---")
+            eng_parts = ", ".join(f"{k}={v}" for k, v in sorted(s_stats.successful_by_engine.items()))
+            print(f"Engine queries: {eng_parts}")
+            if s_stats.failed_by_engine:
+                fail_parts = ", ".join(f"{k}={v}" for k, v in sorted(s_stats.failed_by_engine.items()))
+                print(f"Engine failures: {fail_parts}")
+            print(f"Search: {s_stats.search_full} full, {s_stats.search_partial} partial, {s_stats.search_failed} failed")
+            print(f"Estimated credits: {s_stats.estimated_credits}")
 
     finally:
         engine.dispose()

--- a/lavandula/nonprofits/web_search.py
+++ b/lavandula/nonprofits/web_search.py
@@ -1,0 +1,464 @@
+"""Unified search adapter with Serpex multi-engine support (Spec 0031).
+
+Drop-in replacement for brave_search as the search interface for the
+resolver pipeline. Supports both Serpex (default) and Brave direct backends.
+Serpex enables multi-engine queries (brave, google, bing) with result merging.
+"""
+from __future__ import annotations
+
+import logging
+import re
+import threading
+import time
+from dataclasses import dataclass, field
+from typing import NamedTuple
+from urllib.parse import urlsplit
+
+import requests
+
+log = logging.getLogger(__name__)
+
+VALID_ENGINES = frozenset({"brave", "google", "bing", "auto"})
+
+_SERPEX_URL = "https://api.serpex.dev/api/search"
+_RETRY_STATUSES = {429, 500, 502, 503, 504}
+_RETRY_DELAYS = [2.0, 4.0, 8.0]
+
+
+class SearchError(RuntimeError):
+    """Raised when search fails after all retries (or all engines fail)."""
+
+
+@dataclass(frozen=True)
+class SearchResult:
+    title: str
+    url: str
+    snippet: str
+    engines: tuple[str, ...]
+
+
+@dataclass
+class SearchConfig:
+    backend: str          # "serpex" | "brave-direct"
+    engines: list[str]    # ["brave"] or ["brave", "google"]
+    api_key: str
+    qps: float
+    count: int = 10
+
+    def __repr__(self) -> str:
+        return (
+            f"SearchConfig(backend={self.backend!r}, engines={self.engines!r}, "
+            f"api_key='***', qps={self.qps}, count={self.count})"
+        )
+
+
+class RateLimiter:
+    """Token-bucket rate limiter, thread-safe."""
+
+    def __init__(self, qps: float) -> None:
+        if qps <= 0:
+            raise ValueError("qps must be positive")
+        self._interval = 1.0 / qps
+        self._lock = threading.Lock()
+        self._next_allowed = 0.0
+
+    def acquire(self) -> None:
+        with self._lock:
+            now = time.monotonic()
+            if now < self._next_allowed:
+                wait = self._next_allowed - now
+                self._next_allowed += self._interval
+            else:
+                wait = 0.0
+                self._next_allowed = now + self._interval
+        if wait > 0:
+            time.sleep(wait)
+
+
+# ── Search Stats ─────────────────────────────────────────────────────────────
+
+
+@dataclass
+class SearchStats:
+    successful_by_engine: dict[str, int] = field(default_factory=dict)
+    failed_by_engine: dict[str, int] = field(default_factory=dict)
+    search_full: int = 0
+    search_partial: int = 0
+    search_failed: int = 0
+    _lock: threading.Lock = field(default_factory=threading.Lock, repr=False)
+
+    @property
+    def estimated_credits(self) -> int:
+        return sum(self.successful_by_engine.values())
+
+    def record_success(self, engine: str) -> None:
+        with self._lock:
+            self.successful_by_engine[engine] = self.successful_by_engine.get(engine, 0) + 1
+
+    def record_failure(self, engine: str) -> None:
+        with self._lock:
+            self.failed_by_engine[engine] = self.failed_by_engine.get(engine, 0) + 1
+
+    def record_query_outcome(self, *, total_engines: int, failed_engines: int) -> None:
+        with self._lock:
+            if failed_engines == 0:
+                self.search_full += 1
+            elif failed_engines < total_engines:
+                self.search_partial += 1
+            else:
+                self.search_failed += 1
+
+
+_search_stats = SearchStats()
+
+
+def get_search_stats() -> SearchStats:
+    return _search_stats
+
+
+def reset_search_stats() -> None:
+    global _search_stats
+    _search_stats = SearchStats()
+
+
+# ── URL normalization ────────────────────────────────────────────────────────
+
+
+def _normalize_url(url: str) -> tuple[str, str]:
+    """Normalize URL for dedup. Returns (normalized_key, preferred_url).
+
+    The normalized key drops scheme and fragments, collapses www, trailing /.
+    The preferred_url is the original URL (https preferred over http).
+    """
+    try:
+        parts = urlsplit(url)
+    except Exception:
+        return (url, url)
+
+    hostname = (parts.hostname or "").lower()
+    if hostname.startswith("www."):
+        hostname = hostname[4:]
+
+    port = parts.port
+    if port in (80, 443, None):
+        host = hostname
+    else:
+        host = f"{hostname}:{port}"
+
+    path = parts.path.rstrip("/") if parts.path != "/" else ""
+
+    query = parts.query
+
+    if query:
+        key = f"{host}{path}?{query}"
+    else:
+        key = f"{host}{path}"
+
+    return (key, url)
+
+
+# ── Engine validation ────────────────────────────────────────────────────────
+
+
+def validate_engines(engines: list[str]) -> list[str]:
+    """Validate and deduplicate engine list. Raises ValueError on invalid input."""
+    seen = set()
+    cleaned = []
+    for e in engines:
+        e = e.strip().lower()
+        if not e:
+            continue
+        if e not in VALID_ENGINES:
+            raise ValueError(
+                f"Unknown search engine {e!r}. Valid engines: {sorted(VALID_ENGINES)}"
+            )
+        if e not in seen:
+            seen.add(e)
+            cleaned.append(e)
+
+    if not cleaned:
+        raise ValueError("At least one search engine must be specified")
+
+    if "auto" in cleaned and len(cleaned) > 1:
+        raise ValueError("'auto' cannot be combined with other engines")
+
+    return cleaned
+
+
+# ── Serpex backend ───────────────────────────────────────────────────────────
+
+
+def _serpex_search(
+    query: str,
+    engine: str,
+    *,
+    api_key: str,
+    count: int,
+    rate_limiter: RateLimiter,
+) -> list[SearchResult]:
+    """Single Serpex API call for one engine."""
+    rate_limiter.acquire()
+    t0 = time.monotonic()
+
+    last_exc: Exception | None = None
+    for attempt, delay in enumerate([0.0] + _RETRY_DELAYS, start=1):
+        if attempt > 1:
+            time.sleep(delay)
+
+        try:
+            resp = requests.get(
+                _SERPEX_URL,
+                headers={"X-API-Key": api_key},
+                params={"q": query, "engine": engine, "category": "web"},
+                timeout=30,
+            )
+        except requests.RequestException as exc:
+            last_exc = exc
+            log.warning("Serpex network error engine=%s attempt=%d", engine, attempt)
+            if attempt > len(_RETRY_DELAYS):
+                break
+            continue
+
+        if resp.status_code == 200:
+            elapsed_ms = (time.monotonic() - t0) * 1000
+            data = resp.json()
+            raw_results = data.get("results") or []
+            results = [
+                SearchResult(
+                    title=r.get("title", ""),
+                    url=r.get("url", ""),
+                    snippet=r.get("snippet", ""),
+                    engines=(engine,),
+                )
+                for r in raw_results[:count]
+            ]
+            log.debug(
+                "search.engine=%s query=%s results=%d elapsed=%.0fms",
+                engine, query[:50], len(results), elapsed_ms,
+            )
+            return results
+
+        if resp.status_code == 402:
+            raise SearchError(
+                f"Serpex credit exhaustion (402) for engine={engine}"
+            )
+
+        if resp.status_code not in _RETRY_STATUSES:
+            raise SearchError(
+                f"Serpex API returned {resp.status_code} for engine={engine}"
+            )
+
+        log.warning(
+            "Serpex error status=%d engine=%s attempt=%d",
+            resp.status_code, engine, attempt,
+        )
+        last_exc = SearchError(
+            f"Serpex API returned {resp.status_code}"
+        )
+        if attempt > len(_RETRY_DELAYS):
+            break
+
+    raise SearchError(
+        f"Serpex API failed after retries for engine={engine}: {last_exc}"
+    )
+
+
+# ── Multi-engine merge ───────────────────────────────────────────────────────
+
+
+@dataclass
+class _MergeEntry:
+    engines: set
+    best_rank: int
+    url: str
+    result: SearchResult
+    insertion_order: int
+
+
+def _merge_results(
+    results_by_engine: dict[str, list[SearchResult]],
+) -> list[SearchResult]:
+    """Merge results from multiple engines, dedup by normalized URL."""
+    url_map: dict[str, _MergeEntry] = {}
+    insertion_counter = 0
+
+    for engine, results in results_by_engine.items():
+        for rank, r in enumerate(results):
+            norm_key, _ = _normalize_url(r.url)
+
+            if norm_key in url_map:
+                entry = url_map[norm_key]
+                entry.engines.add(engine)
+                entry.best_rank = min(entry.best_rank, rank)
+                # https wins over http
+                if r.url.startswith("https://") and not entry.url.startswith("https://"):
+                    entry.url = r.url
+                    entry.result = r
+            else:
+                url_map[norm_key] = _MergeEntry(
+                    engines={engine},
+                    best_rank=rank,
+                    url=r.url,
+                    result=r,
+                    insertion_order=insertion_counter,
+                )
+                insertion_counter += 1
+
+    sorted_entries = sorted(
+        url_map.values(),
+        key=lambda e: (-len(e.engines), e.best_rank, e.insertion_order),
+    )
+
+    merged = []
+    for entry in sorted_entries:
+        merged.append(SearchResult(
+            title=entry.result.title,
+            url=entry.url,
+            snippet=entry.result.snippet,
+            engines=tuple(sorted(entry.engines)),
+        ))
+
+    multi_hit = sum(1 for e in sorted_entries if len(e.engines) > 1)
+    if len(results_by_engine) > 1:
+        log.info(
+            "search.multi engines=%s unique_urls=%d multi_hit_urls=%d",
+            ",".join(results_by_engine.keys()),
+            len(merged),
+            multi_hit,
+        )
+
+    return merged
+
+
+# ── Public API ───────────────────────────────────────────────────────────────
+
+
+def search(
+    query: str,
+    *,
+    config: SearchConfig,
+    rate_limiter: RateLimiter,
+) -> list[SearchResult]:
+    """Query configured engine(s) and return results.
+
+    Single engine: one Serpex API call.
+    Multi engine: sequential calls, merge+dedupe.
+    brave-direct backend: delegates to brave_search.search().
+    """
+    if config.backend == "brave-direct":
+        from .brave_search import BraveRateLimiter, BraveSearchError, search as brave_search_fn
+        brave_rl = BraveRateLimiter(config.qps)
+        try:
+            brave_results = brave_search_fn(
+                query, api_key=config.api_key, count=config.count,
+                rate_limiter=brave_rl,
+            )
+        except BraveSearchError as exc:
+            raise SearchError(str(exc)) from exc
+        return [
+            SearchResult(
+                title=r.title, url=r.url, snippet=r.snippet,
+                engines=("brave",),
+            )
+            for r in brave_results
+        ]
+
+    engines = config.engines
+    if len(engines) == 1:
+        results = _serpex_search(
+            query, engines[0],
+            api_key=config.api_key, count=config.count,
+            rate_limiter=rate_limiter,
+        )
+        _search_stats.record_success(engines[0])
+        _search_stats.record_query_outcome(total_engines=1, failed_engines=0)
+        return results
+
+    # Multi-engine
+    results_by_engine: dict[str, list[SearchResult]] = {}
+    failed_engines = 0
+    for engine in engines:
+        try:
+            results_by_engine[engine] = _serpex_search(
+                query, engine,
+                api_key=config.api_key, count=config.count,
+                rate_limiter=rate_limiter,
+            )
+            _search_stats.record_success(engine)
+        except SearchError as exc:
+            failed_engines += 1
+            _search_stats.record_failure(engine)
+            log.warning(
+                "search.engine_failed engine=%s error=%s remaining_engines=%s",
+                engine, exc, [e for e in engines if e != engine and e not in results_by_engine],
+            )
+
+    _search_stats.record_query_outcome(
+        total_engines=len(engines), failed_engines=failed_engines,
+    )
+
+    if not results_by_engine:
+        raise SearchError(
+            f"All engines failed for query: {query[:50]}"
+        )
+
+    return _merge_results(results_by_engine)
+
+
+# ── search_and_filter ────────────────────────────────────────────────────────
+
+
+class SearchFilterResult(NamedTuple):
+    results: list[SearchResult]
+    had_raw_results: bool
+
+
+def search_and_filter(
+    org_name: str,
+    city: str,
+    state: str,
+    *,
+    config: SearchConfig,
+    rate_limiter: RateLimiter,
+    max_results: int = 3,
+) -> SearchFilterResult:
+    """Build query, search (single or multi), filter blocklist, return top N."""
+    sanitized_name = re.sub(r'"', "", org_name or "").strip()
+    query = f'"{sanitized_name}" {city} {state}'
+
+    raw_results = search(query, config=config, rate_limiter=rate_limiter)
+
+    if not raw_results:
+        return SearchFilterResult([], False)
+
+    from .brave_search import is_blocked
+
+    filtered: list[SearchResult] = []
+    for r in raw_results:
+        try:
+            host = urlsplit(r.url).hostname or ""
+        except Exception:
+            continue
+        if is_blocked(host, org_name):
+            continue
+        filtered.append(r)
+        if len(filtered) >= max_results:
+            break
+
+    return SearchFilterResult(filtered, True)
+
+
+__all__ = [
+    "RateLimiter",
+    "SearchConfig",
+    "SearchError",
+    "SearchFilterResult",
+    "SearchResult",
+    "SearchStats",
+    "VALID_ENGINES",
+    "get_search_stats",
+    "reset_search_stats",
+    "search",
+    "search_and_filter",
+    "validate_engines",
+]

--- a/locard/plans/0031-serpex-search-adapter.md
+++ b/locard/plans/0031-serpex-search-adapter.md
@@ -581,3 +581,12 @@ After implementation:
 | Phase 6: Phone enrichment | 2-3 hours |
 | Phase 7: Tests | 2-3 hours |
 | **Total** | **~10 hours** |
+
+## Consultation Log
+
+| Round | Model | Type | Verdict | Key Changes |
+|-------|-------|------|---------|-------------|
+| 1 | Codex | plan-review | REQUEST_CHANGES | Preserved all_blocked vs no_search_results split, fixed SSM path, committed to module-level SearchStats, phone uses existing fetch infra, CLI mutual exclusion, dashboard form value mapping |
+| 2 | Codex | red-team-plan | REQUEST_CHANGES | Unified brave-direct through web_search.py, credit accounting from successful calls only, SearchStats with threading.Lock, SearchFilterResult consistency, phone dashboard trigger fleshed out |
+| — | Gemini | plan-review | SKIPPED | Gemini rate-limited (quota exhausted) |
+| — | Gemini | red-team-plan | SKIPPED | Gemini rate-limited (quota exhausted) |

--- a/locard/plans/0031-serpex-search-adapter.md
+++ b/locard/plans/0031-serpex-search-adapter.md
@@ -1,0 +1,471 @@
+# Plan 0031: Serpex Search Adapter with Multi-Engine & Phone Enrichment
+
+**Spec**: `locard/specs/0031-serpex-search-adapter.md`
+**Status**: Draft
+
+## Overview
+
+7 implementation phases, building bottom-up: core module → pipeline integration → CLI → dashboard → phone enrichment → tests → validation.
+
+## Phase 1: Core Search Module (`web_search.py`)
+
+**New file**: `lavandula/nonprofits/web_search.py`
+
+### Step 1.1: Types and URL normalization
+
+Create `SearchResult`, `SearchConfig`, `SearchError`, `RateLimiter` types.
+
+```python
+@dataclass(frozen=True)
+class SearchResult:
+    title: str
+    url: str
+    snippet: str
+    engines: tuple[str, ...]
+
+@dataclass
+class SearchConfig:
+    backend: str          # "serpex" | "brave-direct"
+    engines: list[str]    # ["brave"] or ["brave", "google"]
+    api_key: str
+    qps: float
+    count: int = 10
+```
+
+`RateLimiter` — copy the token-bucket from `brave_search.py:BraveRateLimiter`, rename. Same logic, thread-safe.
+
+`_normalize_url(url)` — private function implementing the spec's 10-step normalization. Returns `"{host}{path}?{query}"` string.
+
+**ACs**: 1, 7
+
+### Step 1.2: Serpex backend — `_serpex_search()`
+
+Private function that makes a single Serpex API call:
+
+```python
+def _serpex_search(query: str, engine: str, *, api_key: str, count: int, rate_limiter: RateLimiter) -> list[SearchResult]:
+```
+
+- Endpoint: `GET https://api.serpex.dev/api/search`
+- Headers: `X-API-Key: {api_key}`
+- Params: `q`, `engine`, `category=web`
+- Retry logic: same as `brave_search.search()` — retry on 429/5xx with delays [2.0, 4.0, 8.0]
+- 402 → log credit exhaustion, raise `SearchError` immediately (no retry)
+- Parse response: `data["results"]` → `SearchResult(title, url, snippet, engines=(engine,))`
+
+**ACs**: 2, 4, 15, 16, 17
+
+### Step 1.3: Multi-engine merge — `_merge_results()`
+
+Private function:
+
+```python
+def _merge_results(results_by_engine: dict[str, list[SearchResult]]) -> list[SearchResult]:
+```
+
+Implements the spec's merge algorithm:
+1. Build `url_map: dict[str, MergeEntry]` keyed by `_normalize_url()`
+2. `MergeEntry` tracks: `engines: set`, `best_rank: int`, `result: SearchResult`, `insertion_order: int`
+3. When merging, https URL wins over http
+4. Sort by `(-len(engines), best_rank, insertion_order)` — stable sort
+5. Return list of `SearchResult` with merged `engines` tuples
+
+**ACs**: 7, 8, 9
+
+### Step 1.4: Public `search()` function
+
+```python
+def search(query: str, *, config: SearchConfig, rate_limiter: RateLimiter) -> list[SearchResult]:
+```
+
+- If `config.backend == "brave-direct"`: delegate to `brave_search.search()`, wrap results as `SearchResult`
+- If single engine: call `_serpex_search()` directly
+- If multiple engines: loop over `config.engines`, call `_serpex_search()` for each (rate limiter acquired per call), collect results per engine. If one engine fails, log WARNING and continue. If ALL fail, raise `SearchError`. Call `_merge_results()` on collected results.
+- Log each call at DEBUG level with engine, query prefix, result count, latency
+
+**ACs**: 2, 5, 6, 18, 19, 23, 29
+
+### Step 1.5: `search_and_filter()` with blocklist
+
+```python
+def search_and_filter(
+    org_name: str, city: str, state: str,
+    *, config: SearchConfig, rate_limiter: RateLimiter,
+    max_results: int = 3,
+) -> list[SearchResult]:
+```
+
+- Builds query: `f'"{sanitized_name}" {city} {state}'` (same sanitization as `brave_search.search_and_filter`)
+- Calls `search()`
+- Imports `is_blocked` from `brave_search` and filters results
+- Returns up to `max_results` non-blocked results
+- Returns `[]` if all blocked or no results (no error)
+
+**ACs**: 3, 10, 20
+
+### Step 1.6: Engine validation helper
+
+```python
+VALID_ENGINES = frozenset({"brave", "google", "bing", "auto"})
+
+def validate_engines(engines: list[str]) -> list[str]:
+    """Validate and deduplicate engine list. Raises ValueError on invalid input."""
+```
+
+- Reject unknown engines
+- Reject `auto` combined with others
+- Deduplicate
+- Return cleaned list
+
+**ACs**: 11, 12, 13
+
+## Phase 2: Secrets & Configuration
+
+### Step 2.1: Add `get_serpex_api_key()` to `secrets.py`
+
+```python
+def get_serpex_api_key() -> str:
+    return get_secret("serpex-api-key")
+```
+
+SSM path: `/cloud2.lavandulagroup.com/serpex-api-key`
+Env override: `LAVANDULA_SECRET_SERPEX_API_KEY`
+
+Update `__all__` to export it.
+
+**ACs**: 25, 26
+
+## Phase 3: Pipeline Integration
+
+### Step 3.1: Update `pipeline_resolver.py` imports
+
+Replace:
+```python
+from .brave_search import (BraveRateLimiter, BraveSearchError, search, search_and_filter)
+```
+With:
+```python
+from .web_search import (RateLimiter, SearchError, SearchConfig, search_and_filter)
+from .brave_search import is_blocked  # only needed if brave-direct fallback inline filtering
+```
+
+### Step 3.2: Update `producer()` signature
+
+Add `search_config: SearchConfig` parameter. Remove `api_key: str` and `rate_limiter: BraveRateLimiter` — these are now inside `SearchConfig` / `RateLimiter`.
+
+Actually, keep `rate_limiter` as a separate parameter (it's shared across all producer calls and constructed once at startup). The `SearchConfig` holds the static config; the `RateLimiter` is the runtime state.
+
+### Step 3.3: Collapse Stage 1 + Stage 2 in `producer()`
+
+Replace the ~30 lines of Stage 1 (search) + Stage 2 (blocklist filter) with:
+
+```python
+try:
+    results = search_and_filter(
+        name, city, state,
+        config=search_config, rate_limiter=rate_limiter, max_results=3,
+    )
+except SearchError as exc:
+    stats.brave_errors += 1
+    _write_unresolved(engine, ein, f"search_error:{exc}", method=method)
+    continue
+
+if not results:
+    stats.skipped_all_blocked += 1
+    _write_unresolved(engine, ein, "no_results_or_all_blocked", method=method)
+    continue
+```
+
+Note: `stats.brave_errors` field should be renamed to `stats.search_errors` but this is cosmetic — keep it for now to avoid breaking the summary output format.
+
+### Step 3.4: Update Stage 3 to use `SearchResult`
+
+Current code accesses `r.title`, `r.snippet`, `r.url` from `BraveSearchResult`. The new `SearchResult` has the same fields plus `engines`. Stage 3 accesses:
+- `r.url` — unchanged
+- `r.title` — unchanged  
+- `r.snippet` — unchanged
+
+No changes needed in Stage 3. The `engines` field is simply not used downstream.
+
+### Step 3.5: Add search counters to `ProducerStats`
+
+Add `search_full`, `search_partial`, `search_failed` counters to the `ProducerStats` dataclass. These are set by `search()` via callback or by the producer after each `search_and_filter()` call (check result's `engines` tuple lengths).
+
+Actually simpler: let `web_search.search()` return the results, and have `producer()` not track partial failures — that's internal to `web_search.py`. The module-level counters in `web_search.py` track `search_full`/`search_partial`/`search_failed` and expose them via a `get_stats()` function the CLI prints at the end.
+
+**ACs**: 20, 21
+
+## Phase 4: CLI Entry Point
+
+### Step 4.1: Update `pipeline_resolve.py` CLI flags
+
+Add new arguments to `_build_parser()`:
+
+```python
+p.add_argument("--search-backend", choices=["serpex", "brave-direct"], default="serpex")
+p.add_argument("--search-engines", default="brave", help="Comma-separated: brave,google,bing,auto")
+p.add_argument("--serpex-api-key", default=None, help="Serpex API key (literal)")
+p.add_argument("--serpex-ssm-key", default=None, help="SSM path for Serpex API key")
+p.add_argument("--search-qps", type=float, default=None, help="Search queries per second")
+```
+
+Keep existing `--brave-qps` but map it:
+```python
+qps = args.search_qps or args.brave_qps
+```
+
+### Step 4.2: Build `SearchConfig` in `main()`
+
+```python
+from lavandula.nonprofits.web_search import SearchConfig, RateLimiter, validate_engines
+
+engines = validate_engines(args.search_engines.split(","))
+
+if args.search_backend == "serpex":
+    if args.serpex_api_key:
+        search_api_key = args.serpex_api_key
+    elif args.serpex_ssm_key:
+        search_api_key = get_secret(args.serpex_ssm_key)
+    else:
+        search_api_key = get_serpex_api_key()
+else:
+    search_api_key = get_brave_api_key()
+
+search_config = SearchConfig(
+    backend=args.search_backend,
+    engines=engines,
+    api_key=search_api_key,
+    qps=qps,
+)
+rate_limiter = RateLimiter(qps)
+```
+
+### Step 4.3: Update `main()` to pass `search_config`
+
+Replace `api_key=api_key` with `search_config=search_config` in the `producer()` call. Update the summary output to include search stats.
+
+**ACs**: 14, 22, 23, 24
+
+## Phase 5: Dashboard Integration
+
+### Step 5.1: Add engine dropdown to `ResolverForm`
+
+In `forms.py`, add to `ResolverForm`:
+
+```python
+SEARCH_ENGINE_CHOICES = [
+    ("brave", "Brave (default)"),
+    ("google", "Google"),
+    ("brave,google", "Brave + Google"),
+    ("auto", "Auto (Serpex routing)"),
+]
+
+search_engines = forms.ChoiceField(
+    choices=SEARCH_ENGINE_CHOICES,
+    initial="brave",
+    widget=forms.Select(attrs={"class": _SELECT}),
+    label="Search Engine",
+)
+```
+
+### Step 5.2: Update `create_resolve_job()` config passthrough
+
+In `views.py` where `ResolverView` builds the config dict for `create_resolve_job()`, add the `search_engines` value from the form:
+
+```python
+config["search_engines"] = form.cleaned_data.get("search_engines", "brave")
+```
+
+### Step 5.3: Update resolver template
+
+Add the search engine dropdown to `resolver.html` between the LLM preset and brave_qps fields.
+
+### Step 5.4: Rename `brave_qps` field label
+
+Change the label from "Brave QPS" to "Search QPS" in the form. Keep the field name `brave_qps` for backward compat with existing saved configs.
+
+**ACs**: 27, 28
+
+## Phase 6: Phone Number Enrichment
+
+### Step 6.1: Schema migration
+
+New file: `lavandula/migrations/rds/migration_012_phone_enrichment.sql`
+
+```sql
+ALTER TABLE lava_corpus.nonprofits_seed ADD COLUMN IF NOT EXISTS phone TEXT;
+ALTER TABLE lava_corpus.nonprofits_seed ADD COLUMN IF NOT EXISTS phone_source TEXT;
+```
+
+**AC**: 34
+
+### Step 6.2: Phone extraction module
+
+New file: `lavandula/nonprofits/phone_extract.py`
+
+```python
+_US_PHONE_RE = re.compile(
+    r'(?:\+?1[-.\s]?)?'
+    r'\(?(\d{3})\)?[-.\s]'       # area code — MUST have separator after
+    r'(\d{3})[-.\s]'             # exchange — MUST have separator after
+    r'(\d{4})'
+    r'(?!\d)'                    # not followed by another digit
+)
+
+_FAX_CONTEXT_RE = re.compile(r'\bfax\b', re.I)
+_TOLLFREE_PREFIXES = {"800", "888", "877", "866", "855", "844", "833"}
+
+def extract_phone(text: str, *, allow_tollfree: bool = False) -> str | None:
+    """Extract first valid US phone number from text."""
+```
+
+Logic:
+1. Find all `_US_PHONE_RE` matches in text
+2. For each match, check 20-char window before for "fax" → skip
+3. Check area code against toll-free prefixes → skip unless `allow_tollfree`
+4. Return first passing match as normalized `(XXX) XXX-XXXX` string
+5. Return `None` if no valid phone found
+
+**ACs**: 35, 36, 37
+
+### Step 6.3: Phone enrichment pipeline
+
+New file: `lavandula/nonprofits/tools/pipeline_enrich_phone.py`
+
+```python
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--state", help="Filter to orgs in this state")
+    parser.add_argument("--limit", type=int, default=0)
+    parser.add_argument("--search-engines", default="brave")
+    parser.add_argument("--allow-tollfree", action="store_true")
+    parser.add_argument("--serpex-api-key", default=None)
+    parser.add_argument("--search-qps", type=float, default=1.0)
+```
+
+Pipeline:
+1. Query DB: `SELECT ein, name, city, state, website_url FROM nonprofits_seed WHERE resolver_status = 'resolved' AND phone IS NULL` (with optional `--state` filter and `--limit`)
+2. Build `SearchConfig` (same pattern as Phase 4)
+3. For each org:
+   a. Query Serpex: `"{name} {city} {state} phone number"` — note: NO blocklist filtering (Trap #7)
+   b. Scan all result snippets with `extract_phone()`
+   c. If found → write to DB with `phone_source = 'search_snippet'`
+   d. If not found → fetch `{website_url}/contact`, `{website_url}/about`, `{website_url}/about-us` with `requests.get()` (timeout=15, SSRF protections from existing `_fetch_candidate`)
+   e. Scan page text with `extract_phone()`
+   f. If found → write to DB with `phone_source = 'website_extract'`
+   g. If still not found → skip (don't write anything)
+4. Print summary: total processed, found via snippet, found via website, not found
+
+**ACs**: 33, 38, 39
+
+### Step 6.4: Dashboard phone display
+
+Update org detail template (`org_detail.html`) to show `phone` field if present:
+
+```html
+{% if org.phone %}
+<dt>Phone</dt>
+<dd>{{ org.phone }} <span class="text-xs text-gray-400">({{ org.phone_source }})</span></dd>
+{% endif %}
+```
+
+**AC**: 40
+
+### Step 6.5: Dashboard "Enrich Phones" trigger
+
+Add a phone enrichment section to the pipeline controls. Minimal: a button + state dropdown that triggers `pipeline_enrich_phone.py` as a background job. Follows the same `create_*_job()` pattern as resolver/crawler/classifier.
+
+**AC**: 41
+
+## Phase 7: Tests
+
+### Step 7.1: Unit tests for `web_search.py`
+
+File: `tests/test_web_search.py`
+
+Tests (mock HTTP via `responses` or `unittest.mock.patch`):
+
+1. **Serpex API call construction** — verify URL, headers, params for single engine call (AC 42)
+2. **Response parsing** — title, url, snippet extracted correctly (AC 4)
+3. **Multi-engine merge**:
+   - Two engines return same URL → merged with both engines, sorted first (AC 43)
+   - Tie-breaker: equal engine count + equal rank → insertion order (AC 43)
+   - https wins over http in merge (AC 43)
+4. **URL normalization**:
+   - www stripping, trailing slash, fragments, scheme (AC 44)
+   - Query string preserved, path case preserved (AC 44)
+5. **Error handling**:
+   - 402 → SearchError, no retry (AC 45)
+   - 429 → retry with backoff (AC 45)
+   - 5xx → retry with backoff (AC 45)
+   - Network timeout → retry (AC 45)
+   - Multi-engine partial failure: one fails, other succeeds → results from survivor returned (AC 45)
+   - Multi-engine all fail → SearchError (AC 45)
+6. **Engine validation**:
+   - `auto` + `brave` → ValueError (AC 46)
+   - Duplicates deduped (AC 46)
+   - Unknown engine → ValueError (AC 46)
+7. **search_and_filter integration** — mocked Serpex returns 5 results, 2 blocked by `is_blocked()` → 3 returned (AC 47)
+8. **Brave-direct fallback** — `backend="brave-direct"` delegates to `brave_search.search()` (AC 48)
+
+### Step 7.2: Unit tests for `phone_extract.py`
+
+File: `tests/test_phone_extract.py`
+
+Tests (AC 49):
+1. Valid formats: `(555) 123-4567`, `555-123-4567`, `555.123.4567`, `+1 555 123 4567`, `1-555-123-4567`
+2. Fax rejection: `Fax: (555) 123-4567` → None
+3. Toll-free rejection: `(800) 555-1234` → None (default), `(800) 555-1234` with `allow_tollfree=True` → returns it
+4. EIN not matched: `123456789` (9 digits, no separators) → None
+5. Zip code not matched: `12345-6789` → None
+6. Multiple phones: first valid one returned
+7. No phone in text → None
+
+### Step 7.3: Integration test for phone pipeline
+
+File: `tests/test_pipeline_enrich_phone.py` (AC 50)
+
+Mock Serpex to return a snippet containing `"Call us at (555) 123-4567"`. Verify:
+- Phone extracted correctly
+- Written to DB with `phone_source = 'search_snippet'`
+- Fallback to website fetch when snippet has no phone
+
+## Validation
+
+After implementation:
+
+1. **Smoke test**: Run `pipeline_resolve.py --search-backend serpex --search-engines brave --state TX --limit 10` and compare resolver outcomes to a `--search-backend brave-direct` run on the same 10 orgs.
+2. **Multi-engine test**: Run `--search-engines brave,google --limit 50` and verify merge/dedupe logs appear.
+3. **Phone enrichment test**: Run `pipeline_enrich_phone.py --state TX --limit 20` and manually verify 5 phone numbers.
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `lavandula/nonprofits/web_search.py` | **NEW** — core search module |
+| `lavandula/nonprofits/phone_extract.py` | **NEW** — phone regex extraction |
+| `lavandula/nonprofits/tools/pipeline_enrich_phone.py` | **NEW** — phone enrichment CLI |
+| `lavandula/nonprofits/pipeline_resolver.py` | Modify — swap imports, collapse Stage 1+2 |
+| `lavandula/nonprofits/tools/pipeline_resolve.py` | Modify — new CLI flags, build SearchConfig |
+| `lavandula/common/secrets.py` | Modify — add `get_serpex_api_key()` |
+| `lavandula/dashboard/pipeline/forms.py` | Modify — add engine dropdown to ResolverForm |
+| `lavandula/dashboard/pipeline/views.py` | Modify — pass search_engines to job config |
+| `lavandula/dashboard/pipeline/templates/pipeline/resolver.html` | Modify — add engine dropdown |
+| `lavandula/dashboard/pipeline/templates/pipeline/org_detail.html` | Modify — show phone field |
+| `lavandula/migrations/rds/migration_012_phone_enrichment.sql` | **NEW** — phone + phone_source columns |
+| `tests/test_web_search.py` | **NEW** — ~25 unit tests |
+| `tests/test_phone_extract.py` | **NEW** — ~10 unit tests |
+| `tests/test_pipeline_enrich_phone.py` | **NEW** — integration test |
+
+## Estimated Effort
+
+| Phase | Est. |
+|-------|------|
+| Phase 1: Core module | 2-3 hours |
+| Phase 2: Secrets | 15 min |
+| Phase 3: Pipeline integration | 1 hour |
+| Phase 4: CLI | 30 min |
+| Phase 5: Dashboard | 1 hour |
+| Phase 6: Phone enrichment | 2-3 hours |
+| Phase 7: Tests | 2-3 hours |
+| **Total** | **~10 hours** |

--- a/locard/plans/0031-serpex-search-adapter.md
+++ b/locard/plans/0031-serpex-search-adapter.md
@@ -128,10 +128,13 @@ def get_serpex_api_key() -> str:
     return get_secret("serpex-api-key")
 ```
 
-SSM path: `/cloud2.lavandulagroup.com/serpex-api-key`
-Env override: `LAVANDULA_SECRET_SERPEX_API_KEY`
+This uses the existing `get_secret()` which prefixes with `/cloud2.lavandulagroup.com/`, giving SSM path: `/cloud2.lavandulagroup.com/serpex-api-key`
+
+Env override (auto-derived by `_env_var_name`): `LAVANDULA_SECRET_SERPEX_API_KEY`
 
 Update `__all__` to export it.
+
+**Note**: The spec says SSM path `lavandula/serpex/api_key` — this is the short_name convention used in the spec. The actual SSM path is determined by `secrets.py`'s prefix convention: `{_PARAM_PREFIX}{short_name}`. The short_name we use is `serpex-api-key` (following `brave-api-key` convention).
 
 **ACs**: 25, 26
 
@@ -166,17 +169,36 @@ try:
         config=search_config, rate_limiter=rate_limiter, max_results=3,
     )
 except SearchError as exc:
-    stats.brave_errors += 1
-    _write_unresolved(engine, ein, f"search_error:{exc}", method=method)
+    stats.search_errors += 1
+    reason_match = re.search(r"(\d{3})", str(exc))
+    status_code = reason_match.group(1) if reason_match else "unknown"
+    _write_unresolved(engine, ein, f"search_error:{status_code}", method=method)
     continue
 
 if not results:
-    stats.skipped_all_blocked += 1
-    _write_unresolved(engine, ein, "no_results_or_all_blocked", method=method)
+    # Preserve split between "no results at all" vs "had results but all blocked"
+    # search_and_filter returns ([], True) when results existed but were all blocked
+    # vs ([], False) when no results came back from search
+    if search_had_results:
+        stats.skipped_all_blocked += 1
+        _write_unresolved(engine, ein, "all_blocked", method=method)
+    else:
+        stats.skipped_no_results += 1
+        _write_unresolved(engine, ein, "no_search_results", method=method)
     continue
 ```
 
-Note: `stats.brave_errors` field should be renamed to `stats.search_errors` but this is cosmetic — keep it for now to avoid breaking the summary output format.
+To preserve the `all_blocked` vs `no_search_results` distinction, `search_and_filter()` returns a `SearchFilterResult` namedtuple:
+
+```python
+class SearchFilterResult(NamedTuple):
+    results: list[SearchResult]
+    had_raw_results: bool  # True if search returned results (even if all blocked)
+```
+
+This lets the caller distinguish "search found nothing" from "search found things but blocklist rejected all of them" without breaking the existing DB reason strings.
+
+Rename `stats.brave_errors` → `stats.search_errors` in `ProducerStats`.
 
 ### Step 3.4: Update Stage 3 to use `SearchResult`
 
@@ -187,13 +209,37 @@ Current code accesses `r.title`, `r.snippet`, `r.url` from `BraveSearchResult`. 
 
 No changes needed in Stage 3. The `engines` field is simply not used downstream.
 
-### Step 3.5: Add search counters to `ProducerStats`
+### Step 3.5: Search stats tracking
 
-Add `search_full`, `search_partial`, `search_failed` counters to the `ProducerStats` dataclass. These are set by `search()` via callback or by the producer after each `search_and_filter()` call (check result's `engines` tuple lengths).
+`web_search.py` maintains a module-level `SearchStats` dataclass (thread-safe via atomic increments):
 
-Actually simpler: let `web_search.search()` return the results, and have `producer()` not track partial failures — that's internal to `web_search.py`. The module-level counters in `web_search.py` track `search_full`/`search_partial`/`search_failed` and expose them via a `get_stats()` function the CLI prints at the end.
+```python
+@dataclass
+class SearchStats:
+    queries_by_engine: dict[str, int]    # {"brave": 150, "google": 148}
+    failures_by_engine: dict[str, int]   # {"google": 2}
+    search_full: int = 0                 # all engines succeeded
+    search_partial: int = 0              # some engines failed
+    search_failed: int = 0              # all engines failed
+    
+    @property
+    def estimated_credits(self) -> int:
+        return sum(self.queries_by_engine.values())
+```
 
-**ACs**: 20, 21
+`search()` increments these after each call. The module exposes `get_search_stats() → SearchStats` and `reset_search_stats()`.
+
+The CLI (`pipeline_resolve.py`) calls `get_search_stats()` at end-of-run and prints alongside the existing pipeline summary:
+
+```
+--- Search Summary ---
+Engine queries: brave=150, google=148
+Engine failures: google=2
+Search: 148 full, 2 partial, 0 failed
+Estimated credits: 298
+```
+
+**ACs**: 29, 30, 31, 32
 
 ## Phase 4: CLI Entry Point
 
@@ -204,15 +250,29 @@ Add new arguments to `_build_parser()`:
 ```python
 p.add_argument("--search-backend", choices=["serpex", "brave-direct"], default="serpex")
 p.add_argument("--search-engines", default="brave", help="Comma-separated: brave,google,bing,auto")
-p.add_argument("--serpex-api-key", default=None, help="Serpex API key (literal)")
-p.add_argument("--serpex-ssm-key", default=None, help="SSM path for Serpex API key")
 p.add_argument("--search-qps", type=float, default=None, help="Search queries per second")
+
+serpex_key_group = p.add_mutually_exclusive_group()
+serpex_key_group.add_argument("--serpex-api-key", default=None, help="Serpex API key (literal)")
+serpex_key_group.add_argument("--serpex-ssm-key", default=None, help="SSM path for Serpex API key")
 ```
 
 Keep existing `--brave-qps` but map it:
 ```python
 qps = args.search_qps or args.brave_qps
 ```
+
+**Post-parse validation** (in `main()`, before any work):
+```python
+if args.search_backend == "brave-direct":
+    engines = ["brave"]  # ignored per spec AC14
+else:
+    engines = validate_engines(args.search_engines.split(","))
+    # validate_engines raises ValueError for unknown engines, auto+other, etc.
+    # Catch and call parser.error() for clean CLI output
+```
+
+This ensures `--search-backend brave-direct --search-engines google` is silently accepted (engines ignored), while `--search-engines potato` fails immediately.
 
 ### Step 4.2: Build `SearchConfig` in `main()`
 
@@ -256,7 +316,7 @@ In `forms.py`, add to `ResolverForm`:
 SEARCH_ENGINE_CHOICES = [
     ("brave", "Brave (default)"),
     ("google", "Google"),
-    ("brave,google", "Brave + Google"),
+    ("brave_google", "Brave + Google"),
     ("auto", "Auto (Serpex routing)"),
 ]
 
@@ -273,7 +333,8 @@ search_engines = forms.ChoiceField(
 In `views.py` where `ResolverView` builds the config dict for `create_resolve_job()`, add the `search_engines` value from the form:
 
 ```python
-config["search_engines"] = form.cleaned_data.get("search_engines", "brave")
+raw = form.cleaned_data.get("search_engines", "brave")
+config["search_engines"] = raw.replace("_", ",")  # "brave_google" → "brave,google"
 ```
 
 ### Step 5.3: Update resolver template
@@ -315,16 +376,18 @@ _US_PHONE_RE = re.compile(
 _FAX_CONTEXT_RE = re.compile(r'\bfax\b', re.I)
 _TOLLFREE_PREFIXES = {"800", "888", "877", "866", "855", "844", "833"}
 
-def extract_phone(text: str, *, allow_tollfree: bool = False) -> str | None:
-    """Extract first valid US phone number from text."""
+def extract_phone(text: str, *, allow_tollfree: bool = False, org_name: str = "") -> str | None:
+    """Extract best valid US phone number from text."""
 ```
 
 Logic:
-1. Find all `_US_PHONE_RE` matches in text
+1. Find all `_US_PHONE_RE` matches in text with their positions
 2. For each match, check 20-char window before for "fax" → skip
 3. Check area code against toll-free prefixes → skip unless `allow_tollfree`
-4. Return first passing match as normalized `(XXX) XXX-XXXX` string
-5. Return `None` if no valid phone found
+4. Collect all valid candidates with their text positions
+5. If `org_name` provided and multiple candidates: prefer the phone closest to any occurrence of the org name in the text (character distance from match position to nearest org_name occurrence)
+6. If no org_name or only one candidate: return the first valid match
+7. Return as normalized `(XXX) XXX-XXXX` string, or `None` if no valid phone found
 
 **ACs**: 35, 36, 37
 
@@ -350,7 +413,7 @@ Pipeline:
    a. Query Serpex: `"{name} {city} {state} phone number"` — note: NO blocklist filtering (Trap #7)
    b. Scan all result snippets with `extract_phone()`
    c. If found → write to DB with `phone_source = 'search_snippet'`
-   d. If not found → fetch `{website_url}/contact`, `{website_url}/about`, `{website_url}/about-us` with `requests.get()` (timeout=15, SSRF protections from existing `_fetch_candidate`)
+   d. If not found → fetch `{website_url}/contact`, `{website_url}/about`, `{website_url}/about-us` using the existing `_fetch_candidate()` from `pipeline_resolver.py` (which already has SSRF protections: private IP blocking, timeout, size limits)
    e. Scan page text with `extract_phone()`
    f. If found → write to DB with `phone_source = 'website_extract'`
    g. If still not found → skip (don't write anything)

--- a/locard/plans/0031-serpex-search-adapter.md
+++ b/locard/plans/0031-serpex-search-adapter.md
@@ -88,20 +88,26 @@ def search(query: str, *, config: SearchConfig, rate_limiter: RateLimiter) -> li
 ### Step 1.5: `search_and_filter()` with blocklist
 
 ```python
+class SearchFilterResult(NamedTuple):
+    results: list[SearchResult]
+    had_raw_results: bool  # True if search returned results (even if all blocked)
+
 def search_and_filter(
     org_name: str, city: str, state: str,
     *, config: SearchConfig, rate_limiter: RateLimiter,
     max_results: int = 3,
-) -> list[SearchResult]:
+) -> SearchFilterResult:
 ```
 
 - Builds query: `f'"{sanitized_name}" {city} {state}'` (same sanitization as `brave_search.search_and_filter`)
-- Calls `search()`
+- Calls `search()` — if returns empty list, returns `SearchFilterResult([], False)`
 - Imports `is_blocked` from `brave_search` and filters results
-- Returns up to `max_results` non-blocked results
-- Returns `[]` if all blocked or no results (no error)
+- Returns `SearchFilterResult(filtered[:max_results], True)` — `had_raw_results=True` even if all got blocked
+- This lets the caller distinguish "no search results" from "all blocked"
 
-**ACs**: 3, 10, 20
+For `brave-direct` backend: `search()` delegates to `brave_search.search()` internally, so the full execution path goes through `web_search.py` even for brave-direct. This means `pipeline_resolver.py` always calls `web_search.search_and_filter()` regardless of backend — the backend choice is encapsulated inside `web_search.py`. This satisfies AC23 (brave-direct backward compatibility) while centralizing the interface.
+
+**ACs**: 3, 10, 20, 23
 
 ### Step 1.6: Engine validation helper
 
@@ -216,18 +222,28 @@ No changes needed in Stage 3. The `engines` field is simply not used downstream.
 ```python
 @dataclass
 class SearchStats:
-    queries_by_engine: dict[str, int]    # {"brave": 150, "google": 148}
-    failures_by_engine: dict[str, int]   # {"google": 2}
-    search_full: int = 0                 # all engines succeeded
-    search_partial: int = 0              # some engines failed
-    search_failed: int = 0              # all engines failed
+    successful_by_engine: dict[str, int]  # {"brave": 150, "google": 148}
+    failed_by_engine: dict[str, int]      # {"google": 2}
+    search_full: int = 0                  # all engines succeeded
+    search_partial: int = 0               # some engines failed
+    search_failed: int = 0               # all engines failed
+    _lock: threading.Lock = field(default_factory=threading.Lock)
     
     @property
     def estimated_credits(self) -> int:
-        return sum(self.queries_by_engine.values())
+        """Only successful calls count toward credit estimate."""
+        return sum(self.successful_by_engine.values())
+    
+    def record_success(self, engine: str) -> None:
+        with self._lock:
+            self.successful_by_engine[engine] = self.successful_by_engine.get(engine, 0) + 1
+
+    def record_failure(self, engine: str) -> None:
+        with self._lock:
+            self.failed_by_engine[engine] = self.failed_by_engine.get(engine, 0) + 1
 ```
 
-`search()` increments these after each call. The module exposes `get_search_stats() → SearchStats` and `reset_search_stats()`.
+Thread-safe via explicit `threading.Lock` (the producer may run in a separate thread from main). Module exposes `get_search_stats() → SearchStats` and `reset_search_stats()`.
 
 The CLI (`pipeline_resolve.py`) calls `get_search_stats()` at end-of-run and prints alongside the existing pipeline summary:
 
@@ -413,7 +429,7 @@ Pipeline:
    a. Query Serpex: `"{name} {city} {state} phone number"` — note: NO blocklist filtering (Trap #7)
    b. Scan all result snippets with `extract_phone()`
    c. If found → write to DB with `phone_source = 'search_snippet'`
-   d. If not found → fetch `{website_url}/contact`, `{website_url}/about`, `{website_url}/about-us` using the existing `_fetch_candidate()` from `pipeline_resolver.py` (which already has SSRF protections: private IP blocking, timeout, size limits)
+   d. If not found → fetch `{website_url}/contact`, `{website_url}/about`, `{website_url}/about-us` using `fetch_page()` from `lavandula/nonprofits/http_fetch.py` (see Step 6.2b below)
    e. Scan page text with `extract_phone()`
    f. If found → write to DB with `phone_source = 'website_extract'`
    g. If still not found → skip (don't write anything)
@@ -434,9 +450,42 @@ Update org detail template (`org_detail.html`) to show `phone` field if present:
 
 **AC**: 40
 
+### Step 6.2b: Extract shared fetch module
+
+Extract `_fetch_candidate()` from `pipeline_resolver.py` into `lavandula/nonprofits/http_fetch.py` as a public `fetch_page(url, *, timeout=15) → dict` function. This preserves the existing SSRF protections (private IP blocking via `_is_private_ip()`, response size limits, timeout) in a shared location. Both `pipeline_resolver.py` and `pipeline_enrich_phone.py` import from this module.
+
+Alternatively, if extracting is too invasive for this spec, the phone pipeline can use a simpler `requests.get()` with explicit timeout and size limit — the phone fetcher only hits known `website_url` values (already validated by the resolver), not arbitrary URLs from search results. Document this decision.
+
 ### Step 6.5: Dashboard "Enrich Phones" trigger
 
-Add a phone enrichment section to the pipeline controls. Minimal: a button + state dropdown that triggers `pipeline_enrich_phone.py` as a background job. Follows the same `create_*_job()` pattern as resolver/crawler/classifier.
+**Files changed**: `forms.py`, `views.py`, `orchestrator.py`, `pipeline/templates/pipeline/enrichment.html` (new template, or add to existing pipeline controls page)
+
+**Form** in `forms.py`:
+```python
+class PhoneEnrichForm(forms.Form):
+    state = forms.ChoiceField(
+        choices=[("", "All resolved")] + STATE_CHOICES,
+        required=False,
+        widget=forms.Select(attrs={"class": _SELECT}),
+    )
+    limit = forms.IntegerField(required=False, min_value=0, max_value=999999,
+        widget=forms.NumberInput(attrs={"class": _SELECT}))
+    search_engines = forms.ChoiceField(
+        choices=SEARCH_ENGINE_CHOICES, initial="brave",
+        widget=forms.Select(attrs={"class": _SELECT}))
+```
+
+**Job creation** in `orchestrator.py`:
+```python
+def create_phone_enrich_job(config_overrides: dict, host: str) -> Job:
+    # Same pattern as create_resolve_job: dedup check, create Job with phase="enrich_phone"
+```
+
+**Subprocess invocation** (in the job runner): 
+```
+python -m lavandula.nonprofits.tools.pipeline_enrich_phone
+  --state {state} --limit {limit} --search-engines {engines}
+```
 
 **AC**: 41
 

--- a/locard/projectlist.md
+++ b/locard/projectlist.md
@@ -501,8 +501,8 @@ projects:
     notes: "Spec approved 2026-05-01 after 4 review rounds (Codex spec + red-team, Claude spec + red-team). Plan approved 2026-05-01 after 4 review rounds (Codex plan + red-team, Claude plan + red-team). 32 ACs, 8 phases. S3 bucket: lavandula-990-corpus. Unified codebase — manual controls reuse new infrastructure. Builder spawned 2026-05-01."
 
   - id: "0031"
-    title: "Serpex Search Adapter with Multi-Engine Support"
-    summary: "Replace direct Brave Search API calls with Serpex proxy, adding a search adapter abstraction that supports configurable engine selection (brave, google, bing) and a multi-engine mode that queries multiple engines per org and merges/dedupes candidates for higher recall on hard cases. 6-17x cost reduction vs Brave direct."
+    title: "Serpex Search Adapter with Multi-Engine & Phone Enrichment"
+    summary: "Replace direct Brave Search API calls with Serpex proxy, adding a search adapter with configurable engine selection (brave, google, bing) and multi-engine mode that merges/dedupes candidates for higher recall. Includes phone number enrichment pass that extracts org phone numbers from search snippets and website contact pages. 6-17x cost reduction vs Brave direct."
     status: conceived
     priority: high
     files:

--- a/locard/projectlist.md
+++ b/locard/projectlist.md
@@ -503,11 +503,11 @@ projects:
   - id: "0031"
     title: "Serpex Search Adapter with Multi-Engine & Phone Enrichment"
     summary: "Replace direct Brave Search API calls with Serpex proxy, adding a search adapter with configurable engine selection (brave, google, bing) and multi-engine mode that merges/dedupes candidates for higher recall. Includes phone number enrichment pass that extracts org phone numbers from search snippets and website contact pages. 6-17x cost reduction vs Brave direct."
-    status: specified
+    status: planned
     priority: high
     files:
       spec: locard/specs/0031-serpex-search-adapter.md
-      plan: null
+      plan: locard/plans/0031-serpex-search-adapter.md
       review: null
     dependencies: ["0018"]
     tags: [resolver, search, cost-optimization, serpex, multi-engine]

--- a/locard/projectlist.md
+++ b/locard/projectlist.md
@@ -503,7 +503,7 @@ projects:
   - id: "0031"
     title: "Serpex Search Adapter with Multi-Engine & Phone Enrichment"
     summary: "Replace direct Brave Search API calls with Serpex proxy, adding a search adapter with configurable engine selection (brave, google, bing) and multi-engine mode that merges/dedupes candidates for higher recall. Includes phone number enrichment pass that extracts org phone numbers from search snippets and website contact pages. 6-17x cost reduction vs Brave direct."
-    status: conceived
+    status: specified
     priority: high
     files:
       spec: locard/specs/0031-serpex-search-adapter.md

--- a/locard/projectlist.md
+++ b/locard/projectlist.md
@@ -500,9 +500,22 @@ projects:
     tags: [990, infrastructure, s3, automation, pipeline]
     notes: "Spec approved 2026-05-01 after 4 review rounds (Codex spec + red-team, Claude spec + red-team). Plan approved 2026-05-01 after 4 review rounds (Codex plan + red-team, Claude plan + red-team). 32 ACs, 8 phases. S3 bucket: lavandula-990-corpus. Unified codebase — manual controls reuse new infrastructure. Builder spawned 2026-05-01."
 
+  - id: "0031"
+    title: "Serpex Search Adapter with Multi-Engine Support"
+    summary: "Replace direct Brave Search API calls with Serpex proxy, adding a search adapter abstraction that supports configurable engine selection (brave, google, bing) and a multi-engine mode that queries multiple engines per org and merges/dedupes candidates for higher recall on hard cases. 6-17x cost reduction vs Brave direct."
+    status: conceived
+    priority: high
+    files:
+      spec: locard/specs/0031-serpex-search-adapter.md
+      plan: null
+      review: null
+    dependencies: ["0018"]
+    tags: [resolver, search, cost-optimization, serpex, multi-engine]
+    notes: "Motivated by experiment 0001: Serpex matched Brave on easy cases (90% overlap), slightly outperformed on hard cases (5 wins vs 2 losses in manual review of 15 zero-overlap samples). Multi-engine mode addresses the 47% zero-overlap on hard cases — different engines surface different candidates."
+
 ## Next Available Number
 
-**0031** - Reserve this number for your next project
+**0032** - Reserve this number for your next project
 
 ---
 

--- a/locard/specs/0031-serpex-search-adapter.md
+++ b/locard/specs/0031-serpex-search-adapter.md
@@ -84,16 +84,20 @@ class SearchResult:
     title: str
     url: str
     snippet: str
-    engine: str  # which engine returned this result
+    engines: tuple[str, ...]  # engines that returned this URL (e.g. ("brave",) or ("brave", "google"))
 
 @dataclass
 class SearchConfig:
     backend: str          # "serpex" | "brave-direct"
     engines: list[str]    # ["brave"] or ["brave", "google"] etc.
-    api_key: str          # Serpex API key (or Brave key for direct)
+    api_key: str          # Serpex API key when backend="serpex"; Brave API key when backend="brave-direct"
     qps: float            # rate limit (queries per second)
     count: int            # results per engine query (default 10)
 ```
+
+For `brave-direct` backend, `SearchConfig.api_key` is populated from the existing `get_brave_api_key()` in `secrets.py`. The CLI determines which secret-loading function to call based on `--search-backend`:
+- `serpex` → `get_serpex_api_key()` (new)
+- `brave-direct` → `get_brave_api_key()` (existing, unchanged)
 
 #### Public API: `search()`
 
@@ -178,14 +182,14 @@ Env override: `LAVANDULA_SECRET_SERPEX_API_KEY`
 
 The resolver form gains a **search engine preset dropdown**:
 
-| Value | Label | Engines passed to CLI |
-|-------|-------|-----------------------|
+| Form Value | Label | CLI flag |
+|------------|-------|----------|
 | `brave` | Brave (default) | `--search-engines brave` |
 | `google` | Google | `--search-engines google` |
-| `brave_google` | Brave + Google | `--search-engines brave,google` |
+| `brave,google` | Brave + Google | `--search-engines brave,google` |
 | `auto` | Auto (Serpex routing) | `--search-engines auto` |
 
-Default selection: `brave`. The dropdown replaces no existing field — it's a new addition to the resolver controls form alongside the existing LLM model selector. The view passes the selected value as the `--search-engines` flag when spawning the pipeline subprocess.
+Default selection: `brave`. `bing` is not in the dashboard dropdown (CLI-only). The dropdown is a new addition alongside the existing LLM model selector. The view passes the form value directly as the `--search-engines` flag when spawning the pipeline subprocess.
 
 ### Serpex API Integration
 
@@ -227,21 +231,46 @@ normalize(url):
   6. Strip fragment (#...) entirely
   7. Preserve query string as-is (different query params = different pages)
   8. Preserve path as-is (case-sensitive — /About != /about on many servers)
-  9. Normalize scheme to https (http://example.com == https://example.com for dedup)
+  9. Drop scheme entirely from the normalized key (http://example.com == https://example.com for dedup)
   10. Return: "{hostname}{path}?{query}" (no scheme, no fragment)
+
+  When duplicates merge across schemes, the https URL wins (preferred for fetch).
+  If both are https, the first-seen URL is kept.
 ```
 
-This is intentionally conservative: it merges obvious duplicates (www vs non-www, http vs https, trailing slash) without collapsing pages that are genuinely different.
+**Why collapse schemes**: In practice, nonprofit websites universally redirect http→https. Search engines inconsistently return one or the other for the same page. Keeping them separate would create false "multi-engine agreement" signals when both engines found the same page but one returned http and the other https. This is a dedup optimization, not a security decision — Stage 3 fetches the actual URL and follows redirects regardless.
+
+This is intentionally conservative overall: it merges obvious duplicates (www vs non-www, http vs https, trailing slash) without collapsing pages that are genuinely different.
 
 ### Engine Validation Rules
 
 **Valid engines**: `brave`, `google`, `bing`, `auto`
 
-- `auto` **cannot** be combined with other engines (it is Serpex's own routing — combining defeats the purpose)
+- `auto` **cannot** be combined with other engines (it is Serpex's own routing — combining defeats the purpose). CLI error if attempted.
 - Duplicate engine names are silently deduplicated: `--search-engines brave,brave` → `["brave"]`
 - Unknown engine names fail at CLI parse time with a clear error listing valid values
 - `--search-backend brave-direct` ignores `--search-engines` entirely (Brave direct has no engine concept)
-- Dashboard UI: dropdown with values `brave`, `google`, `bing`, `brave+google` (presets, not free-form). Default: `brave`.
+- `bing` is supported in CLI but not exposed in dashboard UI (untested engine, CLI-only for experimentation)
+
+### Partial Failure & Degraded Search
+
+When multi-engine mode is active and one engine fails while others succeed:
+
+1. The query proceeds with results from surviving engines (AC18)
+2. A WARNING log is emitted with the failed engine and error
+3. The run tracks three counters: `search_full` (all engines succeeded), `search_partial` (some engines failed), `search_failed` (all engines failed)
+4. End-of-run summary reports all three counters
+5. Downstream stages (fetch, LLM, DB write) are **not** told about degraded coverage — the LLM disambiguator works with whatever candidates it receives. This is acceptable because:
+   - Single-engine mode is the baseline — partial multi-engine is strictly better than single
+   - The resolver already handles sparse candidates (sometimes only 1 result passes blocklist)
+   - Adding a degraded marker to DB would require schema changes for marginal value
+
+### Empty Results After Filtering
+
+When `search_and_filter()` returns `[]` (all results blocked or no results at all):
+- Returns empty list (no error raised)
+- Caller (`pipeline_resolver.py`) handles this the same as today: writes `all_blocked` or `no_search_results` to DB
+- Metrics: existing `skipped_all_blocked` and `skipped_no_results` counters apply unchanged
 
 ### Multi-Engine Merge Algorithm
 
@@ -287,7 +316,8 @@ End-of-run summary includes:
 - Total unique results
 - Multi-engine overlap rate (for multi-engine runs)
 - Per-engine failure count
-- **Estimated credit usage**: `total_queries × engines_per_query × 1 credit` (Serpex charges 1 credit per search call regardless of engine). This is an estimate — actual billing comes from the Serpex dashboard.
+- `search_full` / `search_partial` / `search_failed` counters
+- **Estimated credit usage**: `successful_calls × 1 credit` (counts only successful API calls, not retries or failures). Labeled explicitly as "estimated" — actual billing comes from the Serpex dashboard. Retries that succeed count as 1 call. `auto` engine counts as 1 call per query.
 
 ### Migration Path
 
@@ -302,7 +332,7 @@ End-of-run summary includes:
 2. `search()` is the single public search function — handles both single and multi-engine modes
 3. `search_and_filter()` owns query construction + search + blocklist filtering (imports `is_blocked()` from `brave_search.py`)
 4. Response parsing extracts title, url, snippet from Serpex JSON response
-5. `engine` field on `SearchResult` records which engine produced the result
+5. `engines` field on `SearchResult` is a `tuple[str, ...]` recording all engines that returned this URL (single-engine: `("brave",)`, multi-engine merged: `("brave", "google")`)
 
 ### Multi-Engine Mode
 6. `search()` with multiple engines queries each sequentially, respecting rate limiter
@@ -343,7 +373,7 @@ End-of-run summary includes:
 29. Each search call logs engine, query prefix, result count, and latency (DEBUG level)
 30. Multi-engine queries log unique URLs and multi-hit count (INFO level)
 31. Partial engine failures logged at WARNING with engine name and error message
-32. End-of-run summary includes per-engine query counts, per-engine failure counts, and estimated credit usage (queries × engines)
+32. End-of-run summary includes per-engine query counts, per-engine failure counts, search_full/partial/failed counters, and estimated credit usage (successful calls × 1)
 
 ### Testing
 33. Unit tests for Serpex API call construction (mock HTTP)

--- a/locard/specs/0031-serpex-search-adapter.md
+++ b/locard/specs/0031-serpex-search-adapter.md
@@ -1,0 +1,326 @@
+# Spec 0031: Serpex Search Adapter with Multi-Engine Support
+
+**Status**: Draft
+**Author**: Architect
+**Dependencies**: Spec 0018 (Gemma Pipeline Resolver)
+**Priority**: High
+
+## Problem
+
+The resolver pipeline (Spec 0018) calls the Brave Search API directly at $5/1K queries. We've resolved ~35K orgs so far (~20-25% of the total), with 100K+ remaining. At current rates, completing URL resolution alone will cost $500+, and future search needs (contractor enrichment, address verification) will add more.
+
+Experiment 0001 validated that Serpex (serpex.dev) returns equivalent or better results at $0.30-$0.80/1K queries — a 6-17x cost reduction. On 200 easy-case queries, Serpex matched Brave at 90% top-3 overlap. On 250 hard cases (ambiguous/unresolved/low-confidence), Serpex diverged significantly (30% overlap) but manual review showed it edged ahead: 5 clear wins vs 2 losses in 15 sampled zero-overlap cases, with Serpex finding more specific/local results.
+
+Additionally, the current pipeline is locked to a single search engine. Different engines have different strengths — Google finds .org sites better, Brave finds local businesses better. A multi-engine mode that queries 2+ engines and merges candidates would improve recall on hard cases while still costing less than single-engine Brave direct.
+
+## Goals
+
+1. **Drop-in Serpex replacement** — Swap Brave direct API calls for Serpex with zero changes to downstream pipeline stages (blocklist filtering, HTTP fetch, LLM disambiguation, DB write)
+2. **Configurable engine selection** — CLI flag to choose which engine(s) Serpex queries (brave, google, bing, or auto)
+3. **Multi-engine mode** — Query N engines per org, merge and dedupe results, pass a wider candidate set to the LLM disambiguator
+4. **Cost transparency** — Log which engine(s) were used per query and total credit consumption for the run
+5. **Backward compatibility** — Brave direct mode remains available as a fallback (flag to bypass Serpex entirely)
+
+## Non-Goals
+
+- Changing the LLM disambiguation stage (Stage 5) — it receives candidates regardless of source
+- Changing the blocklist logic — it operates on URLs, engine-agnostic
+- Building a generic search abstraction for use outside the resolver — this is resolver-specific
+- Caching search results — out of scope for this spec
+- Automatic engine routing (e.g., "use Google for .org queries") — manual selection only for now
+
+## Technical Design
+
+### Architecture
+
+```
+                    ┌─────────────────────────────────┐
+                    │     pipeline_resolver.py         │
+                    │         (unchanged)              │
+                    │                                  │
+                    │  calls: web_search(query, ...)   │
+                    └──────────┬──────────────────────┘
+                               │
+                    ┌──────────▼──────────────────────┐
+                    │      web_search.py (NEW)         │
+                    │                                  │
+                    │  SearchResult(title, url, snip)  │
+                    │  search(query, config) → list    │
+                    │  search_and_filter(org, config)  │
+                    │                                  │
+                    │  Dispatches to backend:          │
+                    │  ├─ SerpexBackend (default)      │
+                    │  └─ BraveDirectBackend (legacy)  │
+                    └──────────┬──────────────────────┘
+                               │
+              ┌────────────────┼────────────────┐
+              │                │                │
+    ┌─────────▼──┐   ┌────────▼───┐   ┌────────▼───┐
+    │  Engine 1  │   │  Engine 2  │   │  Engine N  │
+    │  (brave)   │   │  (google)  │   │  (bing)    │
+    │            │   │            │   │            │
+    │  Serpex    │   │  Serpex    │   │  Serpex    │
+    │  API call  │   │  API call  │   │  API call  │
+    └────────────┘   └────────────┘   └────────────┘
+              │                │                │
+              └────────────────┼────────────────┘
+                               │
+                        merge + dedupe
+                               │
+                    ┌──────────▼──────────────────────┐
+                    │  Deduplicated SearchResult list  │
+                    │  (ordered by: first-seen rank,   │
+                    │   multi-engine boost)            │
+                    └─────────────────────────────────┘
+```
+
+### New Module: `lavandula/nonprofits/web_search.py`
+
+Replaces `brave_search.py` as the search interface for the pipeline. `brave_search.py` is preserved but only used when `--search-backend brave-direct` is specified.
+
+```python
+@dataclass(frozen=True)
+class SearchResult:
+    title: str
+    url: str
+    snippet: str
+    engine: str  # which engine returned this result
+
+@dataclass
+class SearchConfig:
+    backend: str          # "serpex" | "brave-direct"
+    engines: list[str]    # ["brave"] or ["brave", "google"] etc.
+    api_key: str          # Serpex API key (or Brave key for direct)
+    qps: float            # rate limit (queries per second)
+    count: int            # results per engine query (default 10)
+```
+
+#### Single-engine mode (default)
+
+```python
+def search(query: str, *, config: SearchConfig, rate_limiter: RateLimiter) -> list[SearchResult]:
+    """Query one engine, return results."""
+```
+
+Calls Serpex API: `GET https://api.serpex.dev/api/search?q={query}&engine={engine}&category=web`
+
+#### Multi-engine mode
+
+```python
+def search_multi(query: str, *, config: SearchConfig, rate_limiter: RateLimiter) -> list[SearchResult]:
+    """Query multiple engines sequentially, merge and dedupe results."""
+```
+
+When `config.engines` has >1 entry:
+1. Query each engine sequentially (respecting rate limiter between calls)
+2. Merge results into a single list
+3. Dedupe by normalized URL (same logic as experiment: strip www, lowercase, strip trailing slash)
+4. Ordering: results that appear in multiple engines rank first (sorted by best rank across engines), then single-engine results by their original rank
+
+#### Blocklist + filter (same interface as brave_search.py)
+
+```python
+def search_and_filter(
+    org_name: str, city: str, state: str,
+    *, config: SearchConfig, rate_limiter: RateLimiter,
+    max_results: int = 3,
+) -> list[SearchResult]:
+    """Build query, search (single or multi), filter blocklist, return top N."""
+```
+
+Uses the existing `is_blocked()` from `brave_search.py` — no changes to blocklist logic.
+
+### Changes to Existing Modules
+
+#### `pipeline_resolver.py` — Minimal changes
+
+Replace:
+```python
+from .brave_search import search, BraveSearchError, BraveRateLimiter
+```
+With:
+```python
+from .web_search import search, SearchError, RateLimiter, SearchConfig
+```
+
+The `producer()` function's Stage 1 changes from:
+```python
+raw_results = search(query, api_key=api_key, count=20, rate_limiter=rate_limiter)
+```
+To:
+```python
+raw_results = search(query, config=search_config, rate_limiter=rate_limiter)
+```
+
+Stage 2 (blocklist filtering) is unchanged — `is_blocked()` stays in `brave_search.py` and operates on URLs.
+
+#### `pipeline_resolve.py` (CLI entry point) — New flags
+
+```
+--search-backend   serpex | brave-direct          (default: serpex)
+--search-engines   brave,google,bing              (default: brave)
+--serpex-api-key   literal key                    (mutually exclusive with --serpex-ssm-key)
+--serpex-ssm-key   SSM parameter path             (default: lavandula/serpex/api_key)
+```
+
+Existing `--brave-qps` flag is renamed to `--search-qps` (with `--brave-qps` kept as deprecated alias).
+
+#### `secrets.py` — New function
+
+```python
+def get_serpex_api_key() -> str:
+    """Retrieve Serpex API key from SSM or env var."""
+```
+
+SSM path: `lavandula/serpex/api_key`
+Env override: `LAVANDULA_SECRET_SERPEX_API_KEY`
+
+#### Dashboard `pipeline/forms.py` and `views.py`
+
+The resolver form gains a search engine dropdown (or multi-select) so the operator can choose engines from the dashboard UI. This is a cosmetic addition to the existing resolver controls form.
+
+### Serpex API Integration
+
+**Endpoint**: `GET https://api.serpex.dev/api/search`
+
+**Headers**: `X-API-Key: {key}`
+
+**Parameters**:
+| Param | Value |
+|-------|-------|
+| `q` | search query |
+| `engine` | `brave`, `google`, `bing`, or `auto` |
+| `category` | `web` |
+
+**Response** (relevant fields):
+```json
+{
+  "results": [
+    {"title": "...", "url": "...", "snippet": "..."}
+  ]
+}
+```
+
+**Rate limits**: Tier-based concurrent requests (10 starter, 50 standard, 100 scale). We enforce our own QPS limit client-side.
+
+**Error handling**: Same retry logic as current Brave client (429/5xx → exponential backoff with 3 retries). Serpex-specific: 402 Payment Required → log credit exhaustion, fail the query (do not retry).
+
+### Multi-Engine Merge Algorithm
+
+```
+Input: results_by_engine = {engine: [SearchResult, ...]}
+
+1. Normalize each URL: lowercase, strip www., strip trailing /
+2. Build url_map: normalized_url → {engines: set, best_rank: int, result: SearchResult}
+3. For each engine's results (in order):
+   - If URL already in url_map, add engine to set, update best_rank = min(current, rank)
+   - Else, add new entry
+4. Sort by: (-len(engines), best_rank)  # multi-engine hits first, then by rank
+5. Return sorted results
+```
+
+This means a URL that appears in both Brave and Google at rank 2 and 5 respectively will sort before a URL that appears only in Brave at rank 1. The intuition: cross-engine agreement is a stronger signal than single-engine rank.
+
+### Cost Model
+
+| Mode | Cost per org | Cost for 100K orgs |
+|------|-------------|-------------------|
+| Brave direct (current) | $0.005 | $500 |
+| Serpex single (brave) | $0.0003-$0.0008 | $30-$80 |
+| Serpex dual (brave+google) | $0.0006-$0.0016 | $60-$160 |
+| Serpex triple (brave+google+bing) | $0.0009-$0.0024 | $90-$240 |
+
+Even triple-engine Serpex is 2-5x cheaper than single-engine Brave direct.
+
+### Logging & Observability
+
+Each search call logs:
+- `search.engine={engine} query={query[:50]} results={count} elapsed={ms}ms`
+
+Multi-engine mode additionally logs:
+- `search.multi engines={engines} unique_urls={n} multi_hit_urls={m}`
+
+End-of-run summary includes:
+- Total queries by engine
+- Total unique results
+- Multi-engine overlap rate (for multi-engine runs)
+
+### Migration Path
+
+1. **Phase 1**: Ship `web_search.py` with Serpex backend. Default to `--search-backend serpex --search-engines brave`. This is a 1:1 replacement — same engine, different proxy. Validate with a 100-org run.
+2. **Phase 2**: Enable `--search-engines brave,google` for hard cases (re-resolve the ~20K ambiguous/unresolved orgs). Compare resolution rates.
+3. **Phase 3**: Once validated, deprecate `--search-backend brave-direct` flag. `brave_search.py` becomes blocklist-only (no more API client code).
+
+## Acceptance Criteria
+
+### Core Search Adapter
+1. `web_search.py` module exists with `SearchResult`, `SearchConfig`, `RateLimiter`, `SearchError` types
+2. `search()` function calls Serpex API with configurable engine parameter
+3. `search_and_filter()` applies existing blocklist logic from `brave_search.py`
+4. Response parsing extracts title, url, snippet from Serpex JSON response
+5. `engine` field on `SearchResult` records which engine produced the result
+
+### Multi-Engine Mode
+6. `search()` with multiple engines queries each sequentially, respecting rate limiter
+7. Results are deduped by normalized URL (lowercase, no www, no trailing slash)
+8. Multi-engine hits sort before single-engine hits at same rank
+9. Within same engine count, results sort by best rank across engines
+10. `max_results` parameter limits final output after merge+dedupe
+
+### Error Handling
+11. Retries on 429/5xx with exponential backoff (2s, 4s, 8s) — same as current Brave client
+12. 402 Payment Required logged as credit exhaustion, no retry
+13. Network errors (timeouts, connection failures) retried same as status errors
+14. Per-engine failures in multi-engine mode do not abort the entire query — remaining engines still run
+15. `SearchError` raised only when ALL engines fail for a query
+
+### Pipeline Integration
+16. `pipeline_resolver.py` producer Stage 1 uses `web_search.search()` instead of `brave_search.search()`
+17. Stage 2 blocklist filtering unchanged (still uses `brave_search.is_blocked()`)
+18. Stages 3-6 completely unchanged
+19. CLI flags: `--search-backend`, `--search-engines`, `--serpex-api-key`, `--serpex-ssm-key`
+20. `--search-backend brave-direct` falls back to existing `brave_search.search()` for backward compatibility
+
+### Configuration & Secrets
+21. `secrets.py` has `get_serpex_api_key()` reading from SSM path `lavandula/serpex/api_key`
+22. Env var override: `LAVANDULA_SECRET_SERPEX_API_KEY`
+23. `--search-qps` controls rate limit (default 1.0), `--brave-qps` kept as deprecated alias
+
+### Dashboard Integration
+24. Resolver form includes engine selection (dropdown or multi-select for engine choice)
+25. Dashboard resolver trigger passes selected engine(s) to the pipeline
+
+### Logging
+26. Each search call logs engine, query prefix, result count, and latency
+27. Multi-engine queries log unique URLs and multi-hit count
+28. End-of-run summary includes per-engine query counts
+
+### Testing
+29. Unit tests for Serpex API call construction (mock HTTP)
+30. Unit tests for multi-engine merge/dedupe algorithm
+31. Unit tests for error handling (402, 429, 5xx, network error, partial engine failure)
+32. Integration test: `search_and_filter()` with mocked Serpex returning known results, verify blocklist applied
+33. Backward compatibility test: `--search-backend brave-direct` uses existing Brave client
+
+## Traps to Avoid
+
+1. **Don't break the blocklist** — `is_blocked()` must remain the single source of truth for domain filtering. Don't duplicate it in `web_search.py`.
+2. **Don't change query construction** — The `"{clean_name} {city} {state}"` pattern is battle-tested. Serpex takes the same query string.
+3. **Don't parallelize multi-engine queries** — Sequential with rate limiter is safer. Serpex has tier-based concurrency limits and we don't want to burn credits on rate-limit retries.
+4. **402 is not retryable** — Credit exhaustion won't resolve on retry. Log it, fail the query, and let the operator know.
+5. **Don't remove brave_search.py** — It still owns the blocklist and serves as the fallback backend. Remove only the API client code in Phase 3 (future work, not this spec).
+
+## Security Considerations
+
+- Serpex API key stored in AWS SSM (encrypted at rest), same pattern as Brave key
+- API key never logged (existing `log.warning` patterns don't include key)
+- Query strings may contain org names — same exposure as current Brave calls, no change in risk profile
+- Serpex is a third-party proxy — search queries are visible to them. Same trust model as Brave (queries are nonprofit names + locations, not sensitive data)
+
+## Experiment Evidence
+
+See `experiments/0001_serpex_search_comparison/`:
+- **Easy cases** (200 resolved orgs): 90% Brave top-3 overlap, 97% domain-level match
+- **Hard cases** (250 ambiguous/unresolved/low-confidence): 30% overlap, but manual review of 15 zero-overlap samples showed Serpex 5 wins / 2 losses — divergence was often Serpex finding better candidates
+- **Latency**: 2.26s mean, 5.22s p95 (hard cases) — within acceptable range for batch pipeline
+- **Reliability**: 450 queries, 0 errors

--- a/locard/specs/0031-serpex-search-adapter.md
+++ b/locard/specs/0031-serpex-search-adapter.md
@@ -176,7 +176,7 @@ def get_serpex_api_key() -> str:
     """Retrieve Serpex API key from SSM or env var."""
 ```
 
-SSM path: `lavandula/serpex/api_key`
+Short name: `serpex-api-key` (SSM full path: `/cloud2.lavandulagroup.com/serpex-api-key`, following existing `brave-api-key` convention)
 Env override: `LAVANDULA_SECRET_SERPEX_API_KEY`
 
 #### Dashboard `pipeline/forms.py` and `views.py`

--- a/locard/specs/0031-serpex-search-adapter.md
+++ b/locard/specs/0031-serpex-search-adapter.md
@@ -95,29 +95,32 @@ class SearchConfig:
     count: int            # results per engine query (default 10)
 ```
 
-#### Single-engine mode (default)
+#### Public API: `search()`
+
+One public function handles both single and multi-engine modes. No separate `search_multi()`.
 
 ```python
 def search(query: str, *, config: SearchConfig, rate_limiter: RateLimiter) -> list[SearchResult]:
-    """Query one engine, return results."""
+    """Query configured engine(s) and return results.
+    
+    Single engine (len(config.engines) == 1): one Serpex API call.
+    Multi engine (len(config.engines) > 1): sequential calls, merge+dedupe.
+    """
 ```
 
 Calls Serpex API: `GET https://api.serpex.dev/api/search?q={query}&engine={engine}&category=web`
 
-#### Multi-engine mode
-
-```python
-def search_multi(query: str, *, config: SearchConfig, rate_limiter: RateLimiter) -> list[SearchResult]:
-    """Query multiple engines sequentially, merge and dedupe results."""
-```
+Internally, multi-engine dispatch is a private `_merge_results()` helper — not a separate public function.
 
 When `config.engines` has >1 entry:
 1. Query each engine sequentially (respecting rate limiter between calls)
 2. Merge results into a single list
-3. Dedupe by normalized URL (same logic as experiment: strip www, lowercase, strip trailing slash)
+3. Dedupe by normalized URL (see URL Normalization below)
 4. Ordering: results that appear in multiple engines rank first (sorted by best rank across engines), then single-engine results by their original rank
 
-#### Blocklist + filter (same interface as brave_search.py)
+#### Blocklist + filter: `search_and_filter()`
+
+**Ownership model**: `web_search.py` owns the full search-and-filter flow. It imports `is_blocked()` from `brave_search.py` (the single source of truth for domain filtering) and applies it internally. `pipeline_resolver.py` no longer calls `is_blocked()` directly — Stage 2 moves into `search_and_filter()`.
 
 ```python
 def search_and_filter(
@@ -128,31 +131,27 @@ def search_and_filter(
     """Build query, search (single or multi), filter blocklist, return top N."""
 ```
 
-Uses the existing `is_blocked()` from `brave_search.py` — no changes to blocklist logic.
+This means `pipeline_resolver.py` replaces Stage 1 + Stage 2 with a single `search_and_filter()` call. Stages 3-6 remain untouched.
 
 ### Changes to Existing Modules
 
-#### `pipeline_resolver.py` — Minimal changes
+#### `pipeline_resolver.py` — Stages 1+2 collapse into one call
 
 Replace:
 ```python
-from .brave_search import search, BraveSearchError, BraveRateLimiter
+from .brave_search import search, BraveSearchError, BraveRateLimiter, is_blocked
 ```
 With:
 ```python
-from .web_search import search, SearchError, RateLimiter, SearchConfig
+from .web_search import search_and_filter, SearchError, RateLimiter, SearchConfig
 ```
 
-The `producer()` function's Stage 1 changes from:
+The `producer()` function's Stage 1 + Stage 2 collapse from ~30 lines into:
 ```python
-raw_results = search(query, api_key=api_key, count=20, rate_limiter=rate_limiter)
-```
-To:
-```python
-raw_results = search(query, config=search_config, rate_limiter=rate_limiter)
+results = search_and_filter(name, city, state, config=search_config, rate_limiter=rate_limiter, max_results=3)
 ```
 
-Stage 2 (blocklist filtering) is unchanged — `is_blocked()` stays in `brave_search.py` and operates on URLs.
+`search_and_filter()` handles query construction, search dispatch (single or multi-engine), blocklist filtering, and returns the final filtered list. Stages 3-6 remain identical.
 
 #### `pipeline_resolve.py` (CLI entry point) — New flags
 
@@ -177,7 +176,16 @@ Env override: `LAVANDULA_SECRET_SERPEX_API_KEY`
 
 #### Dashboard `pipeline/forms.py` and `views.py`
 
-The resolver form gains a search engine dropdown (or multi-select) so the operator can choose engines from the dashboard UI. This is a cosmetic addition to the existing resolver controls form.
+The resolver form gains a **search engine preset dropdown**:
+
+| Value | Label | Engines passed to CLI |
+|-------|-------|-----------------------|
+| `brave` | Brave (default) | `--search-engines brave` |
+| `google` | Google | `--search-engines google` |
+| `brave_google` | Brave + Google | `--search-engines brave,google` |
+| `auto` | Auto (Serpex routing) | `--search-engines auto` |
+
+Default selection: `brave`. The dropdown replaces no existing field — it's a new addition to the resolver controls form alongside the existing LLM model selector. The view passes the selected value as the `--search-engines` flag when spawning the pipeline subprocess.
 
 ### Serpex API Integration
 
@@ -205,21 +213,52 @@ The resolver form gains a search engine dropdown (or multi-select) so the operat
 
 **Error handling**: Same retry logic as current Brave client (429/5xx → exponential backoff with 3 retries). Serpex-specific: 402 Payment Required → log credit exhaustion, fail the query (do not retry).
 
+### URL Normalization for Dedup
+
+Used only for merge deduplication — the original URL is preserved on the `SearchResult` object.
+
+```
+normalize(url):
+  1. Parse with urllib.parse.urlsplit
+  2. Lowercase scheme and hostname
+  3. Strip "www." prefix from hostname
+  4. Strip trailing "/" from path
+  5. Remove default ports (:80 for http, :443 for https)
+  6. Strip fragment (#...) entirely
+  7. Preserve query string as-is (different query params = different pages)
+  8. Preserve path as-is (case-sensitive — /About != /about on many servers)
+  9. Normalize scheme to https (http://example.com == https://example.com for dedup)
+  10. Return: "{hostname}{path}?{query}" (no scheme, no fragment)
+```
+
+This is intentionally conservative: it merges obvious duplicates (www vs non-www, http vs https, trailing slash) without collapsing pages that are genuinely different.
+
+### Engine Validation Rules
+
+**Valid engines**: `brave`, `google`, `bing`, `auto`
+
+- `auto` **cannot** be combined with other engines (it is Serpex's own routing — combining defeats the purpose)
+- Duplicate engine names are silently deduplicated: `--search-engines brave,brave` → `["brave"]`
+- Unknown engine names fail at CLI parse time with a clear error listing valid values
+- `--search-backend brave-direct` ignores `--search-engines` entirely (Brave direct has no engine concept)
+- Dashboard UI: dropdown with values `brave`, `google`, `bing`, `brave+google` (presets, not free-form). Default: `brave`.
+
 ### Multi-Engine Merge Algorithm
 
 ```
 Input: results_by_engine = {engine: [SearchResult, ...]}
 
-1. Normalize each URL: lowercase, strip www., strip trailing /
+1. Normalize each URL per the normalization rules above
 2. Build url_map: normalized_url → {engines: set, best_rank: int, result: SearchResult}
-3. For each engine's results (in order):
+3. For each engine's results (in order of config.engines, then by rank within engine):
    - If URL already in url_map, add engine to set, update best_rank = min(current, rank)
-   - Else, add new entry
+   - Else, add new entry with engine set = {engine}, best_rank = rank
 4. Sort by: (-len(engines), best_rank)  # multi-engine hits first, then by rank
-5. Return sorted results
+5. Tie-breaker for equal engine-count and equal rank: order of first insertion (stable sort)
+6. Return sorted results
 ```
 
-This means a URL that appears in both Brave and Google at rank 2 and 5 respectively will sort before a URL that appears only in Brave at rank 1. The intuition: cross-engine agreement is a stronger signal than single-engine rank.
+This means a URL that appears in both Brave and Google at rank 2 and 5 respectively will sort before a URL that appears only in Brave at rank 1. The intuition: cross-engine agreement is a stronger signal than single-engine rank. The stable-sort tie-breaker ensures deterministic ordering.
 
 ### Cost Model
 
@@ -234,16 +273,21 @@ Even triple-engine Serpex is 2-5x cheaper than single-engine Brave direct.
 
 ### Logging & Observability
 
-Each search call logs:
+Each search call logs at DEBUG:
 - `search.engine={engine} query={query[:50]} results={count} elapsed={ms}ms`
 
-Multi-engine mode additionally logs:
+Multi-engine mode additionally logs at INFO:
 - `search.multi engines={engines} unique_urls={n} multi_hit_urls={m}`
+
+Partial engine failure logs at WARNING:
+- `search.engine_failed engine={engine} error={msg} remaining_engines={list}`
 
 End-of-run summary includes:
 - Total queries by engine
 - Total unique results
 - Multi-engine overlap rate (for multi-engine runs)
+- Per-engine failure count
+- **Estimated credit usage**: `total_queries × engines_per_query × 1 credit` (Serpex charges 1 credit per search call regardless of engine). This is an estimate — actual billing comes from the Serpex dashboard.
 
 ### Migration Path
 
@@ -255,52 +299,60 @@ End-of-run summary includes:
 
 ### Core Search Adapter
 1. `web_search.py` module exists with `SearchResult`, `SearchConfig`, `RateLimiter`, `SearchError` types
-2. `search()` function calls Serpex API with configurable engine parameter
-3. `search_and_filter()` applies existing blocklist logic from `brave_search.py`
+2. `search()` is the single public search function — handles both single and multi-engine modes
+3. `search_and_filter()` owns query construction + search + blocklist filtering (imports `is_blocked()` from `brave_search.py`)
 4. Response parsing extracts title, url, snippet from Serpex JSON response
 5. `engine` field on `SearchResult` records which engine produced the result
 
 ### Multi-Engine Mode
 6. `search()` with multiple engines queries each sequentially, respecting rate limiter
-7. Results are deduped by normalized URL (lowercase, no www, no trailing slash)
+7. Results are deduped by normalized URL (per URL Normalization rules: lowercase host, strip www, strip trailing /, remove fragment, normalize scheme, preserve query string and path case)
 8. Multi-engine hits sort before single-engine hits at same rank
-9. Within same engine count, results sort by best rank across engines
+9. Within same engine count, results sort by best rank across engines; equal engine-count + equal rank uses insertion order (stable sort)
 10. `max_results` parameter limits final output after merge+dedupe
 
+### Engine Validation
+11. Valid engines: `brave`, `google`, `bing`, `auto`. Unknown values fail at CLI parse with error listing valid options.
+12. `auto` cannot be combined with other engines — CLI error if attempted
+13. Duplicate engine names silently deduplicated
+14. `--search-backend brave-direct` ignores `--search-engines`
+
 ### Error Handling
-11. Retries on 429/5xx with exponential backoff (2s, 4s, 8s) — same as current Brave client
-12. 402 Payment Required logged as credit exhaustion, no retry
-13. Network errors (timeouts, connection failures) retried same as status errors
-14. Per-engine failures in multi-engine mode do not abort the entire query — remaining engines still run
-15. `SearchError` raised only when ALL engines fail for a query
+15. Retries on 429/5xx with exponential backoff (2s, 4s, 8s) — same as current Brave client
+16. 402 Payment Required logged as credit exhaustion, no retry
+17. Network errors (timeouts, connection failures) retried same as status errors
+18. Per-engine failures in multi-engine mode do not abort the entire query — remaining engines still run, failure logged at WARNING with engine name and error
+19. `SearchError` raised only when ALL engines fail for a query
 
 ### Pipeline Integration
-16. `pipeline_resolver.py` producer Stage 1 uses `web_search.search()` instead of `brave_search.search()`
-17. Stage 2 blocklist filtering unchanged (still uses `brave_search.is_blocked()`)
-18. Stages 3-6 completely unchanged
-19. CLI flags: `--search-backend`, `--search-engines`, `--serpex-api-key`, `--serpex-ssm-key`
-20. `--search-backend brave-direct` falls back to existing `brave_search.search()` for backward compatibility
+20. `pipeline_resolver.py` producer replaces Stage 1 + Stage 2 with single `search_and_filter()` call
+21. Stages 3-6 completely unchanged
+22. CLI flags: `--search-backend`, `--search-engines`, `--serpex-api-key`, `--serpex-ssm-key`
+23. `--search-backend brave-direct` falls back to existing `brave_search.search()` + inline blocklist filter for backward compatibility
+24. `--search-qps` controls rate limit (default 1.0), `--brave-qps` kept as deprecated alias that maps to `--search-qps`
 
 ### Configuration & Secrets
-21. `secrets.py` has `get_serpex_api_key()` reading from SSM path `lavandula/serpex/api_key`
-22. Env var override: `LAVANDULA_SECRET_SERPEX_API_KEY`
-23. `--search-qps` controls rate limit (default 1.0), `--brave-qps` kept as deprecated alias
+25. `secrets.py` has `get_serpex_api_key()` reading from SSM path `lavandula/serpex/api_key`
+26. Env var override: `LAVANDULA_SECRET_SERPEX_API_KEY`
 
 ### Dashboard Integration
-24. Resolver form includes engine selection (dropdown or multi-select for engine choice)
-25. Dashboard resolver trigger passes selected engine(s) to the pipeline
+27. Resolver form includes search engine preset dropdown with values: `brave` (default), `google`, `brave_google`, `auto`
+28. Dashboard resolver trigger passes selected engine(s) as `--search-engines` flag to pipeline subprocess
 
 ### Logging
-26. Each search call logs engine, query prefix, result count, and latency
-27. Multi-engine queries log unique URLs and multi-hit count
-28. End-of-run summary includes per-engine query counts
+29. Each search call logs engine, query prefix, result count, and latency (DEBUG level)
+30. Multi-engine queries log unique URLs and multi-hit count (INFO level)
+31. Partial engine failures logged at WARNING with engine name and error message
+32. End-of-run summary includes per-engine query counts, per-engine failure counts, and estimated credit usage (queries × engines)
 
 ### Testing
-29. Unit tests for Serpex API call construction (mock HTTP)
-30. Unit tests for multi-engine merge/dedupe algorithm
-31. Unit tests for error handling (402, 429, 5xx, network error, partial engine failure)
-32. Integration test: `search_and_filter()` with mocked Serpex returning known results, verify blocklist applied
-33. Backward compatibility test: `--search-backend brave-direct` uses existing Brave client
+33. Unit tests for Serpex API call construction (mock HTTP)
+34. Unit tests for multi-engine merge/dedupe algorithm including tie-breaker determinism
+35. Unit tests for URL normalization edge cases (www stripping, trailing slash, fragments, query strings, scheme normalization)
+36. Unit tests for error handling (402, 429, 5xx, network error, partial engine failure in multi-engine)
+37. Unit tests for engine validation (auto+other rejected, duplicates deduped, unknown rejected)
+38. Integration test: `search_and_filter()` with mocked Serpex returning known results, verify blocklist applied
+39. Backward compatibility test: `--search-backend brave-direct` uses existing Brave client path
 
 ## Traps to Avoid
 
@@ -312,10 +364,12 @@ End-of-run summary includes:
 
 ## Security Considerations
 
-- Serpex API key stored in AWS SSM (encrypted at rest), same pattern as Brave key
-- API key never logged (existing `log.warning` patterns don't include key)
-- Query strings may contain org names — same exposure as current Brave calls, no change in risk profile
-- Serpex is a third-party proxy — search queries are visible to them. Same trust model as Brave (queries are nonprofit names + locations, not sensitive data)
+- **API key storage**: Serpex API key stored in AWS SSM (encrypted at rest), same pattern as Brave key. Env var override for local dev only.
+- **Key exposure**: API key never logged — existing `log.warning` patterns don't include key, and new Serpex logging follows the same pattern. `SearchConfig.api_key` field is never included in `__repr__`.
+- **Query exposure**: Query strings contain org names + city/state — same exposure as current Brave calls, no change in risk profile. Nonprofit names and locations are public IRS data.
+- **Third-party proxy trust**: Serpex is a third-party proxy — search queries are visible to them. Same trust model as Brave (queries are nonprofit names + locations, not sensitive data). No PII is sent.
+- **SSRF via returned URLs**: Search results contain third-party URLs that Stage 3 will HTTP-fetch. This is unchanged from the current pipeline — Stage 3's existing SSRF protections (private IP blocking, timeout, size limits) apply regardless of search backend. No additional SSRF surface is introduced.
+- **Multi-engine provenance**: When multi-engine mode produces more candidates, the existing blocklist filter and LLM disambiguator are the quality gates. More candidates = more URLs to fetch, but each fetch goes through the same protections. The `engine` field on `SearchResult` provides audit trail for which engine sourced each URL.
 
 ## Experiment Evidence
 

--- a/locard/specs/0031-serpex-search-adapter.md
+++ b/locard/specs/0031-serpex-search-adapter.md
@@ -20,6 +20,7 @@ Additionally, the current pipeline is locked to a single search engine. Differen
 3. **Multi-engine mode** — Query N engines per org, merge and dedupe results, pass a wider candidate set to the LLM disambiguator
 4. **Cost transparency** — Log which engine(s) were used per query and total credit consumption for the run
 5. **Backward compatibility** — Brave direct mode remains available as a fallback (flag to bypass Serpex entirely)
+6. **Phone number enrichment** — Separate enrichment pass that uses the search adapter to find org phone numbers from search snippets and website contact pages
 
 ## Non-Goals
 
@@ -319,11 +320,74 @@ End-of-run summary includes:
 - `search_full` / `search_partial` / `search_failed` counters
 - **Estimated credit usage**: `successful_calls × 1 credit` (counts only successful API calls, not retries or failures). Labeled explicitly as "estimated" — actual billing comes from the Serpex dashboard. Retries that succeed count as 1 call. `auto` engine counts as 1 call per query.
 
+### Phone Number Enrichment Pass
+
+A separate enrichment pipeline that uses `web_search.py` to find org phone numbers. Runs independently of the URL resolver — targets orgs that are already resolved (have `website_url`) but lack a phone number.
+
+#### Schema Change
+
+Migration adds a `phone` column to `nonprofits_seed`:
+
+```sql
+ALTER TABLE lava_corpus.nonprofits_seed ADD COLUMN IF NOT EXISTS phone TEXT;
+ALTER TABLE lava_corpus.nonprofits_seed ADD COLUMN IF NOT EXISTS phone_source TEXT;
+```
+
+`phone_source` records provenance: `search_snippet`, `website_extract`, or `manual`.
+
+#### Pipeline Design
+
+```
+New CLI: pipeline_enrich_phone.py
+
+1. SELECT resolved orgs where phone IS NULL
+2. For each org:
+   a. Query: "{org_name} {city} {state} phone number"
+   b. Extract phone from search snippets using regex
+   c. If found in snippets → write directly (no HTTP fetch needed)
+   d. If not found in snippets → fetch org's website_url contact/about page,
+      extract phone from page text
+   e. Validate: US phone format (10 digits, optional +1), not a fax number
+   f. Write to nonprofits_seed.phone + phone_source
+```
+
+#### Phone Extraction Strategy
+
+**Priority 1 — Search snippets** (cheapest, no HTTP fetch):
+Search engines frequently surface phone numbers in Knowledge Panels and local listing snippets. A regex scan of search result snippets catches these at zero additional cost.
+
+```python
+_US_PHONE_RE = re.compile(
+    r'(?:\+?1[-.\s]?)?'          # optional +1 or 1
+    r'\(?(\d{3})\)?[-.\s]?'      # area code
+    r'(\d{3})[-.\s]?'            # exchange
+    r'(\d{4})'                   # subscriber
+)
+```
+
+**Priority 2 — Website contact page** (fallback):
+If snippets don't contain a phone, fetch the org's known `website_url` and look for `/contact`, `/about`, or `/about-us` pages. Extract phone from page text using the same regex. This reuses the existing HTTP fetch infrastructure from Stage 3 of the resolver (SSRF protections, timeouts, size limits).
+
+**Validation rules**:
+- Must be 10-digit US number (with optional +1 prefix)
+- Reject known non-phone patterns: fax numbers (skip if preceded by "fax" within 20 chars)
+- Reject toll-free numbers starting with 800/888/877/866/855/844/833 (these are call centers, not local offices — configurable)
+- If multiple phones found, prefer the one closest to the org name in the text
+
+#### Dashboard Integration
+
+The org detail page (`/orgs/{ein}/`) already shows org metadata. Add `phone` to the display. The pipeline controls page gains an "Enrich Phones" button that triggers the enrichment pipeline for a selected state or all resolved orgs.
+
+#### Cost
+
+Phone enrichment uses 1 Serpex credit per org (single search query). For 100K resolved orgs: ~$30-80 at Serpex rates. Website fetch fallback adds no search cost (uses already-known URLs).
+
 ### Migration Path
 
 1. **Phase 1**: Ship `web_search.py` with Serpex backend. Default to `--search-backend serpex --search-engines brave`. This is a 1:1 replacement — same engine, different proxy. Validate with a 100-org run.
 2. **Phase 2**: Enable `--search-engines brave,google` for hard cases (re-resolve the ~20K ambiguous/unresolved orgs). Compare resolution rates.
-3. **Phase 3**: Once validated, deprecate `--search-backend brave-direct` flag. `brave_search.py` becomes blocklist-only (no more API client code).
+3. **Phase 3**: Phone number enrichment pass on all resolved orgs.
+4. **Phase 4**: Once validated, deprecate `--search-backend brave-direct` flag. `brave_search.py` becomes blocklist-only (no more API client code).
 
 ## Acceptance Criteria
 
@@ -375,14 +439,27 @@ End-of-run summary includes:
 31. Partial engine failures logged at WARNING with engine name and error message
 32. End-of-run summary includes per-engine query counts, per-engine failure counts, search_full/partial/failed counters, and estimated credit usage (successful calls × 1)
 
+### Phone Number Enrichment
+33. `pipeline_enrich_phone.py` CLI exists with `--state`, `--limit`, `--search-engines` flags
+34. Migration adds `phone` and `phone_source` columns to `nonprofits_seed`
+35. Phone regex extracts 10-digit US numbers from search snippets
+36. Fax numbers rejected (preceded by "fax" within 20 characters)
+37. Toll-free numbers (800/888/877/866/855/844/833) rejected by default, configurable via `--allow-tollfree`
+38. Fallback: if no phone in snippets, fetches org's website_url contact/about page
+39. Writes `phone` and `phone_source` (`search_snippet` or `website_extract`) to DB
+40. Dashboard org detail page displays phone number
+41. Dashboard pipeline controls includes "Enrich Phones" trigger
+
 ### Testing
-33. Unit tests for Serpex API call construction (mock HTTP)
-34. Unit tests for multi-engine merge/dedupe algorithm including tie-breaker determinism
-35. Unit tests for URL normalization edge cases (www stripping, trailing slash, fragments, query strings, scheme normalization)
-36. Unit tests for error handling (402, 429, 5xx, network error, partial engine failure in multi-engine)
-37. Unit tests for engine validation (auto+other rejected, duplicates deduped, unknown rejected)
-38. Integration test: `search_and_filter()` with mocked Serpex returning known results, verify blocklist applied
-39. Backward compatibility test: `--search-backend brave-direct` uses existing Brave client path
+42. Unit tests for Serpex API call construction (mock HTTP)
+43. Unit tests for multi-engine merge/dedupe algorithm including tie-breaker determinism
+44. Unit tests for URL normalization edge cases (www stripping, trailing slash, fragments, query strings, scheme normalization)
+45. Unit tests for error handling (402, 429, 5xx, network error, partial engine failure in multi-engine)
+46. Unit tests for engine validation (auto+other rejected, duplicates deduped, unknown rejected)
+47. Integration test: `search_and_filter()` with mocked Serpex returning known results, verify blocklist applied
+48. Backward compatibility test: `--search-backend brave-direct` uses existing Brave client path
+49. Unit tests for phone regex extraction (valid US formats, fax rejection, toll-free rejection, multiple phones)
+50. Integration test: phone enrichment pipeline with mocked search returning snippet with phone number
 
 ## Traps to Avoid
 
@@ -390,7 +467,9 @@ End-of-run summary includes:
 2. **Don't change query construction** — The `"{clean_name} {city} {state}"` pattern is battle-tested. Serpex takes the same query string.
 3. **Don't parallelize multi-engine queries** — Sequential with rate limiter is safer. Serpex has tier-based concurrency limits and we don't want to burn credits on rate-limit retries.
 4. **402 is not retryable** — Credit exhaustion won't resolve on retry. Log it, fail the query, and let the operator know.
-5. **Don't remove brave_search.py** — It still owns the blocklist and serves as the fallback backend. Remove only the API client code in Phase 3 (future work, not this spec).
+5. **Don't remove brave_search.py** — It still owns the blocklist and serves as the fallback backend. Remove only the API client code in Phase 4 (future work, not this spec).
+6. **Phone regex false positives** — EINs are 9 digits, zip codes are 5+4 digits, dates look like phone numbers. The phone regex must require exactly 10 digits in phone-like grouping (3-3-4) with separators. Don't extract bare digit sequences without format markers (parens, dashes, dots).
+7. **Don't use the phone enrichment blocklist** — The resolver blocklist blocks directory/aggregator sites. For phone enrichment, those sites (Yelp, MapQuest, ChamberOfCommerce) are actually good phone sources. The phone pipeline should NOT apply `is_blocked()` to search results — it uses its own simpler filter (or none).
 
 ## Security Considerations
 

--- a/locard/specs/0031-serpex-search-adapter.md
+++ b/locard/specs/0031-serpex-search-adapter.md
@@ -487,3 +487,12 @@ See `experiments/0001_serpex_search_comparison/`:
 - **Hard cases** (250 ambiguous/unresolved/low-confidence): 30% overlap, but manual review of 15 zero-overlap samples showed Serpex 5 wins / 2 losses — divergence was often Serpex finding better candidates
 - **Latency**: 2.26s mean, 5.22s p95 (hard cases) — within acceptable range for batch pipeline
 - **Reliability**: 450 queries, 0 errors
+
+## Consultation Log
+
+| Round | Model | Type | Verdict | Key Changes |
+|-------|-------|------|---------|-------------|
+| 1 | Codex | spec-review | REQUEST_CHANGES | Unified search()/search_multi() API, clarified blocklist ownership, added URL normalization rules, engine validation, dashboard presets, SSRF analysis, merge tie-breaker tests |
+| 2 | Codex | red-team-spec | REQUEST_CHANGES | SearchResult.engines tuple, partial failure counters, brave-direct config path, scheme-collapsing rationale, empty-results behavior |
+| — | Gemini | spec-review | SKIPPED | Gemini rate-limited (quota exhausted) |
+| — | Gemini | red-team-spec | SKIPPED | Gemini rate-limited (quota exhausted) |


### PR DESCRIPTION
## Summary
- **Serpex search adapter** (`web_search.py`): Drop-in replacement for Brave direct API calls via Serpex proxy, achieving 6-17x cost reduction ($30-80 vs $500 per 100K orgs)
- **Multi-engine support**: Query multiple engines (brave, google, bing) per org with result merge/dedup algorithm that prioritizes cross-engine agreement
- **Phone enrichment pipeline** (`pipeline_enrich_phone.py`): Extracts US phone numbers from search snippets and website contact pages for resolved orgs

## Changes

### New Files
| File | Purpose |
|------|---------|
| `lavandula/nonprofits/web_search.py` | Core search module with Serpex backend, multi-engine merge, URL normalization |
| `lavandula/nonprofits/phone_extract.py` | US phone number extraction with fax/toll-free filtering |
| `lavandula/nonprofits/tools/pipeline_enrich_phone.py` | Phone enrichment CLI |
| `lavandula/migrations/rds/migration_012_phone_enrichment.sql` | `phone` + `phone_source` columns |
| `lavandula/dashboard/pipeline/templates/pipeline/phone_enrich.html` | Dashboard phone enrichment page |

### Modified Files
| File | Change |
|------|--------|
| `pipeline_resolver.py` | Stage 1+2 collapsed into `search_and_filter()` call |
| `tools/pipeline_resolve.py` | New flags: `--search-backend`, `--search-engines`, `--serpex-api-key`, `--search-qps` |
| `common/secrets.py` | Added `get_serpex_api_key()` |
| `dashboard/pipeline/forms.py` | Search engine dropdown on ResolverForm, PhoneEnrichForm |
| `dashboard/pipeline/views.py` | Phone enrich view + resolve job search_engines passthrough |
| `dashboard/pipeline/orchestrator.py` | `search_engines` param for resolve, `enrich-phone` command map |
| `org_detail.html` | Phone field display |

### Test Results
- 101 tests passing (67 new + 34 existing, 0 regressions)
- New test coverage: Serpex API calls, multi-engine merge/dedup, URL normalization, error handling (402/429/5xx/partial failure), engine validation, phone regex, blocklist integration

## Test plan
- [ ] Unit tests: `pytest lavandula/nonprofits/tests/unit/test_web_search.py test_phone_extract.py test_pipeline_enrich_phone.py test_pipeline_resolver.py` — all 101 pass
- [ ] Smoke test: `pipeline_resolve.py --search-backend serpex --search-engines brave --state TX --limit 10`
- [ ] Multi-engine test: `--search-engines brave,google --limit 50` — verify merge/dedup logs
- [ ] Phone enrichment: `pipeline_enrich_phone.py --state TX --limit 20` — verify phone numbers
- [ ] Backward compat: `--search-backend brave-direct` uses existing Brave client path

🤖 Generated with [Claude Code](https://claude.com/claude-code)