### PR TITLE
[Spec 0032] Dashboard national ingest tracker + phase page parity

### DIFF
--- a/lavandula/dashboard/dashboard/settings.py
+++ b/lavandula/dashboard/dashboard/settings.py
@@ -25,6 +25,7 @@ INSTALLED_APPS = [
     "django.contrib.sessions",
     "django.contrib.messages",
     "django.contrib.staticfiles",
+    "django.contrib.humanize",
     "pipeline",
 ]
 

--- a/lavandula/dashboard/pipeline/templates/pipeline/990_index.html
+++ b/lavandula/dashboard/pipeline/templates/pipeline/990_index.html
@@ -1,5 +1,5 @@
 {% extends "pipeline/base.html" %}
-{% load pipeline_tags %}
+{% load humanize pipeline_tags %}
 {% block title %}990 Index — Lavandula Pipeline{% endblock %}
 {% block content %}
 <h1 class="text-2xl font-bold text-gray-900 mb-6">990 Index Controls</h1>
@@ -28,6 +28,9 @@
         <span class="w-3 h-3 rounded-full bg-blue-500 animate-pulse"></span>
         <span class="font-medium">Job #{{ running_job.pk }} running</span>
       </div>
+      {% if running_job.config_display %}
+      <div class="text-xs text-gray-500 mt-1 font-mono">{{ running_job.config_display|join:" | " }}</div>
+      {% endif %}
       {% elif pending_job %}
       <div class="flex items-center gap-2 mb-2">
         <span class="w-3 h-3 rounded-full bg-yellow-500"></span>
@@ -96,6 +99,12 @@
       </table>
     </div>
     {% endif %}
+
+    <!-- Recent 990 Index Jobs -->
+    <div class="bg-white rounded-lg shadow p-5">
+      <h2 class="text-lg font-semibold text-gray-900 mb-3">Recent 990 Index Jobs</h2>
+      {% include "pipeline/partials/_recent_jobs_table.html" %}
+    </div>
   </div>
 </div>
 {% endblock %}

--- a/lavandula/dashboard/pipeline/templates/pipeline/990_parse.html
+++ b/lavandula/dashboard/pipeline/templates/pipeline/990_parse.html
@@ -1,5 +1,5 @@
 {% extends "pipeline/base.html" %}
-{% load pipeline_tags %}
+{% load humanize pipeline_tags %}
 {% block title %}990 Parse — Lavandula Pipeline{% endblock %}
 {% block content %}
 <h1 class="text-2xl font-bold text-gray-900 mb-6">990 Parse Controls</h1>
@@ -14,6 +14,9 @@
         <span class="w-3 h-3 rounded-full bg-blue-500 animate-pulse"></span>
         <span class="font-medium">Job #{{ running_job.pk }} running</span>
       </div>
+      {% if running_job.config_display %}
+      <div class="text-xs text-gray-500 mt-1 font-mono">{{ running_job.config_display|join:" | " }}</div>
+      {% endif %}
       {% elif pending_job %}
       <div class="flex items-center gap-2 mb-2">
         <span class="w-3 h-3 rounded-full bg-yellow-500"></span>
@@ -46,21 +49,29 @@
   </div>
 
   <!-- Filing Counts + People -->
-  <div class="lg:col-span-2 bg-white rounded-lg shadow p-5">
-    <h2 class="text-lg font-semibold text-gray-900 mb-3">Filing &amp; People Counts</h2>
-    <div class="grid grid-cols-2 md:grid-cols-4 gap-4 mb-4">
-      {% for sc in status_counts %}
-      <div class="border rounded p-3 text-center">
-        <span class="inline-block px-2 py-0.5 rounded text-xs font-medium {{ sc.status|filing_badge }}">{{ sc.status }}</span>
-        <div class="text-2xl font-bold mt-1">{{ sc.count|default:"0" }}</div>
+  <div class="lg:col-span-2 space-y-6">
+    <div class="bg-white rounded-lg shadow p-5">
+      <h2 class="text-lg font-semibold text-gray-900 mb-3">Filing &amp; People Counts</h2>
+      <div class="grid grid-cols-2 md:grid-cols-4 gap-4 mb-4">
+        {% for sc in status_counts %}
+        <div class="border rounded p-3 text-center">
+          <span class="inline-block px-2 py-0.5 rounded text-xs font-medium {{ sc.status|filing_badge }}">{{ sc.status }}</span>
+          <div class="text-2xl font-bold mt-1">{{ sc.count|default:"0" }}</div>
+        </div>
+        {% empty %}
+        <div class="col-span-4 text-gray-500 text-sm">No filings found.</div>
+        {% endfor %}
       </div>
-      {% empty %}
-      <div class="col-span-4 text-gray-500 text-sm">No filings found.</div>
-      {% endfor %}
+      <div class="flex gap-6 text-sm text-gray-500">
+        <span>Total filings: {{ total_filings }}</span>
+        <span>Total people: {{ people_count }}</span>
+      </div>
     </div>
-    <div class="flex gap-6 text-sm text-gray-500">
-      <span>Total filings: {{ total_filings }}</span>
-      <span>Total people: {{ people_count }}</span>
+
+    <!-- Recent 990 Parse Jobs -->
+    <div class="bg-white rounded-lg shadow p-5">
+      <h2 class="text-lg font-semibold text-gray-900 mb-3">Recent 990 Parse Jobs</h2>
+      {% include "pipeline/partials/_recent_jobs_table.html" %}
     </div>
   </div>
 </div>

--- a/lavandula/dashboard/pipeline/templates/pipeline/classifier.html
+++ b/lavandula/dashboard/pipeline/templates/pipeline/classifier.html
@@ -1,5 +1,5 @@
 {% extends "pipeline/base.html" %}
-{% load pipeline_tags %}
+{% load humanize pipeline_tags %}
 {% block title %}Classifier — Lavandula Pipeline{% endblock %}
 {% block content %}
 <h1 class="text-2xl font-bold text-gray-900 mb-6">Classifier Controls</h1>
@@ -14,6 +14,9 @@
         <span class="w-3 h-3 rounded-full bg-blue-500 animate-pulse"></span>
         <span class="font-medium">Job #{{ running_job.pk }} running</span>
       </div>
+      {% if running_job.config_display %}
+      <div class="text-xs text-gray-500 mt-1 font-mono">{{ running_job.config_display|join:" | " }}</div>
+      {% endif %}
       {% elif process and process.status == "running" %}
       <div class="flex items-center gap-2 mb-2">
         <span class="w-3 h-3 rounded-full bg-green-500 animate-pulse"></span>
