### PR TITLE
[Spec 0031] Fix legal suffix stripping regression and single-engine stats

### DIFF
--- a/lavandula/nonprofits/tests/unit/test_web_search.py
+++ b/lavandula/nonprofits/tests/unit/test_web_search.py
@@ -240,6 +240,22 @@ class TestErrorHandling:
         assert len(out) == 1
         assert "google" in out[0].engines
 
+    def test_single_engine_error_increments_search_failed(self):
+        reset_search_stats()
+        rl = _fast_rl()
+        config = _make_config(engines=["brave"])
+
+        with patch("lavandula.nonprofits.web_search.requests.get") as mock_get:
+            mock_get.return_value = _mock_serpex_error(500)
+            with patch("lavandula.nonprofits.web_search.time.sleep"):
+                with pytest.raises(SearchError):
+                    search("test", config=config, rate_limiter=rl)
+
+        from lavandula.nonprofits.web_search import get_search_stats
+        stats = get_search_stats()
+        assert stats.search_failed == 1
+        assert stats.failed_by_engine.get("brave", 0) == 1
+
     def test_multi_engine_all_fail(self):
         reset_search_stats()
         rl = _fast_rl()
@@ -409,6 +425,25 @@ class TestSearchAndFilter:
 
         assert result.results == []
         assert result.had_raw_results is False
+
+    def test_legal_suffix_stripped(self):
+        """Legal suffixes like Inc, Foundation are stripped from query."""
+        reset_search_stats()
+        rl = _fast_rl()
+        config = _make_config()
+        results = [{"title": "T", "url": "https://example.org", "snippet": "S"}]
+
+        with patch("lavandula.nonprofits.web_search.requests.get") as mock_get:
+            mock_get.return_value = _mock_serpex_response(results)
+            search_and_filter(
+                "American Red Cross Inc", "Austin", "TX",
+                config=config, rate_limiter=rl,
+            )
+
+        call_args = mock_get.call_args
+        query = call_args.kwargs["params"]["q"]
+        assert "Inc" not in query
+        assert "American Red Cross" in query
 
     def test_all_blocked(self):
         reset_search_stats()

--- a/lavandula/nonprofits/web_search.py
+++ b/lavandula/nonprofits/web_search.py
@@ -24,6 +24,11 @@ _SERPEX_URL = "https://api.serpex.dev/api/search"
 _RETRY_STATUSES = {429, 500, 502, 503, 504}
 _RETRY_DELAYS = [2.0, 4.0, 8.0]
 
+_LEGAL_SUFFIX_RE = re.compile(
+    r"\s+(?:Inc|Corp|Corporation|LLC|Ltd|Co|Foundation|Trust|Assn|Association|Pc)\s*$",
+    re.I,
+)
+
 
 class SearchError(RuntimeError):
     """Raised when search fails after all retries (or all engines fail)."""
@@ -365,11 +370,16 @@ def search(
 
     engines = config.engines
     if len(engines) == 1:
-        results = _serpex_search(
-            query, engines[0],
-            api_key=config.api_key, count=config.count,
-            rate_limiter=rate_limiter,
-        )
+        try:
+            results = _serpex_search(
+                query, engines[0],
+                api_key=config.api_key, count=config.count,
+                rate_limiter=rate_limiter,
+            )
+        except SearchError:
+            _search_stats.record_failure(engines[0])
+            _search_stats.record_query_outcome(total_engines=1, failed_engines=1)
+            raise
         _search_stats.record_success(engines[0])
         _search_stats.record_query_outcome(total_engines=1, failed_engines=0)
         return results
@@ -424,7 +434,8 @@ def search_and_filter(
 ) -> SearchFilterResult:
     """Build query, search (single or multi), filter blocklist, return top N."""
     sanitized_name = re.sub(r'"', "", org_name or "").strip()
-    query = f'"{sanitized_name}" {city} {state}'
+    clean_name = _LEGAL_SUFFIX_RE.sub("", sanitized_name).strip()
+    query = f'{clean_name} {city} {state}'
 
     raw_results = search(query, config=config, rate_limiter=rate_limiter)
 


### PR DESCRIPTION
## Summary
Follow-up to PR #25, fixing two issues from review:

- **Legal suffix stripping regression**: `search_and_filter()` now strips legal suffixes (Inc, Corp, Foundation, etc.) from org names before building the query string. This was previously done in `pipeline_resolver.py` Stage 1 but was lost when Stage 1+2 collapsed.
- **Single-engine search_failed stat**: `SearchError` in the single-engine path now increments `search_failed` and `failed_by_engine` counters before re-raising. Previously only multi-engine failures were tracked.

## Test plan
- [x] `test_legal_suffix_stripped` — verifies "Inc" removed from query
- [x] `test_single_engine_error_increments_search_failed` — verifies stats incremented
- [x] All 103 tests passing (2 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)