@@ -65,30 +68,53 @@
   </div>
 
   <!-- Results -->
-  <div class="lg:col-span-2 bg-white rounded-lg shadow p-5">
-    <h2 class="text-lg font-semibold text-gray-900 mb-3">Recent Classifications</h2>
-    {% if recent_results %}
-    <div class="overflow-x-auto">
-      <table class="w-full text-sm">
-        <thead><tr class="text-left text-gray-500 border-b">
-          <th class="pb-2">Filename</th><th class="pb-2">Org</th><th class="pb-2">Classification</th><th class="pb-2">Confidence</th><th class="pb-2">Archived</th>
-        </tr></thead>
-        <tbody>
-          {% for r in recent_results %}
-          <tr class="border-b hover:bg-gray-50">
-            <td class="py-2"><a href="{% url 'report_detail' r.content_sha256 %}" class="text-blue-600 hover:underline text-xs">{{ r.source_url_redacted|url_basename|truncatechars:40 }}</a></td>
-            <td class="py-2">{{ r.source_org_ein }}</td>
-            <td class="py-2">{{ r.classification }}</td>
-            <td class="py-2">{% if r.classification_confidence %}{{ r.classification_confidence|floatformat:2 }}{% else %}-{% endif %}</td>
-            <td class="py-2 text-gray-500 text-xs">{{ r.archived_at }}</td>
-          </tr>
-          {% endfor %}
-        </tbody>
-      </table>
+  <div class="lg:col-span-2 space-y-6">
+    <!-- Classify Stats by State -->
+    {% if classify_stats %}
+    <div class="bg-white rounded-lg shadow p-5">
+      <h2 class="text-lg font-semibold text-gray-900 mb-3">Classify Stats by State</h2>
+      <div class="flex flex-wrap gap-2">
+        {% for stat in classify_stats %}
+        <span class="px-2 py-1 rounded text-xs font-mono {% if stat.pct == 0 %}bg-gray-100 text-gray-500{% elif stat.pct < 80 %}bg-yellow-100 text-yellow-700{% else %}bg-green-100 text-green-700{% endif %}">
+          {{ stat.state }}: {{ stat.classified|intcomma }}/{{ stat.total_reports|intcomma }} ({{ stat.pct }}%)
+        </span>
+        {% endfor %}
+      </div>
     </div>
-    {% else %}
-    <p class="text-gray-500 text-sm">No recent classifications.</p>
     {% endif %}
+
+    <!-- Recent Classify Jobs -->
+    <div class="bg-white rounded-lg shadow p-5">
+      <h2 class="text-lg font-semibold text-gray-900 mb-3">Recent Classify Jobs</h2>
+      {% include "pipeline/partials/_recent_jobs_table.html" %}
+    </div>
+
+    <!-- Recent Classifications -->
+    <div class="bg-white rounded-lg shadow p-5">
+      <h2 class="text-lg font-semibold text-gray-900 mb-3">Recent Classifications</h2>
+      {% if recent_results %}
+      <div class="overflow-x-auto">
+        <table class="w-full text-sm">
+          <thead><tr class="text-left text-gray-500 border-b">
+            <th class="pb-2">Filename</th><th class="pb-2">Org</th><th class="pb-2">Classification</th><th class="pb-2">Confidence</th><th class="pb-2">Archived</th>
+          </tr></thead>
+          <tbody>
+            {% for r in recent_results %}
+            <tr class="border-b hover:bg-gray-50">
+              <td class="py-2"><a href="{% url 'report_detail' r.content_sha256 %}" class="text-blue-600 hover:underline text-xs">{{ r.source_url_redacted|url_basename|truncatechars:40 }}</a></td>
+              <td class="py-2">{{ r.source_org_ein }}</td>
+              <td class="py-2">{{ r.classification }}</td>
+              <td class="py-2">{% if r.classification_confidence %}{{ r.classification_confidence|floatformat:2 }}{% else %}-{% endif %}</td>
+              <td class="py-2 text-gray-500 text-xs">{{ r.archived_at }}</td>
+            </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      </div>
+      {% else %}
+      <p class="text-gray-500 text-sm">No recent classifications.</p>
+      {% endif %}
+    </div>
   </div>
 </div>
 {% endblock %}

--- a/lavandula/dashboard/pipeline/templates/pipeline/crawler.html
+++ b/lavandula/dashboard/pipeline/templates/pipeline/crawler.html
@@ -1,5 +1,5 @@
 {% extends "pipeline/base.html" %}
-{% load pipeline_tags %}
+{% load humanize pipeline_tags %}
 {% block title %}Crawler — Lavandula Pipeline{% endblock %}
 {% block content %}
 <h1 class="text-2xl font-bold text-gray-900 mb-6">Crawler Controls</h1>
@@ -16,6 +16,9 @@
         <span class="font-medium">Job #{{ running_job.pk }} running</span>
       </div>
       <div class="text-sm text-gray-500">PID: {{ running_job.pid|default:"-" }} | Started: {{ running_job.started_at|elapsed_since }} ago</div>
+      {% if running_job.config_display %}
+      <div class="text-xs text-gray-500 mt-1 font-mono">{{ running_job.config_display|join:" | " }}</div>
+      {% endif %}
       {% elif process and process.status == "running" %}
       <div class="flex items-center gap-2 mb-2">
         <span class="w-3 h-3 rounded-full bg-green-500 animate-pulse"></span>
@@ -69,6 +72,26 @@
 
   <!-- Results -->
   <div class="lg:col-span-2 space-y-6">
+    <!-- Crawled Orgs by State -->
+    {% if crawl_stats %}
+    <div class="bg-white rounded-lg shadow p-5">
+      <h2 class="text-lg font-semibold text-gray-900 mb-3">Crawled Orgs by State</h2>
+      <div class="flex flex-wrap gap-2">
+        {% for stat in crawl_stats %}
+        <span class="px-2 py-1 rounded text-xs font-mono {% if stat.pct == 0 %}bg-gray-100 text-gray-500{% elif stat.pct < 80 %}bg-yellow-100 text-yellow-700{% else %}bg-green-100 text-green-700{% endif %}">
+          {{ stat.state }}: {{ stat.crawled|intcomma }}/{{ stat.resolved|intcomma }} ({{ stat.pct }}%)
+        </span>
+        {% endfor %}
+      </div>
+    </div>
+    {% endif %}
+
+    <!-- Recent Crawl Jobs -->
+    <div class="bg-white rounded-lg shadow p-5">
+      <h2 class="text-lg font-semibold text-gray-900 mb-3">Recent Crawl Jobs</h2>
+      {% include "pipeline/partials/_recent_jobs_table.html" %}
+    </div>
+
     <!-- Recently Crawled Orgs -->
     <div class="bg-white rounded-lg shadow p-5">
       <h2 class="text-lg font-semibold text-gray-900 mb-3">Recently Crawled Orgs</h2>

--- a/lavandula/dashboard/pipeline/templates/pipeline/partials/_recent_jobs_table.html
+++ b/lavandula/dashboard/pipeline/templates/pipeline/partials/_recent_jobs_table.html
@@ -1,0 +1,32 @@
+{% load humanize pipeline_tags %}
+<div class="overflow-x-auto">
+  <table class="w-full text-sm">
+    <thead><tr class="text-left text-gray-500 border-b">
+      <th class="pb-2">ID</th>
+      {% if show_phase %}<th class="pb-2">Phase</th>{% endif %}
+      <th class="pb-2">State</th><th class="pb-2">Status</th><th class="pb-2">Exit</th><th class="pb-2">Progress</th><th class="pb-2">Duration</th><th class="pb-2">Created</th>
+    </tr></thead>
+    <tbody>
+      {% for job in recent_jobs %}
+      <tr class="border-b hover:bg-gray-50">
+        <td class="py-2"><a href="{% url 'job_detail' job.pk %}" class="text-blue-600 hover:underline">#{{ job.pk }}</a></td>
+        {% if show_phase %}<td class="py-2">{{ job.phase }}</td>{% endif %}
+        <td class="py-2">{{ job.state_code|default:"—" }}</td>
+        <td class="py-2">
+          {% if job.status == "running" %}<span class="text-blue-600">Running</span>
+          {% elif job.status == "completed" %}<span class="text-green-600">Completed</span>
+          {% elif job.status == "failed" %}<span class="text-red-600">Failed</span>
+          {% elif job.status == "pending" %}<span class="text-yellow-600">Pending</span>
+          {% else %}<span class="text-gray-500">{{ job.status }}</span>{% endif %}
+        </td>
+        <td class="py-2">{{ job.exit_code|default:"—" }}</td>
+        <td class="py-2">{% if job.progress_total %}{{ job.progress_current|intcomma }}/{{ job.progress_total|intcomma }}{% else %}—{% endif %}</td>
+        <td class="py-2">{{ job.duration_display|default:"—" }}</td>
+        <td class="py-2 text-gray-500 text-xs">{{ job.created_at|timesince }} ago</td>
+      </tr>
+      {% empty %}
+      <tr><td colspan="{% if show_phase %}8{% else %}7{% endif %}" class="px-2 py-4 text-center text-gray-400">No jobs yet</td></tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</div>

--- a/lavandula/dashboard/pipeline/templates/pipeline/partials/dashboard_stats.html
+++ b/lavandula/dashboard/pipeline/templates/pipeline/partials/dashboard_stats.html
@@ -1,71 +1,54 @@
-{% load pipeline_tags %}
-<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+{% load humanize pipeline_tags %}
 
-  <!-- Job Queue -->
-  <div class="bg-white rounded-lg shadow p-5">
-    <h2 class="text-sm font-semibold text-gray-500 uppercase mb-3">Job Queue</h2>
-    <div class="space-y-2">
-      <div class="flex justify-between"><span class="text-gray-600">Running</span><span class="font-bold text-blue-600">{{ jobs_running }}</span></div>
-      <div class="flex justify-between"><span class="text-gray-600">Pending</span><span class="font-bold text-yellow-600">{{ jobs_pending }}</span></div>
-      <div class="flex justify-between"><span class="text-gray-600">Completed</span><span class="font-bold text-green-600">{{ jobs_completed }}</span></div>
-      <div class="flex justify-between"><span class="text-gray-600">Failed</span><span class="font-bold text-red-600">{{ jobs_failed }}</span></div>
-    </div>
-    <a href="{% url 'job_list' %}" class="block mt-3 text-sm text-blue-600 hover:underline">View all jobs →</a>
+{% if running_jobs %}
+<div class="mb-6">
+  <h2 class="text-lg font-semibold text-gray-900 mb-3">Running Jobs</h2>
+  {% for job in running_jobs %}
+  <div class="flex items-center gap-3 p-3 bg-blue-50 border border-blue-200 rounded mb-2">
+    <span class="h-3 w-3 rounded-full bg-blue-500 animate-pulse flex-shrink-0"></span>
+    <span class="font-mono text-sm">
+      Job #{{ job.pk }} — {{ job.phase }} {{ job.state_code|default:"" }}
+      {% for param in job.config_display %} | {{ param }}{% endfor %}
+      | {{ job.elapsed }}
+    </span>
   </div>
-
-  <!-- Seed Pool -->
-  <div class="bg-white rounded-lg shadow p-5">
-    <h2 class="text-sm font-semibold text-gray-500 uppercase mb-3">Seed Pool</h2>
-    <div class="space-y-2">
-      <div class="flex justify-between"><span class="text-gray-600">Total Orgs</span><span class="font-bold">{{ seed_total }}</span></div>
-      {% for status, count in seed_by_status %}
-      <div class="flex justify-between"><span class="text-gray-600">{% if status == "unresolved" %}no website found{% elif status == "ambiguous" %}ambiguous (multiple matches){% else %}{{ status|default:"pending (not run)" }}{% endif %}</span><span class="font-medium">{{ count }}</span></div>
-      {% endfor %}
-    </div>
-  </div>
-
-  <!-- Resolver -->
-  <div class="bg-white rounded-lg shadow p-5">
-    <h2 class="text-sm font-semibold text-gray-500 uppercase mb-3">Resolver</h2>
-    <div class="space-y-2">
-      <div class="flex justify-between"><span class="text-gray-600">Resolved</span><span class="font-bold text-green-600">{{ resolver_resolved }}</span></div>
-      <div class="flex justify-between"><span class="text-gray-600">Unresolved</span><span class="font-bold text-gray-600">{{ resolver_unresolved }}</span></div>
-      {% for method, count in resolver_by_method %}
-      <div class="flex justify-between"><span class="text-gray-600 text-sm">{{ method }}</span><span class="font-medium text-sm">{{ count }}</span></div>
-      {% endfor %}
-    </div>
-  </div>
-
-  <!-- Crawler -->
-  <div class="bg-white rounded-lg shadow p-5">
-    <h2 class="text-sm font-semibold text-gray-500 uppercase mb-3">Crawler</h2>
-    <div class="space-y-2">
-      <div class="flex justify-between"><span class="text-gray-600">Orgs Crawled</span><span class="font-bold">{{ crawler_orgs }}</span></div>
-      <div class="flex justify-between"><span class="text-gray-600">Total Reports</span><span class="font-bold">{{ crawler_reports }}</span></div>
-    </div>
-  </div>
-
-  <!-- Classifier -->
-  <div class="bg-white rounded-lg shadow p-5">
-    <h2 class="text-sm font-semibold text-gray-500 uppercase mb-3">Classifier</h2>
-    <div class="space-y-2">
-      <div class="flex justify-between"><span class="text-gray-600">Classified</span><span class="font-bold text-green-600">{{ classifier_done }}</span></div>
-      <div class="flex justify-between"><span class="text-gray-600">Unclassified</span><span class="font-bold text-gray-600">{{ classifier_pending }}</span></div>
-      {% for cls, count in classifier_by_type %}
-      <div class="flex justify-between"><span class="text-gray-600 text-sm">{{ cls }}</span><span class="font-medium text-sm">{{ count }}</span></div>
-      {% endfor %}
-    </div>
-  </div>
-
-  <!-- Reports -->
-  <div class="bg-white rounded-lg shadow p-5">
-    <h2 class="text-sm font-semibold text-gray-500 uppercase mb-3">Reports</h2>
-    <div class="space-y-2">
-      <div class="flex justify-between"><span class="text-gray-600">Total Reports</span><span class="font-bold">{{ reports_total }}</span></div>
-      {% for year, count in reports_by_year %}
-      <div class="flex justify-between"><span class="text-gray-600 text-sm">{{ year|default:"Unknown" }}</span><span class="font-medium text-sm">{{ count }}</span></div>
-      {% endfor %}
-    </div>
-  </div>
-
+  {% endfor %}
 </div>
+{% endif %}
+
+<h2 class="text-lg font-semibold text-gray-900 mb-3">National Ingest Progress</h2>
+<div class="overflow-x-auto">
+  <table class="min-w-full text-sm">
+    <thead class="bg-gray-100">
+      <tr>
+        <th class="px-3 py-2 text-left">State</th>
+        <th class="px-3 py-2 text-right">Seeded</th>
+        <th class="px-3 py-2 text-right">Resolved</th>
+        <th class="px-3 py-2 text-right">Crawled</th>
+        <th class="px-3 py-2 text-right">Classified</th>
+        <th class="px-3 py-2 text-right">Reports</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for row in state_rows %}
+      <tr class="border-b {% if row.is_running %}border-l-4 border-l-blue-500 bg-blue-50{% elif row.is_pending %}border-l-4 border-l-yellow-500 bg-yellow-50{% endif %}">
+        <td class="px-3 py-2 font-medium">{{ row.state }}</td>
+        <td class="px-3 py-2 text-right">{{ row.seeded|intcomma }}</td>
+        <td class="px-3 py-2 text-right">
+          <span class="{% if row.resolved_pct == 0 %}text-gray-400{% elif row.resolved_pct < 80 %}text-yellow-600{% else %}text-green-600{% endif %}">
+            {{ row.resolved|intcomma }} / {{ row.seeded|intcomma }} ({{ row.resolved_pct }}%)
+          </span>
+        </td>
+        <td class="px-3 py-2 text-right">{{ row.crawled|intcomma }}</td>
+        <td class="px-3 py-2 text-right">{{ row.classified|intcomma }}</td>
+        <td class="px-3 py-2 text-right">{{ row.total_reports|intcomma }}</td>
+      </tr>
+      {% empty %}
+      <tr><td colspan="6" class="px-3 py-4 text-center text-gray-400">No states seeded yet</td></tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</div>
+
+<h2 class="text-lg font-semibold text-gray-900 mt-6 mb-3">Recent Jobs</h2>
+{% include "pipeline/partials/_recent_jobs_table.html" %}

--- a/lavandula/dashboard/pipeline/templates/pipeline/partials/dashboard_stats.html
+++ b/lavandula/dashboard/pipeline/templates/pipeline/partials/dashboard_stats.html
@@ -8,7 +8,7 @@
     <span class="h-3 w-3 rounded-full bg-blue-500 animate-pulse flex-shrink-0"></span>
     <span class="font-mono text-sm">
       Job #{{ job.pk }} — {{ job.phase }} {{ job.state_code|default:"" }}
-      {% for param in job.config_display %} | {{ param }}{% endfor %}
+      {% if job.config_display %} | {{ job.config_display|join:" | " }}{% endif %}
       | {{ job.elapsed }}
     </span>
   </div>

--- a/lavandula/dashboard/pipeline/templates/pipeline/phone_enrich.html
+++ b/lavandula/dashboard/pipeline/templates/pipeline/phone_enrich.html
@@ -68,6 +68,17 @@
       <h2 class="text-lg font-semibold text-gray-900 mb-3">Recent Phone Enrich Jobs</h2>
       {% include "pipeline/partials/_recent_jobs_table.html" %}
     </div>
+
+    <!-- About -->
+    <div class="bg-white rounded-lg shadow p-5">
+      <h2 class="text-lg font-semibold text-gray-900 mb-3">About</h2>
+      <p class="text-sm text-gray-600">
+        The phone enrichment pipeline finds phone numbers for resolved orgs by searching for
+        "{org name} {city} {state} phone number" and extracting US phone numbers from search
+        snippets. If no phone is found in snippets, it falls back to fetching the org's website
+        contact/about page.
+      </p>
+    </div>
   </div>
 </div>
 {% endblock %}

--- a/lavandula/dashboard/pipeline/templates/pipeline/phone_enrich.html
+++ b/lavandula/dashboard/pipeline/templates/pipeline/phone_enrich.html
@@ -1,5 +1,5 @@
 {% extends "pipeline/base.html" %}
-{% load pipeline_tags %}
+{% load humanize pipeline_tags %}
 {% block title %}Phone Enrichment — Lavandula Pipeline{% endblock %}
 {% block content %}
 <h1 class="text-2xl font-bold text-gray-900 mb-6">Phone Enrichment</h1>
@@ -15,6 +15,9 @@
         <span class="font-medium">Job #{{ running_job.pk }} running</span>
       </div>
       <div class="text-sm text-gray-500">PID: {{ running_job.pid|default:"-" }} | Started: {{ running_job.started_at|elapsed_since }} ago</div>
+      {% if running_job.config_display %}
+      <div class="text-xs text-gray-500 mt-1 font-mono">{{ running_job.config_display|join:" | " }}</div>
+      {% endif %}
       {% else %}
       <div class="flex items-center gap-2">
         <span class="w-3 h-3 rounded-full bg-gray-400"></span>
@@ -45,14 +48,26 @@
     </div>
   </div>
 
-  <div class="lg:col-span-2 bg-white rounded-lg shadow p-5">
-    <h2 class="text-lg font-semibold text-gray-900 mb-3">About</h2>
-    <p class="text-sm text-gray-600">
-      The phone enrichment pipeline finds phone numbers for resolved orgs by searching for
-      "{org name} {city} {state} phone number" and extracting US phone numbers from search
-      snippets. If no phone is found in snippets, it falls back to fetching the org's website
-      contact/about page.
-    </p>
+  <div class="lg:col-span-2 space-y-6">
+    <!-- Phone Stats by State -->
+    {% if phone_stats %}
+    <div class="bg-white rounded-lg shadow p-5">
+      <h2 class="text-lg font-semibold text-gray-900 mb-3">Phone Stats by State</h2>
+      <div class="flex flex-wrap gap-2">
+        {% for stat in phone_stats %}
+        <span class="px-2 py-1 rounded text-xs font-mono {% if stat.pct == 0 %}bg-gray-100 text-gray-500{% elif stat.pct < 80 %}bg-yellow-100 text-yellow-700{% else %}bg-green-100 text-green-700{% endif %}">
+          {{ stat.state }}: {{ stat.has_phone|intcomma }}/{{ stat.resolved|intcomma }} ({{ stat.pct }}%)
+        </span>
+        {% endfor %}
+      </div>
+    </div>
+    {% endif %}
+
+    <!-- Recent Phone Enrich Jobs -->
+    <div class="bg-white rounded-lg shadow p-5">
+      <h2 class="text-lg font-semibold text-gray-900 mb-3">Recent Phone Enrich Jobs</h2>
+      {% include "pipeline/partials/_recent_jobs_table.html" %}
+    </div>
   </div>
 </div>
 {% endblock %}

--- a/lavandula/dashboard/pipeline/templates/pipeline/resolver.html
+++ b/lavandula/dashboard/pipeline/templates/pipeline/resolver.html
@@ -1,5 +1,5 @@
 {% extends "pipeline/base.html" %}
-{% load pipeline_tags %}
+{% load humanize pipeline_tags %}
 {% block title %}Resolver — Lavandula Pipeline{% endblock %}
 {% block content %}
 <h1 class="text-2xl font-bold text-gray-900 mb-6">Resolver Controls</h1>
@@ -16,6 +16,9 @@
         <span class="font-medium">Job #{{ running_job.pk }} running</span>
       </div>
       <div class="text-sm text-gray-500">PID: {{ running_job.pid|default:"-" }} | Started: {{ running_job.started_at|elapsed_since }} ago</div>
+      {% if running_job.config_display %}
+      <div class="text-xs text-gray-500 mt-1 font-mono">{{ running_job.config_display|join:" | " }}</div>
+      {% endif %}
       {% else %}
       <div class="flex items-center gap-2">
         <span class="w-3 h-3 rounded-full bg-gray-400"></span>
@@ -43,36 +46,61 @@
   </div>
 
   <!-- Results -->
-  <div class="lg:col-span-2 bg-white rounded-lg shadow p-5">
-    <h2 class="text-lg font-semibold text-gray-900 mb-3">Recent Results</h2>
-    {% if recent_results %}
-    <div class="overflow-x-auto">
-      <table class="w-full text-sm">
-        <thead><tr class="text-left text-gray-500 border-b">
-          <th class="pb-2">EIN</th><th class="pb-2">Name</th><th class="pb-2">City</th><th class="pb-2">Status</th><th class="pb-2">Confidence</th><th class="pb-2">URL</th><th class="pb-2">Method</th><th class="pb-2">Updated</th>
-        </tr></thead>
-        <tbody>
-          {% for org in recent_results %}
-          <tr class="border-b hover:bg-gray-50">
-            <td class="py-2"><a href="{% url 'org_detail' org.ein %}" class="text-blue-600 hover:underline">{{ org.ein }}</a></td>
-            <td class="py-2 max-w-xs truncate">{{ org.name|default:"-" }}</td>
-            <td class="py-2">{{ org.city|default:"-" }}</td>
-            <td class="py-2">
-              {% if org.resolver_status == "resolved" %}<span class="text-green-600">{{ org.resolver_status }}</span>
-              {% else %}<span class="text-gray-500">{{ org.resolver_status|default:"-" }}</span>{% endif %}
-            </td>
-            <td class="py-2">{% if org.resolver_confidence %}{{ org.resolver_confidence|floatformat:2 }}{% else %}-{% endif %}</td>
-            <td class="py-2 max-w-xs truncate text-xs">{{ org.website_url|default:"-" }}</td>
-            <td class="py-2">{{ org.resolver_method|default:"-" }}</td>
-            <td class="py-2 text-gray-500 text-xs">{{ org.resolver_updated_at|timesince }} ago</td>
-          </tr>
-          {% endfor %}
-        </tbody>
-      </table>
+  <div class="lg:col-span-2 space-y-6">
+    <!-- Resolve Stats by State -->
+    {% if resolve_stats %}
+    <div class="bg-white rounded-lg shadow p-5">
+      <h2 class="text-lg font-semibold text-gray-900 mb-3">Resolve Stats by State</h2>
+      <div class="flex flex-wrap gap-2">
+        {% for stat in resolve_stats %}
+        {% if stat.total > 0 %}
+        <span class="px-2 py-1 rounded text-xs font-mono {% if stat.pct == 0 %}bg-gray-100 text-gray-500{% elif stat.pct < 80 %}bg-yellow-100 text-yellow-700{% else %}bg-green-100 text-green-700{% endif %}">
+          {{ stat.state }}: {{ stat.resolved|intcomma }}/{{ stat.total|intcomma }} ({{ stat.pct }}%)
+        </span>
+        {% endif %}
+        {% endfor %}
+      </div>
     </div>
-    {% else %}
-    <p class="text-gray-500 text-sm">No recent resolver results.</p>
     {% endif %}
+
+    <!-- Recent Resolve Jobs -->
+    <div class="bg-white rounded-lg shadow p-5">
+      <h2 class="text-lg font-semibold text-gray-900 mb-3">Recent Resolve Jobs</h2>
+      {% include "pipeline/partials/_recent_jobs_table.html" %}
+    </div>
+
+    <!-- Recent Results -->
+    <div class="bg-white rounded-lg shadow p-5">
+      <h2 class="text-lg font-semibold text-gray-900 mb-3">Recent Results</h2>
+      {% if recent_results %}
+      <div class="overflow-x-auto">
+        <table class="w-full text-sm">
+          <thead><tr class="text-left text-gray-500 border-b">
+            <th class="pb-2">EIN</th><th class="pb-2">Name</th><th class="pb-2">City</th><th class="pb-2">Status</th><th class="pb-2">Confidence</th><th class="pb-2">URL</th><th class="pb-2">Method</th><th class="pb-2">Updated</th>
+          </tr></thead>
+          <tbody>
+            {% for org in recent_results %}
+            <tr class="border-b hover:bg-gray-50">
+              <td class="py-2"><a href="{% url 'org_detail' org.ein %}" class="text-blue-600 hover:underline">{{ org.ein }}</a></td>
+              <td class="py-2 max-w-xs truncate">{{ org.name|default:"-" }}</td>
+              <td class="py-2">{{ org.city|default:"-" }}</td>
+              <td class="py-2">
+                {% if org.resolver_status == "resolved" %}<span class="text-green-600">{{ org.resolver_status }}</span>
+                {% else %}<span class="text-gray-500">{{ org.resolver_status|default:"-" }}</span>{% endif %}
+              </td>
+              <td class="py-2">{% if org.resolver_confidence %}{{ org.resolver_confidence|floatformat:2 }}{% else %}-{% endif %}</td>
+              <td class="py-2 max-w-xs truncate text-xs">{{ org.website_url|default:"-" }}</td>
+              <td class="py-2">{{ org.resolver_method|default:"-" }}</td>
+              <td class="py-2 text-gray-500 text-xs">{{ org.resolver_updated_at|timesince }} ago</td>
+            </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      </div>
+      {% else %}
+      <p class="text-gray-500 text-sm">No recent resolver results.</p>
+      {% endif %}
+    </div>
   </div>
 </div>
 {% endblock %}

--- a/lavandula/dashboard/pipeline/views.py
+++ b/lavandula/dashboard/pipeline/views.py
@@ -7,6 +7,7 @@ from django.db.models import Count, Q
 from django.http import HttpResponse, HttpResponseRedirect
 from django.shortcuts import get_object_or_404, redirect
 from django.urls import reverse
+from django.utils import timezone
 from django.views import View
 from django.views.generic import DetailView, ListView, TemplateView
 
@@ -72,6 +73,63 @@ def _expand_llm_preset(config: dict) -> dict:
 
 
 # ---------------------------------------------------------------------------
+# Shared helpers for job display
+# ---------------------------------------------------------------------------
+
+_CONFIG_ALLOWLIST = {
+    "seed": ["states", "target", "ntee_majors"],
+    "resolve": ["state", "search_engines", "llm_model", "brave_qps", "search_qps", "consumer_threads", "limit"],
+    "crawl": ["state", "limit"],
+    "classify": ["state", "llm_model", "definition", "limit", "re_classify"],
+    "enrich-phone": ["state", "search_engines", "limit"],
+    "990-index": ["filing_year"],
+    "990-parse": ["filing_year", "limit"],
+}
+
+
+def _format_job_config(job):
+    if not job or not job.config_json:
+        return []
+    allowed = _CONFIG_ALLOWLIST.get(job.phase, [])
+    parts = []
+    for key in allowed:
+        val = job.config_json.get(key)
+        if val is not None and val != "":
+            parts.append(f"{key}={val}")
+    return parts
+
+
+def _annotate_running_jobs(jobs):
+    now = timezone.now()
+    annotated = []
+    for job in jobs:
+        job.config_display = _format_job_config(job)
+        if job.started_at:
+            mins = int((now - job.started_at).total_seconds() // 60)
+            job.elapsed = f"{mins}m ago" if mins > 0 else "just started"
+        else:
+            job.elapsed = "pending"
+        annotated.append(job)
+    return annotated
+
+
+def _job_duration(job):
+    if job.finished_at and job.started_at:
+        total_secs = int((job.finished_at - job.started_at).total_seconds())
+        if total_secs < 60:
+            return f"{total_secs}s"
+        mins = total_secs // 60
+        return f"{mins}m {total_secs % 60}s"
+    return None
+
+
+def _annotate_recent_jobs(jobs):
+    for job in jobs:
+        job.duration_display = _job_duration(job)
+    return list(jobs)
+
+
+# ---------------------------------------------------------------------------
 # Dashboard
 # ---------------------------------------------------------------------------
 
@@ -94,56 +152,74 @@ class DashboardStatsPartial(HtmxLoginRequiredMixin, TemplateView):
 
 
 def _dashboard_stats():
-    stats = {}
-    stats["jobs_running"] = Job.objects.filter(status="running").count()
-    stats["jobs_pending"] = Job.objects.filter(status="pending").count()
-    stats["jobs_completed"] = Job.objects.filter(status="completed").count()
-    stats["jobs_failed"] = Job.objects.filter(status="failed").count()
+    from django.db import connections
 
-    stats["seed_total"] = NonprofitSeed.objects.count()
-    stats["seed_by_status"] = list(
-        NonprofitSeed.objects.values_list("resolver_status")
-        .annotate(c=Count("ein"))
-        .order_by("-c")[:10]
+    with connections["pipeline"].cursor() as cursor:
+        cursor.execute("""
+            SELECT
+                s.state,
+                COUNT(*) as seeded,
+                SUM(CASE WHEN s.resolver_status = 'resolved' THEN 1 ELSE 0 END) as resolved,
+                COUNT(DISTINCT co.ein) as crawled,
+                SUM(CASE WHEN s.phone IS NOT NULL AND s.phone != '' THEN 1 ELSE 0 END) as has_phone
+            FROM nonprofits_seed s
+            LEFT JOIN crawled_orgs co ON s.ein = co.ein
+            GROUP BY s.state
+            ORDER BY COUNT(*) DESC
+        """)
+        columns = [col[0] for col in cursor.description]
+        state_rows = [dict(zip(columns, row)) for row in cursor.fetchall()]
+
+        cursor.execute("""
+            SELECT
+                s.state,
+                COUNT(DISTINCT c.content_sha256) as total_reports,
+                COUNT(DISTINCT CASE WHEN c.classification IS NOT NULL THEN c.content_sha256 END) as classified
+            FROM nonprofits_seed s
+            JOIN corpus c ON s.ein = c.source_org_ein
+            GROUP BY s.state
+        """)
+        report_rows = {row[0]: {"total_reports": row[1], "classified": row[2]} for row in cursor.fetchall()}
+
+    for row in state_rows:
+        rpt = report_rows.get(row["state"], {})
+        row["total_reports"] = rpt.get("total_reports", 0)
+        row["classified"] = rpt.get("classified", 0)
+        row["resolved_pct"] = round(row["resolved"] / row["seeded"] * 100) if row["seeded"] > 0 else 0
+
+    running_jobs = _annotate_running_jobs(
+        Job.objects.filter(status="running").select_related()
     )
 
-    stats["resolver_resolved"] = NonprofitSeed.objects.filter(
-        resolver_status="resolved"
-    ).count()
-    stats["resolver_unresolved"] = NonprofitSeed.objects.exclude(
-        resolver_status="resolved"
-    ).count()
-    stats["resolver_by_method"] = list(
-        NonprofitSeed.objects.filter(resolver_method__isnull=False)
-        .values_list("resolver_method")
-        .annotate(c=Count("ein"))
-        .order_by("-c")[:10]
-    )
+    running_states = set()
+    pending_states = set()
+    for job in Job.objects.filter(status__in=["running", "pending"]):
+        if job.state_code:
+            if job.status == "running":
+                running_states.add(job.state_code)
+            else:
+                pending_states.add(job.state_code)
 
-    stats["crawler_orgs"] = CrawledOrg.objects.count()
-    stats["crawler_reports"] = Report.objects.count()
+    def sort_key(r):
+        if r["state"] in running_states:
+            return (0, -r["seeded"])
+        if r["state"] in pending_states:
+            return (1, -r["seeded"])
+        return (2, -r["seeded"])
 
-    stats["classifier_done"] = Report.objects.filter(
-        classification__isnull=False
-    ).count()
-    stats["classifier_pending"] = Report.objects.filter(
-        classification__isnull=True
-    ).count()
-    stats["classifier_by_type"] = list(
-        Report.objects.filter(classification__isnull=False)
-        .values_list("classification")
-        .annotate(c=Count("content_sha256"))
-        .order_by("-c")[:10]
-    )
+    state_rows.sort(key=sort_key)
+    for row in state_rows:
+        row["is_running"] = row["state"] in running_states
+        row["is_pending"] = row["state"] in pending_states
 
-    stats["reports_total"] = Report.objects.count()
-    stats["reports_by_year"] = list(
-        Report.objects.values_list("report_year")
-        .annotate(c=Count("content_sha256"))
-        .order_by("-report_year")[:10]
-    )
+    recent_jobs = _annotate_recent_jobs(Job.objects.order_by("-created_at")[:10])
 
-    return stats
+    return {
+        "state_rows": state_rows,
+        "running_jobs": running_jobs,
+        "recent_jobs": recent_jobs,
+        "show_phase": True,
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -371,11 +447,28 @@ class ResolverView(LoginRequiredMixin, TemplateView):
 
     def get_context_data(self, **kwargs):
         ctx = super().get_context_data(**kwargs)
-        ctx["running_job"] = Job.objects.filter(phase="resolve", status="running").first()
+        running = Job.objects.filter(phase="resolve", status="running").first()
+        if running:
+            running = _annotate_running_jobs([running])[0]
+        ctx["running_job"] = running
         ctx["pending_job"] = Job.objects.filter(phase="resolve", status="pending").first()
         ctx["recent_results"] = NonprofitSeed.objects.filter(
             resolver_updated_at__isnull=False
         ).order_by("-resolver_updated_at")[:50]
+        ctx["recent_jobs"] = _annotate_recent_jobs(
+            Job.objects.filter(phase="resolve").order_by("-created_at")[:20]
+        )
+        resolve_stats = list(
+            NonprofitSeed.objects.values("state")
+            .annotate(
+                total=Count("ein"),
+                resolved=Count("ein", filter=models.Q(resolver_status="resolved")),
+            )
+            .order_by("state")
+        )
+        for stat in resolve_stats:
+            stat["pct"] = round(stat["resolved"] / stat["total"] * 100) if stat["total"] > 0 else 0
+        ctx["resolve_stats"] = resolve_stats
         from .forms import ResolverForm
         ctx["form"] = ResolverForm()
         return ctx
@@ -390,9 +483,31 @@ class CrawlerView(LoginRequiredMixin, TemplateView):
             ctx["process"] = check_process("crawl")
         except PipelineProcess.DoesNotExist:
             ctx["process"] = None
-        ctx["running_job"] = Job.objects.filter(phase="crawl", status="running").first()
+        running = Job.objects.filter(phase="crawl", status="running").first()
+        if running:
+            running = _annotate_running_jobs([running])[0]
+        ctx["running_job"] = running
         ctx["recent_orgs"] = CrawledOrg.objects.order_by("-last_crawled_at")[:50]
         ctx["recent_reports"] = Report.objects.order_by("-archived_at")[:50]
+        ctx["recent_jobs"] = _annotate_recent_jobs(
+            Job.objects.filter(phase="crawl").order_by("-created_at")[:20]
+        )
+        from django.db import connections
+        with connections["pipeline"].cursor() as cursor:
+            cursor.execute("""
+                SELECT s.state,
+                       SUM(CASE WHEN s.resolver_status = 'resolved' THEN 1 ELSE 0 END) as resolved,
+                       COUNT(DISTINCT co.ein) as crawled
+                FROM nonprofits_seed s
+                LEFT JOIN crawled_orgs co ON s.ein = co.ein
+                WHERE s.resolver_status = 'resolved'
+                GROUP BY s.state ORDER BY s.state
+            """)
+            crawl_stats = []
+            for row in cursor.fetchall():
+                pct = round(row[2] / row[1] * 100) if row[1] > 0 else 0
+                crawl_stats.append({"state": row[0], "resolved": row[1], "crawled": row[2], "pct": pct})
+        ctx["crawl_stats"] = crawl_stats
         from .forms import CrawlerForm, RunCrawlForm
         ctx["form"] = CrawlerForm()
         ctx["crawl_job_form"] = RunCrawlForm()
@@ -408,10 +523,31 @@ class ClassifierView(LoginRequiredMixin, TemplateView):
             ctx["process"] = check_process("classify")
         except PipelineProcess.DoesNotExist:
             ctx["process"] = None
-        ctx["running_job"] = Job.objects.filter(phase="classify", status="running").first()
+        running = Job.objects.filter(phase="classify", status="running").first()
+        if running:
+            running = _annotate_running_jobs([running])[0]
+        ctx["running_job"] = running
         ctx["recent_results"] = Report.objects.filter(
             classification__isnull=False
         ).order_by("-archived_at")[:50]
+        ctx["recent_jobs"] = _annotate_recent_jobs(
+            Job.objects.filter(phase="classify").order_by("-created_at")[:20]
+        )
+        from django.db import connections
+        with connections["pipeline"].cursor() as cursor:
+            cursor.execute("""
+                SELECT s.state,
+                       COUNT(DISTINCT c.content_sha256) as total_reports,
+                       COUNT(DISTINCT CASE WHEN c.classification IS NOT NULL THEN c.content_sha256 END) as classified
+                FROM nonprofits_seed s
+                JOIN corpus c ON s.ein = c.source_org_ein
+                GROUP BY s.state ORDER BY s.state
+            """)
+            classify_stats = []
+            for row in cursor.fetchall():
+                pct = round(row[2] / row[1] * 100) if row[1] > 0 else 0
+                classify_stats.append({"state": row[0], "total_reports": row[1], "classified": row[2], "pct": pct})
+        ctx["classify_stats"] = classify_stats
         from .forms import ClassifierForm
         ctx["form"] = ClassifierForm()
         return ctx
@@ -575,8 +711,14 @@ class EnrichIndexView(LoginRequiredMixin, TemplateView):
 
     def get_context_data(self, **kwargs):
         ctx = super().get_context_data(**kwargs)
-        ctx["running_job"] = Job.objects.filter(phase="990-index", status="running").first()
+        running = Job.objects.filter(phase="990-index", status="running").first()
+        if running:
+            running = _annotate_running_jobs([running])[0]
+        ctx["running_job"] = running
         ctx["pending_job"] = Job.objects.filter(phase="990-index", status="pending").first()
+        ctx["recent_jobs"] = _annotate_recent_jobs(
+            Job.objects.filter(phase="990-index").order_by("-created_at")[:20]
+        )
         from .forms import EnrichIndexForm
         ctx["form"] = EnrichIndexForm()
 
@@ -637,8 +779,14 @@ class EnrichParseView(LoginRequiredMixin, TemplateView):
 
     def get_context_data(self, **kwargs):
         ctx = super().get_context_data(**kwargs)
-        ctx["running_job"] = Job.objects.filter(phase="990-parse", status="running").first()
+        running = Job.objects.filter(phase="990-parse", status="running").first()
+        if running:
+            running = _annotate_running_jobs([running])[0]
+        ctx["running_job"] = running
         ctx["pending_job"] = Job.objects.filter(phase="990-parse", status="pending").first()
+        ctx["recent_jobs"] = _annotate_recent_jobs(
+            Job.objects.filter(phase="990-parse").order_by("-created_at")[:20]
+        )
         from .forms import EnrichParseForm
         ctx["form"] = EnrichParseForm()
 
@@ -692,7 +840,10 @@ class PhoneEnrichView(LoginRequiredMixin, TemplateView):
 
     def get_context_data(self, **kwargs):
         ctx = super().get_context_data(**kwargs)
-        ctx["running_job"] = Job.objects.filter(phase="enrich-phone", status="running").first()
+        running = Job.objects.filter(phase="enrich-phone", status="running").first()
+        if running:
+            running = _annotate_running_jobs([running])[0]
+        ctx["running_job"] = running
         ctx["pending_job"] = Job.objects.filter(phase="enrich-phone", status="pending").first()
         from .forms import PhoneEnrichForm
         ctx["form"] = PhoneEnrichForm()
@@ -700,6 +851,21 @@ class PhoneEnrichView(LoginRequiredMixin, TemplateView):
         ctx["resolved_no_phone"] = NonprofitSeed.objects.filter(
             resolver_status="resolved", phone__isnull=True,
         ).count()
+        ctx["recent_jobs"] = _annotate_recent_jobs(
+            Job.objects.filter(phase="enrich-phone").order_by("-created_at")[:20]
+        )
+        phone_stats = list(
+            NonprofitSeed.objects.filter(resolver_status="resolved")
+            .values("state")
+            .annotate(
+                resolved=Count("ein"),
+                has_phone=Count("ein", filter=models.Q(phone__isnull=False) & ~models.Q(phone="")),
+            )
+            .order_by("state")
+        )
+        for stat in phone_stats:
+            stat["pct"] = round(stat["has_phone"] / stat["resolved"] * 100) if stat["resolved"] > 0 else 0
+        ctx["phone_stats"] = phone_stats
         return ctx
 
 

--- a/lavandula/dashboard/pipeline/views.py
+++ b/lavandula/dashboard/pipeline/views.py
@@ -188,7 +188,7 @@ def _dashboard_stats():
         row["resolved_pct"] = round(row["resolved"] / row["seeded"] * 100) if row["seeded"] > 0 else 0
 
     running_jobs = _annotate_running_jobs(
-        Job.objects.filter(status="running").select_related()
+        Job.objects.filter(status="running")
     )
 
     running_states = set()


### PR DESCRIPTION
## Summary

- **Dashboard rewrite**: Replace 6 aggregate summary cards with a state × pipeline-stage progress table (one row per seeded state, columns for seeded/resolved/crawled/classified/reports). Running jobs section above table with config params. Recent jobs table below.
- **Phase page parity**: Add stats-by-state pill grids and recent jobs tables to resolver, classifier, crawler, and phone enrich pages. Add recent jobs tables to 990 index and 990 parse pages.
- **Running job config display**: All pages now show allowlisted config params (engine, model, QPS, etc.) on running jobs instead of raw JSON. Security: only keys from a per-phase allowlist are surfaced.

## Files changed

| File | Change |
|------|--------|
| `settings.py` | Add `django.contrib.humanize` to INSTALLED_APPS |
| `views.py` | Config/duration helpers, rewrite `_dashboard_stats()`, add context to 6 views |
| `partials/dashboard_stats.html` | Rewrite: state progress table + running/recent jobs |
| `partials/_recent_jobs_table.html` | **New**: shared recent jobs table partial |
| `resolver.html` | Add stats pills + recent jobs + config on running job |
| `classifier.html` | Add stats pills + recent jobs + config on running job |
| `crawler.html` | Add stats pills + recent jobs + config on running job (preserves existing orgs/reports tables) |
| `phone_enrich.html` | Add stats pills + recent jobs + config on running job |
| `990_index.html` | Add recent jobs + config on running job (preserves existing refresh history) |
| `990_parse.html` | Add recent jobs + config on running job (preserves existing filing/people counts) |

## Test plan

- [ ] Dashboard loads with state progress table, running jobs, recent jobs
- [ ] HTMX 5s auto-refresh still works on dashboard (check Network tab)
- [ ] Each phase page shows stats + recent jobs alongside existing content
- [ ] Running job config params display correctly for each phase
- [ ] Empty state (no jobs, no data) doesn't break any page
- [ ] Numbers cross-check: dashboard Resolved column matches resolver page stats
- [ ] No new migration files created

🤖 Generated with [Claude Code](https://claude.com/claude-code)