### PR TITLE
[Spec 0034] Pipeline control plane and org provenance

### DIFF
--- a/lavandula/dashboard/pipeline/management/commands/backfill_provenance.py
+++ b/lavandula/dashboard/pipeline/management/commands/backfill_provenance.py
@@ -1,0 +1,102 @@
+"""
+One-time backfill of org_provenance from existing pipeline tables.
+
+Reads nonprofits_seed, crawled_orgs, and corpus to populate initial provenance state.
+Idempotent: uses INSERT ON CONFLICT DO NOTHING for initial rows, then UPDATEs.
+"""
+from django.core.management.base import BaseCommand
+from django.db import connection
+
+
+class Command(BaseCommand):
+    help = "Backfill org_provenance table from existing pipeline data"
+
+    def add_arguments(self, parser):
+        parser.add_argument("--dry-run", action="store_true", help="Show SQL without executing")
+
+    def handle(self, *args, **options):
+        dry_run = options["dry_run"]
+        steps = [
+            ("seed", self._backfill_seed),
+            ("resolve", self._backfill_resolve),
+            ("crawl", self._backfill_crawl),
+            ("classify", self._backfill_classify),
+        ]
+
+        for name, fn in steps:
+            self.stdout.write(f"Backfilling {name}...")
+            count = fn(dry_run)
+            self.stdout.write(f"  {name}: {count} rows affected")
+
+        self.stdout.write(self.style.SUCCESS("Backfill complete."))
+
+    def _backfill_seed(self, dry_run: bool) -> int:
+        sql = """
+        INSERT INTO lava_pipeline.org_provenance (ein, seed_status, seed_completed_at, updated_at)
+        SELECT ein, 'completed', COALESCE(resolver_updated_at, NOW()), NOW()
+        FROM lava_impact.nonprofits_seed
+        ON CONFLICT (ein) DO NOTHING
+        """
+        return self._execute(sql, dry_run)
+
+    def _backfill_resolve(self, dry_run: bool) -> int:
+        sql = """
+        UPDATE lava_pipeline.org_provenance p SET
+            resolve_status = CASE
+                WHEN s.resolver_status IN ('resolved', 'accepted') THEN 'completed'
+                WHEN s.resolver_status IN ('rejected', 'error') THEN 'failed'
+                WHEN s.resolver_status IS NOT NULL THEN 'in_progress'
+                ELSE 'not_started'
+            END,
+            resolve_completed_at = CASE
+                WHEN s.resolver_status IN ('resolved', 'accepted') THEN s.resolver_updated_at
+                ELSE NULL
+            END,
+            updated_at = NOW()
+        FROM lava_impact.nonprofits_seed s
+        WHERE p.ein = s.ein
+        """
+        return self._execute(sql, dry_run)
+
+    def _backfill_crawl(self, dry_run: bool) -> int:
+        sql = """
+        UPDATE lava_pipeline.org_provenance p SET
+            crawl_status = CASE
+                WHEN co.ein IS NOT NULL THEN 'completed'
+                ELSE 'not_started'
+            END,
+            crawl_completed_at = CASE
+                WHEN co.ein IS NOT NULL THEN co.last_crawled_at::timestamptz
+                ELSE NULL
+            END,
+            updated_at = NOW()
+        FROM lava_pipeline.org_provenance p2
+        LEFT JOIN lava_impact.crawled_orgs co ON p2.ein = co.ein
+        WHERE p.ein = p2.ein
+        """
+        return self._execute(sql, dry_run)
+
+    def _backfill_classify(self, dry_run: bool) -> int:
+        sql = """
+        UPDATE lava_pipeline.org_provenance p SET
+            classify_status = CASE
+                WHEN NOT EXISTS (
+                    SELECT 1 FROM lava_corpus.corpus c WHERE c.source_org_ein = p.ein
+                ) THEN 'not_applicable'
+                WHEN NOT EXISTS (
+                    SELECT 1 FROM lava_corpus.corpus c
+                    WHERE c.source_org_ein = p.ein AND c.material_type IS NULL
+                ) THEN 'completed'
+                ELSE 'in_progress'
+            END,
+            updated_at = NOW()
+        """
+        return self._execute(sql, dry_run)
+
+    def _execute(self, sql: str, dry_run: bool) -> int:
+        if dry_run:
+            self.stdout.write(f"  [DRY RUN] {sql.strip()[:100]}...")
+            return 0
+        with connection.cursor() as cursor:
+            cursor.execute(sql)
+            return cursor.rowcount or 0

--- a/lavandula/dashboard/pipeline/management/commands/run_orchestrator.py
+++ b/lavandula/dashboard/pipeline/management/commands/run_orchestrator.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import os
 import signal
 import socket
@@ -8,20 +9,20 @@ import sys
 import time
 
 from django.core.management.base import BaseCommand
+from django.db import connection
 from django.utils import timezone
 
-from pipeline.models import CrawledOrg, Job, NonprofitSeed, Report, Worker
-from pipeline.orchestrator import (
-    LOG_DIR,
-    PROJECT_ROOT,
-    build_argv,
-    check_phase_conflict,
-    get_eligible_jobs,
-)
+from pipeline.models import Job, Worker
+from pipeline.orchestrator import LOG_DIR, PROJECT_ROOT, get_eligible_jobs
+from pipeline.param_validators import build_argv_for_phase, ValidationError
+from pipeline.stages import STAGE_REGISTRY
+
+logger = logging.getLogger("pipeline.orchestrator")
 
 POLL_INTERVAL = 10
 HEARTBEAT_STALE_THRESHOLD = 300
 HEARTBEAT_OFFLINE_THRESHOLD = 1800
+ADVISORY_LOCK_ID = 34001
 
 
 class Command(BaseCommand):
@@ -35,13 +36,19 @@ class Command(BaseCommand):
         self.hostname = socket.gethostname()
         self.stdout.write(f"Orchestrator starting on {self.hostname}")
 
+        if not self._acquire_advisory_lock():
+            self.stderr.write(
+                "Another orchestrator instance is running (advisory lock held). Exiting."
+            )
+            sys.exit(1)
+
         signal.signal(signal.SIGTERM, self._signal_handler)
         signal.signal(signal.SIGINT, self._signal_handler)
 
         LOG_DIR.mkdir(parents=True, exist_ok=True)
 
         self._register_worker()
-        self._recover_orphaned_jobs()
+        self._crash_recovery()
 
         self._tracked: dict[int, subprocess.Popen] = {}
 
@@ -54,6 +61,14 @@ class Command(BaseCommand):
 
         self._shutdown_worker()
         self.stdout.write("Orchestrator shutting down")
+
+    def _acquire_advisory_lock(self) -> bool:
+        if connection.vendor != "postgresql":
+            return True
+        with connection.cursor() as cur:
+            cur.execute("SELECT pg_try_advisory_lock(%s)", [ADVISORY_LOCK_ID])
+            row = cur.fetchone()
+            return row[0] if row else False
 
     def _signal_handler(self, signum, frame):
         self._shutdown = True
@@ -115,20 +130,31 @@ class Command(BaseCommand):
         except Exception:
             return None
 
-    def _recover_orphaned_jobs(self):
-        """On startup, mark dead running jobs as failed."""
-        orphans = Job.objects.filter(status="running", host=self.hostname)
-        for job in orphans:
-            if job.pid and self._is_pid_alive(job.pid):
+    def _crash_recovery(self):
+        """On startup, recover from unclean shutdown."""
+        now = timezone.now()
+
+        # Scheduled jobs (picked up but never spawned) -> reset to pending
+        scheduled = Job.objects.filter(status="scheduled", host=self.hostname)
+        for job in scheduled:
+            job.status = "pending"
+            job.blocked_reason = None
+            job.save(update_fields=["status", "blocked_reason"])
+            self.stdout.write(f"Reset scheduled Job #{job.pk} to pending (orchestrator restart)")
+
+        # Running jobs -> reconcile via PID + start time
+        running = Job.objects.filter(status="running", host=self.hostname)
+        for job in running:
+            if job.pid and self._is_pid_alive_with_start_time(job):
+                self.stdout.write(f"Job #{job.pk} still running (PID {job.pid}), resuming tracking")
                 continue
             job.status = "failed"
-            job.error_message = "orphaned: PID not found on restart"
-            job.finished_at = timezone.now()
+            job.error_message = "orphaned: PID not found or start time mismatch on restart"
+            job.finished_at = now
             job.save(update_fields=["status", "error_message", "finished_at"])
             self.stdout.write(f"Marked orphaned Job #{job.pk} as failed")
 
     def _poll_running_jobs(self):
-        """Check on tracked subprocesses and update heartbeats."""
         running = Job.objects.filter(status="running", host=self.hostname)
         for job in running:
             proc = self._tracked.get(job.pk)
@@ -150,18 +176,35 @@ class Command(BaseCommand):
                     self._save_with_retry(job, ["status", "error_message", "finished_at"])
 
     def _start_eligible_jobs(self):
-        """Pick and start the next eligible job."""
         eligible = get_eligible_jobs(self.hostname)
+        from pipeline.orchestrator import check_phase_conflict
+
         for job in eligible[:3]:
             if check_phase_conflict(job.phase, job.state_code):
+                reason = f"Phase conflict: {job.phase} already running"
+                if job.state_code:
+                    reason += f" for {job.state_code}"
+                self._update_blocked_reason(job, reason)
                 continue
+
+            self._clear_blocked_reason(job)
             self._launch_job(job)
 
     def _launch_job(self, job: Job):
-        """Spawn a subprocess for the job."""
+        # Transition to scheduled
+        job.status = "scheduled"
+        job.save(update_fields=["status"])
+
+        # Build argv using registry (fall back to legacy COMMAND_MAP)
         try:
-            argv = build_argv(job.phase, job.config_json)
-        except Exception as exc:
+            if job.phase in STAGE_REGISTRY:
+                from pipeline.param_validators import build_argv
+                argv = build_argv(STAGE_REGISTRY[job.phase], job.config_json)
+            else:
+                from pipeline.orchestrator import build_argv as legacy_build_argv
+                argv = legacy_build_argv(job.phase, job.config_json)
+                logger.warning("Stage '%s' not in STAGE_REGISTRY, using legacy COMMAND_MAP", job.phase)
+        except (ValidationError, Exception) as exc:
             job.status = "failed"
             job.error_message = f"Command build error: {exc}"
             job.finished_at = timezone.now()
@@ -192,14 +235,17 @@ class Command(BaseCommand):
             self.stderr.write(f"Failed to spawn Job #{job.pk}: {exc}")
             return
 
+        now = timezone.now()
         job.status = "running"
         job.pid = proc.pid
-        job.started_at = timezone.now()
-        job.last_heartbeat = timezone.now()
+        job.started_at = now
+        job.started_at_precise = now
+        job.last_heartbeat = now
         job.log_file = str(log_path)
         job.progress_total = self._init_progress_total(job)
         job.save(update_fields=[
-            "status", "pid", "started_at", "last_heartbeat", "log_file", "progress_total",
+            "status", "pid", "started_at", "started_at_precise",
+            "last_heartbeat", "log_file", "progress_total",
         ])
 
         self._tracked[job.pk] = proc
@@ -214,16 +260,14 @@ class Command(BaseCommand):
     }
 
     def _finish_job(self, job: Job, exit_code: int):
-        """Mark a job as completed or failed based on exit code."""
-        if exit_code == 3:
-            job.status = "pending"
-            job.pid = None
-            job.started_at = None
-            job.log_file = None
-            job.log_tail = None
-            self._save_with_retry(job, ["status", "pid", "started_at", "log_file", "log_tail"])
-            self.stdout.write(f"Job #{job.pk} returned exit 3 (lock busy), re-queued")
-            return
+        stage = STAGE_REGISTRY.get(job.phase)
+
+        # Check if this exit code is retryable
+        if stage and stage.retry_policy.auto_retry and exit_code in stage.retry_policy.retryable_exit_codes:
+            if job.attempt_number < stage.retry_policy.max_attempts:
+                self._retry_job(job, exit_code, stage.retry_policy)
+                return
+
         job.status = "completed" if exit_code == 0 else "failed"
         job.exit_code = exit_code
         job.finished_at = timezone.now()
@@ -242,8 +286,61 @@ class Command(BaseCommand):
                     job.log_tail = f.read().decode("utf-8", errors="replace")[-16_384:]
             except OSError:
                 pass
-        self._save_with_retry(job, ["status", "exit_code", "finished_at", "error_message", "log_tail"])
+        self._save_with_retry(job, [
+            "status", "exit_code", "finished_at", "error_message", "log_tail",
+        ])
         self.stdout.write(f"Job #{job.pk} finished: {job.status} (exit {exit_code})")
+
+    def _retry_job(self, failed_job: Job, exit_code: int, retry_policy):
+        """Create a retry clone of a failed job and rebound dependents."""
+        from django.db import transaction
+
+        failed_job.status = "failed"
+        failed_job.exit_code = exit_code
+        failed_job.finished_at = timezone.now()
+        hint = self._EXIT_CODE_HINTS.get(exit_code, "unknown error")
+        failed_job.error_message = f"Exit {exit_code}: {hint} (auto-retrying)"
+        self._save_with_retry(failed_job, [
+            "status", "exit_code", "finished_at", "error_message",
+        ])
+
+        with transaction.atomic():
+            retry_job = Job.objects.create(
+                state_code=failed_job.state_code,
+                phase=failed_job.phase,
+                status="pending",
+                host=failed_job.host,
+                config_json=failed_job.config_json,
+                retry_of=failed_job,
+                attempt_number=failed_job.attempt_number + 1,
+            )
+            # Rebound pending dependents to the retry job
+            rebound_count = Job.objects.filter(
+                depends_on=failed_job, status="pending"
+            ).update(depends_on=retry_job)
+
+        self.stdout.write(
+            f"Job #{failed_job.pk} failed (exit {exit_code}), "
+            f"auto-retry as Job #{retry_job.pk} "
+            f"(attempt {retry_job.attempt_number}/{retry_policy.max_attempts}), "
+            f"{rebound_count} dependent(s) rebound"
+        )
+
+    def _update_blocked_reason(self, job: Job, reason: str):
+        if job.blocked_reason != reason:
+            job.blocked_reason = reason
+            try:
+                job.save(update_fields=["blocked_reason"])
+            except Exception:
+                pass
+
+    def _clear_blocked_reason(self, job: Job):
+        if job.blocked_reason:
+            job.blocked_reason = None
+            try:
+                job.save(update_fields=["blocked_reason"])
+            except Exception:
+                pass
 
     def _update_heartbeat(self, job: Job):
         job.last_heartbeat = timezone.now()
@@ -262,7 +359,6 @@ class Command(BaseCommand):
             pass
 
     def _save_with_retry(self, job: Job, fields: list[str]):
-        """Save job state, retry once on failure, kill process on second failure."""
         try:
             job.save(update_fields=fields)
         except Exception:
@@ -280,10 +376,16 @@ class Command(BaseCommand):
                     except (ProcessLookupError, PermissionError):
                         pass
 
-    @staticmethod
-    def _init_progress_total(job: Job):
-        """Set progress_total at job start based on phase."""
+    def _init_progress_total(self, job: Job):
+        stage = STAGE_REGISTRY.get(job.phase)
+        if stage and stage.progress_estimator:
+            try:
+                return stage.progress_estimator(job.config_json)
+            except Exception:
+                pass
+        # Legacy fallback
         try:
+            from pipeline.models import CrawledOrg, NonprofitSeed, Report
             if job.phase == "resolve" and job.state_code:
                 return NonprofitSeed.objects.filter(
                     state=job.state_code,
@@ -298,6 +400,24 @@ class Command(BaseCommand):
             pass
         return None
 
+    def _is_pid_alive_with_start_time(self, job: Job) -> bool:
+        """Check PID is alive AND started at approximately the right time."""
+        if not job.pid:
+            return False
+        if not self._is_pid_alive(job.pid):
+            return False
+        if not job.started_at_precise:
+            return self._is_pid_alive(job.pid)
+        try:
+            stat_path = f"/proc/{job.pid}/stat"
+            with open(stat_path) as f:
+                stat_content = f.read()
+            # Field 22 (0-indexed from after the comm field) is starttime in clock ticks
+            # For basic validation, just confirm the process exists and PID matches
+            return True
+        except (OSError, IndexError, ValueError):
+            return self._is_pid_alive(job.pid)
+
     _LOG_NOISE = frozenset([
         "Ignoring wrong pointing object",
         "do_cmap",
@@ -307,7 +427,6 @@ class Command(BaseCommand):
     _ERROR_SIGNALS = ("ERROR", "Exception", "Traceback", "CRITICAL", "FATAL", "failed", "Error:")
 
     def _extract_last_meaningful_line(self, job: Job) -> str | None:
-        """Extract last error line from log_tail, falling back to None if only progress lines."""
         tail = job.log_tail
         if not tail:
             if job.log_file:

--- a/lavandula/dashboard/pipeline/management/commands/run_orchestrator.py
+++ b/lavandula/dashboard/pipeline/management/commands/run_orchestrator.py
@@ -12,9 +12,13 @@ from django.core.management.base import BaseCommand
 from django.db import connection
 from django.utils import timezone
 
-from pipeline.models import Job, Worker
+from pipeline.models import Job, Worker, create_job_event
 from pipeline.orchestrator import LOG_DIR, PROJECT_ROOT, get_eligible_jobs
-from pipeline.param_validators import build_argv_for_phase, ValidationError
+from pipeline.param_validators import ValidationError
+from pipeline.protocol_reader import ProtocolReader, create_protocol_pipe, setup_fd3_for_subprocess
+from pipeline.provenance import read_provenance_file, update_org_provenance
+from pipeline.scheduler import select_next_jobs, is_dependency_satisfied
+from pipeline.scheduler_config import load_config as load_scheduler_config
 from pipeline.stages import STAGE_REGISTRY
 
 logger = logging.getLogger("pipeline.orchestrator")
@@ -31,6 +35,7 @@ class Command(BaseCommand):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._shutdown = False
+        self._protocol_readers: dict[int, ProtocolReader] = {}
 
     def handle(self, *args, **options):
         self.hostname = socket.gethostname()
@@ -87,9 +92,12 @@ class Command(BaseCommand):
 
     def _update_worker_heartbeat(self):
         try:
+            cpu_pct, mem_pct = self._read_system_metrics()
             Worker.objects.filter(hostname=self.hostname).update(
                 status="online",
                 last_heartbeat=timezone.now(),
+                cpu_pct=cpu_pct,
+                mem_pct=mem_pct,
             )
         except Exception:
             pass
@@ -140,6 +148,7 @@ class Command(BaseCommand):
             job.status = "pending"
             job.blocked_reason = None
             job.save(update_fields=["status", "blocked_reason"])
+            create_job_event(job, "reset", {"reason": "orchestrator restart, was scheduled"})
             self.stdout.write(f"Reset scheduled Job #{job.pk} to pending (orchestrator restart)")
 
         # Running jobs -> reconcile via PID + start time
@@ -152,6 +161,7 @@ class Command(BaseCommand):
             job.error_message = "orphaned: PID not found or start time mismatch on restart"
             job.finished_at = now
             job.save(update_fields=["status", "error_message", "finished_at"])
+            create_job_event(job, "failed", {"reason": "orphaned on orchestrator restart"})
             self.stdout.write(f"Marked orphaned Job #{job.pk} as failed")
 
     def _poll_running_jobs(self):
@@ -174,17 +184,30 @@ class Command(BaseCommand):
                     job.error_message = "orphaned: PID not found"
                     job.finished_at = timezone.now()
                     self._save_with_retry(job, ["status", "error_message", "finished_at"])
+                    create_job_event(job, "failed", {"reason": "orphaned: PID not found"})
 
     def _start_eligible_jobs(self):
         eligible = get_eligible_jobs(self.hostname)
         from pipeline.orchestrator import check_phase_conflict
 
-        for job in eligible[:3]:
+        # Filter by dependency satisfaction
+        ready = [j for j in eligible if is_dependency_satisfied(j)]
+
+        # Use resource-aware scheduler
+        workers = list(Worker.objects.filter(is_active=True, status="online"))
+        config = load_scheduler_config()
+        placements = select_next_jobs(ready, workers, config)
+
+        for job, worker in placements:
+            if worker.hostname != self.hostname:
+                continue
+
             if check_phase_conflict(job.phase, job.state_code):
                 reason = f"Phase conflict: {job.phase} already running"
                 if job.state_code:
                     reason += f" for {job.state_code}"
                 self._update_blocked_reason(job, reason)
+                create_job_event(job, "blocked", {"reason": reason})
                 continue
 
             self._clear_blocked_reason(job)
@@ -194,6 +217,7 @@ class Command(BaseCommand):
         # Transition to scheduled
         job.status = "scheduled"
         job.save(update_fields=["status"])
+        create_job_event(job, "scheduled", {"host": self.hostname})
 
         # Build argv using registry (fall back to legacy COMMAND_MAP)
         try:
@@ -209,6 +233,7 @@ class Command(BaseCommand):
             job.error_message = f"Command build error: {exc}"
             job.finished_at = timezone.now()
             job.save(update_fields=["status", "error_message", "finished_at"])
+            create_job_event(job, "failed", {"reason": f"Command build error: {exc}"})
             return
 
         state_label = job.state_code or "global"
@@ -217,23 +242,56 @@ class Command(BaseCommand):
 
         env = {**os.environ, "PYTHONPATH": str(PROJECT_ROOT)}
 
+        # Set up fd 3 protocol pipe for v1 stages
+        stage = STAGE_REGISTRY.get(job.phase)
+        protocol_pipe_r = None
+        extra_popen_kwargs = {}
+        if stage and stage.protocol_version >= 1:
+            r_fd, w_fd = create_protocol_pipe()
+            protocol_pipe_r = r_fd
+            extra_popen_kwargs = setup_fd3_for_subprocess(w_fd)
+
         try:
             log_fh = open(log_path, "w")
-            proc = subprocess.Popen(
-                argv,
-                stdout=log_fh,
-                stderr=subprocess.STDOUT,
-                cwd=str(PROJECT_ROOT),
-                env=env,
-                preexec_fn=os.setpgrp,
-            )
+            popen_kwargs = {
+                "stdout": log_fh,
+                "stderr": subprocess.STDOUT,
+                "cwd": str(PROJECT_ROOT),
+                "env": env,
+            }
+            if extra_popen_kwargs:
+                popen_kwargs["pass_fds"] = extra_popen_kwargs["pass_fds"]
+                popen_kwargs["preexec_fn"] = extra_popen_kwargs["preexec_fn"]
+            else:
+                popen_kwargs["preexec_fn"] = os.setpgrp
+
+            proc = subprocess.Popen(argv, **popen_kwargs)
+
+            # Close write end of protocol pipe in parent
+            if stage and stage.protocol_version >= 1:
+                os.close(w_fd)
         except (OSError, FileNotFoundError) as exc:
+            if protocol_pipe_r is not None:
+                os.close(protocol_pipe_r)
+                os.close(w_fd)
             job.status = "failed"
             job.error_message = f"Spawn error: {exc}"
             job.finished_at = timezone.now()
             job.save(update_fields=["status", "error_message", "finished_at"])
+            create_job_event(job, "failed", {"reason": f"Spawn error: {exc}"})
             self.stderr.write(f"Failed to spawn Job #{job.pk}: {exc}")
             return
+
+        # Start protocol reader for v1 stages
+        if protocol_pipe_r is not None:
+            reader = ProtocolReader(
+                protocol_pipe_r,
+                on_progress=lambda p, jid=job.pk: self._handle_protocol_progress(jid, p),
+                on_error=lambda e, jid=job.pk: self._handle_protocol_error(jid, e),
+                on_warning=lambda w, jid=job.pk: self._handle_protocol_warning(jid, w),
+            )
+            reader.start()
+            self._protocol_readers[job.pk] = reader
 
         now = timezone.now()
         job.status = "running"
@@ -249,6 +307,11 @@ class Command(BaseCommand):
         ])
 
         self._tracked[job.pk] = proc
+        create_job_event(job, "started", {
+            "pid": proc.pid,
+            "log_file": str(log_path),
+            "protocol_version": stage.protocol_version if stage else 0,
+        })
         self.stdout.write(f"Started Job #{job.pk} ({job.phase} {state_label}) PID={proc.pid}")
 
     _EXIT_CODE_HINTS = {
@@ -261,6 +324,11 @@ class Command(BaseCommand):
 
     def _finish_job(self, job: Job, exit_code: int):
         stage = STAGE_REGISTRY.get(job.phase)
+
+        # Stop protocol reader if one was running
+        reader = self._protocol_readers.pop(job.pk, None)
+        if reader:
+            reader.stop()
 
         # Check if this exit code is retryable
         if stage and stage.retry_policy.auto_retry and exit_code in stage.retry_policy.retryable_exit_codes:
@@ -286,14 +354,35 @@ class Command(BaseCommand):
                     job.log_tail = f.read().decode("utf-8", errors="replace")[-16_384:]
             except OSError:
                 pass
+
+        # Collect summary from protocol reader if available
+        event_payload = {"exit_code": exit_code}
+        if reader and reader.last_summary:
+            event_payload["summary"] = reader.last_summary
+        if reader and reader.errors:
+            event_payload["protocol_errors"] = len(reader.errors)
+
         self._save_with_retry(job, [
             "status", "exit_code", "finished_at", "error_message", "log_tail",
         ])
+
+        event_type = "completed" if exit_code == 0 else "failed"
+        create_job_event(job, event_type, event_payload)
+
+        # Update org provenance on successful completion
+        if exit_code == 0 and stage and stage.provenance_column:
+            self._update_provenance(job, stage)
+
         self.stdout.write(f"Job #{job.pk} finished: {job.status} (exit {exit_code})")
 
     def _retry_job(self, failed_job: Job, exit_code: int, retry_policy):
         """Create a retry clone of a failed job and rebound dependents."""
         from django.db import transaction
+
+        # Stop protocol reader if one was running
+        reader = self._protocol_readers.pop(failed_job.pk, None)
+        if reader:
+            reader.stop()
 
         failed_job.status = "failed"
         failed_job.exit_code = exit_code
@@ -303,6 +392,10 @@ class Command(BaseCommand):
         self._save_with_retry(failed_job, [
             "status", "exit_code", "finished_at", "error_message",
         ])
+
+        create_job_event(failed_job, "failed", {
+            "exit_code": exit_code, "auto_retrying": True,
+        })
 
         with transaction.atomic():
             retry_job = Job.objects.create(
@@ -318,6 +411,14 @@ class Command(BaseCommand):
             rebound_count = Job.objects.filter(
                 depends_on=failed_job, status="pending"
             ).update(depends_on=retry_job)
+
+        create_job_event(retry_job, "retried", {
+            "retry_of": failed_job.pk,
+            "attempt": retry_job.attempt_number,
+            "max_attempts": retry_policy.max_attempts,
+        })
+        if rebound_count:
+            create_job_event(retry_job, "dependency_rebound", {"rebound_count": rebound_count})
 
         self.stdout.write(
             f"Job #{failed_job.pk} failed (exit {exit_code}), "
@@ -407,14 +508,34 @@ class Command(BaseCommand):
         if not self._is_pid_alive(job.pid):
             return False
         if not job.started_at_precise:
-            return self._is_pid_alive(job.pid)
+            return True
         try:
             stat_path = f"/proc/{job.pid}/stat"
             with open(stat_path) as f:
                 stat_content = f.read()
-            # Field 22 (0-indexed from after the comm field) is starttime in clock ticks
-            # For basic validation, just confirm the process exists and PID matches
-            return True
+            # Parse field 22 (starttime in clock ticks since boot).
+            # Fields are space-separated but field 2 (comm) can contain spaces/parens,
+            # so we split from the last ')' which ends the comm field.
+            after_comm = stat_content[stat_content.rfind(")") + 2:]
+            fields = after_comm.split()
+            # Field 22 in /proc/PID/stat is index 19 after the comm field (0-indexed)
+            starttime_ticks = int(fields[19])
+            clk_tck = os.sysconf("SC_CLK_TCK")
+
+            # Get system boot time
+            with open("/proc/stat") as f:
+                for line in f:
+                    if line.startswith("btime "):
+                        boot_time = int(line.split()[1])
+                        break
+                else:
+                    return True
+
+            proc_start_epoch = boot_time + (starttime_ticks / clk_tck)
+            job_start_epoch = job.started_at_precise.timestamp()
+
+            # Allow 5 seconds of skew between recorded start and actual start
+            return abs(proc_start_epoch - job_start_epoch) < 5.0
         except (OSError, IndexError, ValueError):
             return self._is_pid_alive(job.pid)
 
@@ -450,6 +571,82 @@ class Command(BaseCommand):
             if any(sig in stripped for sig in self._ERROR_SIGNALS):
                 return stripped[:200]
         return None
+
+    def _update_provenance(self, job: Job, stage):
+        """Read provenance file and update org_provenance table."""
+        try:
+            outcomes = read_provenance_file(job.pk)
+            if outcomes:
+                count = update_org_provenance(stage.name, outcomes)
+                logger.info("Job #%d: updated provenance for %d EINs", job.pk, count)
+        except FileNotFoundError:
+            logger.debug("Job #%d: no provenance file (stage may not emit one)", job.pk)
+        except Exception as exc:
+            logger.warning("Job #%d: provenance update failed: %s", job.pk, exc)
+
+    def _handle_protocol_progress(self, job_pk: int, progress: dict):
+        """Handle a PROGRESS event from the protocol reader."""
+        try:
+            job = Job.objects.get(pk=job_pk)
+            updated_fields = []
+            if "current" in progress:
+                job.progress_current = progress["current"]
+                updated_fields.append("progress_current")
+            if "total" in progress:
+                job.progress_total = progress["total"]
+                updated_fields.append("progress_total")
+            if updated_fields:
+                job.save(update_fields=updated_fields)
+        except Exception:
+            pass
+
+    def _handle_protocol_error(self, job_pk: int, error: dict):
+        """Handle an ERROR event from the protocol reader."""
+        try:
+            job = Job.objects.get(pk=job_pk)
+            create_job_event(job, "error", {
+                "error_class": error.get("error_class", ""),
+                "detail": error.get("error_detail", ""),
+            })
+        except Exception:
+            pass
+
+    def _handle_protocol_warning(self, job_pk: int, warning: dict):
+        """Handle a WARNING event from the protocol reader."""
+        try:
+            job = Job.objects.get(pk=job_pk)
+            create_job_event(job, "warning", {
+                "warning_class": warning.get("warning_class", ""),
+                "detail": warning.get("detail", ""),
+            })
+        except Exception:
+            pass
+
+    @staticmethod
+    def _read_system_metrics() -> tuple[float | None, float | None]:
+        """Read current CPU and memory utilization from /proc."""
+        cpu_pct = None
+        mem_pct = None
+        try:
+            with open("/proc/meminfo") as f:
+                meminfo = {}
+                for line in f:
+                    parts = line.split()
+                    if len(parts) >= 2:
+                        meminfo[parts[0].rstrip(":")] = int(parts[1])
+            total = meminfo.get("MemTotal", 0)
+            available = meminfo.get("MemAvailable", 0)
+            if total > 0:
+                mem_pct = round((1 - available / total) * 100, 1)
+        except (OSError, ValueError, KeyError):
+            pass
+        try:
+            load1 = os.getloadavg()[0]
+            ncpu = os.cpu_count() or 1
+            cpu_pct = round(min(load1 / ncpu * 100, 100.0), 1)
+        except (OSError, AttributeError):
+            pass
+        return cpu_pct, mem_pct
 
     @staticmethod
     def _is_pid_alive(pid: int) -> bool:

--- a/lavandula/dashboard/pipeline/migrations/0007_job_lifecycle_v2.py
+++ b/lavandula/dashboard/pipeline/migrations/0007_job_lifecycle_v2.py
@@ -1,0 +1,69 @@
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('pipeline', '0006_add_job_log_tail'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='job',
+            name='status',
+            field=models.CharField(
+                choices=[
+                    ('pending', 'Pending'),
+                    ('scheduled', 'Scheduled'),
+                    ('running', 'Running'),
+                    ('completed', 'Completed'),
+                    ('failed', 'Failed'),
+                    ('cancelled', 'Cancelled'),
+                ],
+                default='pending',
+                max_length=20,
+            ),
+        ),
+        migrations.AddField(
+            model_name='job',
+            name='blocked_reason',
+            field=models.TextField(blank=True, null=True),
+        ),
+        migrations.AddField(
+            model_name='job',
+            name='retry_of',
+            field=models.ForeignKey(
+                blank=True,
+                null=True,
+                on_delete=django.db.models.deletion.SET_NULL,
+                related_name='retries',
+                to='pipeline.job',
+            ),
+        ),
+        migrations.AddField(
+            model_name='job',
+            name='attempt_number',
+            field=models.IntegerField(default=1),
+        ),
+        migrations.AddField(
+            model_name='job',
+            name='started_at_precise',
+            field=models.DateTimeField(blank=True, null=True),
+        ),
+        migrations.AddField(
+            model_name='worker',
+            name='cpu_pct',
+            field=models.FloatField(blank=True, null=True),
+        ),
+        migrations.AddField(
+            model_name='worker',
+            name='mem_pct',
+            field=models.FloatField(blank=True, null=True),
+        ),
+        migrations.AddField(
+            model_name='worker',
+            name='has_gpu',
+            field=models.BooleanField(default=False),
+        ),
+    ]

--- a/lavandula/dashboard/pipeline/migrations/0008_job_event.py
+++ b/lavandula/dashboard/pipeline/migrations/0008_job_event.py
@@ -1,0 +1,52 @@
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('pipeline', '0007_job_lifecycle_v2'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='JobEvent',
+            fields=[
+                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('timestamp', models.DateTimeField(auto_now_add=True)),
+                ('event_type', models.CharField(
+                    choices=[
+                        ('created', 'Created'),
+                        ('blocked', 'Blocked'),
+                        ('scheduled', 'Scheduled'),
+                        ('started', 'Started'),
+                        ('progress', 'Progress'),
+                        ('warning', 'Warning'),
+                        ('error', 'Error'),
+                        ('completed', 'Completed'),
+                        ('failed', 'Failed'),
+                        ('cancelled', 'Cancelled'),
+                        ('retried', 'Retried'),
+                        ('reset', 'Reset'),
+                        ('dependency_rebound', 'Dependency Rebound'),
+                    ],
+                    db_index=True,
+                    max_length=20,
+                )),
+                ('payload', models.JSONField(default=dict)),
+                ('job', models.ForeignKey(
+                    on_delete=django.db.models.deletion.CASCADE,
+                    related_name='events',
+                    to='pipeline.job',
+                )),
+            ],
+            options={
+                'ordering': ['timestamp'],
+                'indexes': [
+                    models.Index(fields=['job', 'timestamp'], name='pipeline_jo_job_id_timest_idx'),
+                    models.Index(fields=['event_type', 'timestamp'], name='pipeline_jo_event_t_timest_idx'),
+                ],
+                'db_table': 'job_events',
+            },
+        ),
+    ]

--- a/lavandula/dashboard/pipeline/models.py
+++ b/lavandula/dashboard/pipeline/models.py
@@ -163,11 +163,19 @@ class Job(models.Model):
     ]
     STATUS_CHOICES = [
         ("pending", "Pending"),
+        ("scheduled", "Scheduled"),
         ("running", "Running"),
         ("completed", "Completed"),
         ("failed", "Failed"),
         ("cancelled", "Cancelled"),
     ]
+
+    TERMINAL_STATUSES = frozenset({"completed", "failed", "cancelled"})
+    VALID_TRANSITIONS = {
+        "pending": {"scheduled", "cancelled"},
+        "scheduled": {"running", "failed", "cancelled", "pending"},
+        "running": {"completed", "failed", "cancelled"},
+    }
 
     state_code = models.CharField(max_length=2, null=True, blank=True)
     phase = models.CharField(max_length=20, choices=PHASE_CHOICES)
@@ -188,6 +196,12 @@ class Job(models.Model):
     )
     last_heartbeat = models.DateTimeField(null=True, blank=True)
     log_tail = models.TextField(null=True, blank=True)
+    blocked_reason = models.TextField(null=True, blank=True)
+    retry_of = models.ForeignKey(
+        "self", null=True, blank=True, on_delete=models.SET_NULL, related_name="retries"
+    )
+    attempt_number = models.IntegerField(default=1)
+    started_at_precise = models.DateTimeField(null=True, blank=True)
 
     class Meta:
         db_table = "jobs"
@@ -199,6 +213,19 @@ class Job(models.Model):
     def __str__(self):
         state = self.state_code or "global"
         return f"Job {self.pk}: {self.phase} ({state}) [{self.status}]"
+
+    def can_transition_to(self, new_status: str) -> bool:
+        if self.status in self.TERMINAL_STATUSES:
+            return False
+        allowed = self.VALID_TRANSITIONS.get(self.status, set())
+        return new_status in allowed
+
+    def transition_status(self, new_status: str) -> None:
+        if not self.can_transition_to(new_status):
+            raise ValueError(
+                f"Invalid transition: {self.status} -> {new_status} "
+                f"(allowed: {self.VALID_TRANSITIONS.get(self.status, {})})"
+            )
 
 
 class Worker(models.Model):
@@ -215,6 +242,9 @@ class Worker(models.Model):
     registered_at = models.DateTimeField(auto_now_add=True)
     ip_address = models.GenericIPAddressField(null=True, blank=True)
     is_active = models.BooleanField(default=True)
+    cpu_pct = models.FloatField(null=True, blank=True)
+    mem_pct = models.FloatField(null=True, blank=True)
+    has_gpu = models.BooleanField(default=False)
 
     class Meta:
         db_table = "workers"

--- a/lavandula/dashboard/pipeline/models.py
+++ b/lavandula/dashboard/pipeline/models.py
@@ -340,6 +340,36 @@ def create_job_event(job, event_type: str, payload: dict | None = None, actor: s
     return JobEvent.objects.create(job=job, event_type=event_type, payload=payload)
 
 
+class OrgProvenance(models.Model):
+    PROVENANCE_STATUS_CHOICES = [
+        ("not_started", "Not Started"),
+        ("in_progress", "In Progress"),
+        ("completed", "Completed"),
+        ("failed", "Failed"),
+        ("not_applicable", "Not Applicable"),
+    ]
+
+    ein = models.TextField(primary_key=True)
+    seed_status = models.TextField(default="not_started")
+    seed_completed_at = models.DateTimeField(null=True, blank=True)
+    resolve_status = models.TextField(default="not_started")
+    resolve_completed_at = models.DateTimeField(null=True, blank=True)
+    crawl_status = models.TextField(default="not_started")
+    crawl_completed_at = models.DateTimeField(null=True, blank=True)
+    classify_status = models.TextField(default="not_started")
+    classify_completed_at = models.DateTimeField(null=True, blank=True)
+    filing_990_status = models.TextField(default="not_started")
+    filing_990_completed_at = models.DateTimeField(null=True, blank=True)
+    updated_at = models.DateTimeField(auto_now=True)
+
+    class Meta:
+        managed = False
+        db_table = '"lava_pipeline"."org_provenance"'
+
+    def __str__(self):
+        return f"Provenance {self.ein}"
+
+
 class PipelineAuditLog(models.Model):
     action = models.CharField(max_length=20)
     process_name = models.CharField(max_length=50)

--- a/lavandula/dashboard/pipeline/models.py
+++ b/lavandula/dashboard/pipeline/models.py
@@ -277,6 +277,69 @@ class PipelineProcess(models.Model):
         return f"{self.name} [{self.status}]"
 
 
+class JobEvent(models.Model):
+    EVENT_TYPE_CHOICES = [
+        ("created", "Created"),
+        ("blocked", "Blocked"),
+        ("scheduled", "Scheduled"),
+        ("started", "Started"),
+        ("progress", "Progress"),
+        ("warning", "Warning"),
+        ("error", "Error"),
+        ("completed", "Completed"),
+        ("failed", "Failed"),
+        ("cancelled", "Cancelled"),
+        ("retried", "Retried"),
+        ("reset", "Reset"),
+        ("dependency_rebound", "Dependency Rebound"),
+    ]
+
+    job = models.ForeignKey(Job, on_delete=models.CASCADE, related_name="events")
+    timestamp = models.DateTimeField(auto_now_add=True)
+    event_type = models.CharField(max_length=20, choices=EVENT_TYPE_CHOICES, db_index=True)
+    payload = models.JSONField(default=dict)
+
+    class Meta:
+        db_table = "job_events"
+        ordering = ["timestamp"]
+        indexes = [
+            models.Index(fields=["job", "timestamp"]),
+            models.Index(fields=["event_type", "timestamp"]),
+        ]
+
+    def __str__(self):
+        return f"Job #{self.job_id} {self.event_type} @ {self.timestamp}"
+
+
+PAYLOAD_MAX_BYTES = 65536
+
+
+def truncate_payload(payload: dict, max_bytes: int = PAYLOAD_MAX_BYTES) -> dict:
+    """Truncate payload if its JSON representation exceeds max_bytes."""
+    import json
+    encoded = json.dumps(payload)
+    if len(encoded.encode("utf-8")) <= max_bytes:
+        return payload
+    # Truncate string values to fit
+    truncated = {}
+    for key, value in payload.items():
+        if isinstance(value, str) and len(value) > 500:
+            truncated[key] = value[:500] + "..."
+        else:
+            truncated[key] = value
+    truncated["_truncated"] = True
+    return truncated
+
+
+def create_job_event(job, event_type: str, payload: dict | None = None, actor: str = "orchestrator") -> "JobEvent":
+    """Create a JobEvent with payload truncation and actor attribution."""
+    if payload is None:
+        payload = {}
+    payload["actor"] = actor
+    payload = truncate_payload(payload)
+    return JobEvent.objects.create(job=job, event_type=event_type, payload=payload)
+
+
 class PipelineAuditLog(models.Model):
     action = models.CharField(max_length=20)
     process_name = models.CharField(max_length=50)

--- a/lavandula/dashboard/pipeline/orchestrator.py
+++ b/lavandula/dashboard/pipeline/orchestrator.py
@@ -478,7 +478,7 @@ def create_phone_enrich_job(config_overrides: dict, host: str) -> Job:
 
 
 def retry_job(job: Job) -> Job:
-    """Create a new pending job from a failed job, rewiring dependents."""
+    """Create a new pending job from a failed job, rewiring pending dependents."""
     if job.status != "failed":
         raise ValueError(f"Can only retry failed jobs, got {job.status}")
 
@@ -489,15 +489,16 @@ def retry_job(job: Job) -> Job:
             status="pending",
             host=job.host,
             config_json=job.config_json,
-            depends_on=job.depends_on,
+            retry_of=job,
+            attempt_number=job.attempt_number + 1,
         )
-        Job.objects.filter(depends_on=job).update(depends_on=new_job)
+        Job.objects.filter(depends_on=job, status="pending").update(depends_on=new_job)
         return new_job
 
 
 def cancel_job(job: Job) -> None:
     """Cancel a job. If running, send SIGTERM→SIGKILL. Cascade to dependents."""
-    if job.status not in ("pending", "running"):
+    if job.status not in ("pending", "scheduled", "running"):
         return
 
     if job.status == "running" and job.pid:
@@ -524,16 +525,24 @@ def cancel_job(job: Job) -> None:
     job.finished_at = timezone.now()
     job.save(update_fields=["status", "finished_at"])
 
-    for dep in Job.objects.filter(depends_on=job, status__in=["pending", "running"]):
+    for dep in Job.objects.filter(depends_on=job, status__in=["pending", "scheduled", "running"]):
         cancel_job(dep)
 
 
 def get_eligible_jobs(host: str):
-    """Get jobs that are ready to run on this host."""
+    """Get jobs that are ready to run on this host.
+
+    A job is eligible if:
+    - Status is pending
+    - Its dependency is satisfied (completed, or a retry of the dependency completed)
+    - No phase conflict (global or per-state)
+    """
     from django.db.models import Q
 
+    active_statuses = ("running", "scheduled")
+
     globally_blocked = set(
-        Job.objects.filter(status="running")
+        Job.objects.filter(status__in=active_statuses)
         .exclude(phase__in=_PER_STATE_PHASES)
         .values_list("phase", flat=True)
     ) | set(
@@ -541,7 +550,7 @@ def get_eligible_jobs(host: str):
     )
 
     running_per_state = set(
-        Job.objects.filter(status="running", phase__in=_PER_STATE_PHASES)
+        Job.objects.filter(status__in=active_statuses, phase__in=_PER_STATE_PHASES)
         .values_list("phase", "state_code")
     )
 

--- a/lavandula/dashboard/pipeline/param_validators.py
+++ b/lavandula/dashboard/pipeline/param_validators.py
@@ -1,0 +1,152 @@
+"""
+Parameter validation and argv construction for pipeline stages.
+
+Validates job parameters against the stage's ParamSpec definitions
+and builds safe subprocess argv arrays (never shell=True, never string interpolation).
+"""
+from __future__ import annotations
+
+import re
+
+from .stages import ParamSpec, StageDefinition, STAGE_REGISTRY
+
+
+US_STATES = frozenset([
+    "AL", "AK", "AZ", "AR", "CA", "CO", "CT", "DE", "FL", "GA",
+    "HI", "ID", "IL", "IN", "IA", "KS", "KY", "LA", "ME", "MD",
+    "MA", "MI", "MN", "MS", "MO", "MT", "NE", "NV", "NH", "NJ",
+    "NM", "NY", "NC", "ND", "OH", "OK", "OR", "PA", "RI", "SC",
+    "SD", "TN", "TX", "UT", "VT", "VA", "WA", "WV", "WI", "WY",
+    "DC", "PR", "VI", "GU", "AS", "MP",
+])
+
+_SHELL_METACHARACTERS = re.compile(r"[;&|`$(){}!\\\n\r\x00]")
+_SAFE_STRING = re.compile(r"^[a-zA-Z0-9_./:@,\-= ]+$")
+
+
+class ValidationError(Exception):
+    pass
+
+
+def validate_param(name: str, value, spec: ParamSpec) -> str | None:
+    """Validate a single parameter value against its spec.
+
+    Returns the cleaned string value, or None for boolean flags (presence = true).
+    Raises ValidationError on invalid input.
+    """
+    if spec.type == "boolean":
+        if value in (True, "true", "on", "1"):
+            return None  # flag presence indicates true
+        if value in (False, "false", "off", "0", "", None):
+            return ""  # empty = don't emit flag
+        raise ValidationError(f"{name}: expected boolean, got {value!r}")
+
+    if spec.type == "state_code":
+        sval = str(value).strip().upper()
+        if sval not in US_STATES:
+            raise ValidationError(f"{name}: '{sval}' is not a valid US state/territory code")
+        return sval
+
+    if spec.type == "integer":
+        try:
+            ival = int(value)
+        except (TypeError, ValueError):
+            raise ValidationError(f"{name}: expected integer, got {value!r}")
+        if spec.min_value is not None and ival < spec.min_value:
+            raise ValidationError(f"{name}: {ival} < minimum {spec.min_value}")
+        if spec.max_value is not None and ival > spec.max_value:
+            raise ValidationError(f"{name}: {ival} > maximum {spec.max_value}")
+        return str(ival)
+
+    if spec.type == "float":
+        try:
+            fval = float(value)
+        except (TypeError, ValueError):
+            raise ValidationError(f"{name}: expected float, got {value!r}")
+        if spec.min_value is not None and fval < spec.min_value:
+            raise ValidationError(f"{name}: {fval} < minimum {spec.min_value}")
+        if spec.max_value is not None and fval > spec.max_value:
+            raise ValidationError(f"{name}: {fval} > maximum {spec.max_value}")
+        return str(fval)
+
+    if spec.type == "choice":
+        sval = str(value)
+        if spec.choices is None:
+            raise ValidationError(f"{name}: choice type but no choices defined")
+        if sval not in spec.choices:
+            raise ValidationError(f"{name}: '{sval}' not in {spec.choices}")
+        return sval
+
+    if spec.type == "string":
+        sval = str(value)
+        if not sval:
+            raise ValidationError(f"{name}: empty string")
+        if len(sval) > 200:
+            raise ValidationError(f"{name}: exceeds 200 char limit ({len(sval)} chars)")
+        if _SHELL_METACHARACTERS.search(sval):
+            raise ValidationError(f"{name}: contains shell metacharacters")
+        if spec.pattern and not re.match(spec.pattern, sval):
+            raise ValidationError(f"{name}: '{sval}' does not match pattern {spec.pattern}")
+        return sval
+
+    raise ValidationError(f"{name}: unknown parameter type '{spec.type}'")
+
+
+def validate_config(stage: StageDefinition, config_json: dict) -> dict[str, str | None]:
+    """Validate all parameters in config_json against stage's param specs.
+
+    Returns dict of validated {name: cleaned_value}.
+    Raises ValidationError on first invalid parameter.
+    """
+    validated = {}
+
+    for key in config_json:
+        if key not in stage.parameters:
+            raise ValidationError(
+                f"Unknown parameter '{key}' for stage '{stage.name}' "
+                f"(allowed: {list(stage.parameters.keys())})"
+            )
+
+    for name, spec in stage.parameters.items():
+        if name in config_json:
+            value = config_json[name]
+            if value is None or value == "":
+                if spec.required:
+                    raise ValidationError(f"{name}: required parameter is empty")
+                continue
+            validated[name] = validate_param(name, value, spec)
+        elif spec.required:
+            raise ValidationError(f"{name}: required parameter missing")
+
+    return validated
+
+
+def build_argv(stage: StageDefinition, config_json: dict) -> list[str]:
+    """Build a safe subprocess argv from stage command + validated parameters.
+
+    Parameters are validated against the stage's ParamSpec before inclusion.
+    Returns a list suitable for subprocess.Popen(argv, shell=False).
+    """
+    validated = validate_config(stage, config_json)
+
+    argv = list(stage.command)
+    for name, spec in stage.parameters.items():
+        if name not in validated:
+            continue
+        clean_value = validated[name]
+        if spec.type == "boolean":
+            if clean_value is None:  # None = flag should be emitted
+                argv.append(spec.cli_flag)
+            # empty string = flag not emitted
+        else:
+            if clean_value and spec.cli_flag:
+                argv.extend([spec.cli_flag, clean_value])
+
+    return argv
+
+
+def build_argv_for_phase(phase: str, config_json: dict) -> list[str]:
+    """Convenience wrapper: look up stage by name and build argv."""
+    if phase not in STAGE_REGISTRY:
+        raise ValidationError(f"Unknown stage: '{phase}'")
+    return build_argv(STAGE_REGISTRY[phase], config_json)

--- a/lavandula/dashboard/pipeline/protocol_reader.py
+++ b/lavandula/dashboard/pipeline/protocol_reader.py
@@ -1,0 +1,123 @@
+"""
+Protocol reader for the orchestrator's fd 3 pipe.
+
+When spawning a protocol v1 stage, the orchestrator creates a pipe,
+passes the write end as fd 3 to the subprocess, and reads structured
+events from the read end in a background thread.
+
+For protocol v0 stages: no pipe is created. Exit code + log file size only.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import threading
+from typing import Callable
+
+from .summary_parser import parse_error_line, parse_progress_line, parse_summary_line
+
+logger = logging.getLogger("pipeline.protocol_reader")
+
+
+class ProtocolReader:
+    """Reads structured events from a pipe (fd 3 of a subprocess).
+
+    Runs a background thread that continuously drains the pipe and
+    dispatches parsed events via callbacks.
+    """
+
+    def __init__(
+        self,
+        read_fd: int,
+        on_progress: Callable[[dict], None] | None = None,
+        on_error: Callable[[dict], None] | None = None,
+        on_warning: Callable[[dict], None] | None = None,
+        on_summary: Callable[[dict], None] | None = None,
+    ):
+        self._read_fd = read_fd
+        self._on_progress = on_progress
+        self._on_error = on_error
+        self._on_warning = on_warning
+        self._on_summary = on_summary
+        self._thread: threading.Thread | None = None
+        self._stopped = False
+        self.last_summary: dict | None = None
+        self.errors: list[dict] = []
+
+    def start(self) -> None:
+        self._thread = threading.Thread(target=self._read_loop, daemon=True)
+        self._thread.start()
+
+    def stop(self) -> None:
+        self._stopped = True
+        if self._thread and self._thread.is_alive():
+            self._thread.join(timeout=5)
+
+    def _read_loop(self) -> None:
+        try:
+            with os.fdopen(self._read_fd, "r") as f:
+                for line in f:
+                    if self._stopped:
+                        break
+                    self._dispatch_line(line.rstrip("\n"))
+        except (OSError, ValueError):
+            pass
+
+    def _dispatch_line(self, line: str) -> None:
+        if not line:
+            return
+
+        if line.startswith("PROGRESS:"):
+            parsed = parse_progress_line(line)
+            if parsed and self._on_progress:
+                self._on_progress(parsed)
+        elif line.startswith("ERROR:"):
+            parsed = parse_error_line(line)
+            if parsed:
+                self.errors.append(parsed)
+                if self._on_error:
+                    self._on_error(parsed)
+        elif line.startswith("WARNING:"):
+            parsed = parse_error_line("ERROR:" + line[len("WARNING:"):])
+            if parsed:
+                warning = {"warning_class": parsed.get("error_class", ""), "detail": parsed.get("error_detail", "")}
+                if self._on_warning:
+                    self._on_warning(warning)
+        elif line.startswith("SUMMARY:"):
+            parsed = parse_summary_line(line)
+            if parsed:
+                self.last_summary = parsed
+                if self._on_summary:
+                    self._on_summary(parsed)
+        else:
+            logger.debug("Ignoring unrecognized protocol line: %s", line[:100])
+
+
+def create_protocol_pipe() -> tuple[int, int]:
+    """Create a pipe for fd 3 protocol communication.
+
+    Returns (read_fd, write_fd). The write_fd should be passed to
+    the subprocess as fd 3. The read_fd is consumed by ProtocolReader.
+    """
+    return os.pipe()
+
+
+def setup_fd3_for_subprocess(write_fd: int) -> dict:
+    """Return kwargs for subprocess.Popen to pass write_fd as fd 3.
+
+    The caller must:
+    1. Create the pipe: read_fd, write_fd = create_protocol_pipe()
+    2. Pass write_fd via pass_fds
+    3. Use preexec_fn to dup2 write_fd to 3 (if write_fd != 3)
+    4. Close write_fd in the parent after spawn
+    5. Start ProtocolReader on read_fd
+    """
+    def _preexec():
+        if write_fd != 3:
+            os.dup2(write_fd, 3)
+            os.close(write_fd)
+
+    return {
+        "pass_fds": (write_fd,) if write_fd == 3 else (write_fd,),
+        "preexec_fn": _preexec,
+    }

--- a/lavandula/dashboard/pipeline/provenance.py
+++ b/lavandula/dashboard/pipeline/provenance.py
@@ -1,0 +1,137 @@
+"""
+Provenance writer for the pipeline control plane.
+
+Updates org_provenance table per-EIN as each stage completes.
+Enforces column ownership: a stage can only write to its own column.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+from pathlib import Path
+
+from django.db import connection
+from django.utils import timezone
+
+from .stages import STAGE_REGISTRY
+
+logger = logging.getLogger("pipeline.provenance")
+
+VALID_STATUSES = frozenset({"not_started", "in_progress", "completed", "failed", "not_applicable"})
+
+PROVENANCE_BASE_DIR = os.environ.get("PROVENANCE_BASE_DIR", "/var/lib/lava/provenance")
+
+
+class ProvenanceSecurityError(Exception):
+    pass
+
+
+def update_org_provenance(stage_name: str, outcomes: list[tuple[str, str]]) -> int:
+    """Update provenance for a batch of EINs after a stage completes.
+
+    Args:
+        stage_name: The stage that just completed (must be in STAGE_REGISTRY)
+        outcomes: List of (ein, status) tuples
+
+    Returns:
+        Count of rows updated/inserted.
+
+    Raises:
+        ProvenanceSecurityError: If stage tries to write to wrong column.
+        ValueError: If invalid status values are provided.
+    """
+    if stage_name not in STAGE_REGISTRY:
+        raise ValueError(f"Unknown stage: '{stage_name}'")
+
+    stage = STAGE_REGISTRY[stage_name]
+    column = stage.provenance_column
+    if not column:
+        return 0
+
+    # Enforce column ownership
+    if not column.startswith(stage_name.replace("-", "_")):
+        logger.error(
+            "SECURITY: stage '%s' provenance_column '%s' doesn't match expected pattern",
+            stage_name, column,
+        )
+        raise ProvenanceSecurityError(
+            f"Stage '{stage_name}' cannot write to column '{column}'"
+        )
+
+    # Validate all status values
+    for ein, status in outcomes:
+        if status not in VALID_STATUSES:
+            raise ValueError(f"Invalid status '{status}' for EIN {ein}")
+
+    if not outcomes:
+        return 0
+
+    completed_column = column.replace("_status", "_completed_at")
+    now = timezone.now()
+    updated = 0
+
+    # Batch update using raw SQL for performance
+    with connection.cursor() as cursor:
+        for ein, status in outcomes:
+            completed_at = now if status == "completed" else None
+            cursor.execute(
+                f"""
+                INSERT INTO lava_pipeline.org_provenance (ein, {column}, {completed_column}, updated_at)
+                VALUES (%s, %s, %s, %s)
+                ON CONFLICT (ein) DO UPDATE SET
+                    {column} = EXCLUDED.{column},
+                    {completed_column} = EXCLUDED.{completed_column},
+                    updated_at = EXCLUDED.updated_at
+                """,
+                [ein, status, completed_at, now],
+            )
+            updated += 1
+
+    logger.info("Updated provenance for %d EINs (stage=%s)", updated, stage_name)
+    return updated
+
+
+def read_provenance_file(job_id: int) -> list[tuple[str, str]]:
+    """Read provenance outcomes from the orchestrator-assigned JSONL file.
+
+    Validates path (realpath + prefix check) and parses each line.
+    Returns list of (ein, status) tuples.
+
+    Raises:
+        ProvenanceSecurityError: If path traversal is detected.
+        FileNotFoundError: If file doesn't exist.
+    """
+    file_path = os.path.join(PROVENANCE_BASE_DIR, f"{job_id}.jsonl")
+    real_path = os.path.realpath(file_path)
+
+    if not real_path.startswith(os.path.realpath(PROVENANCE_BASE_DIR)):
+        raise ProvenanceSecurityError(
+            f"Path traversal detected: {file_path} resolves to {real_path}"
+        )
+
+    outcomes = []
+    with open(real_path) as f:
+        for line_num, line in enumerate(f, 1):
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                record = json.loads(line)
+            except json.JSONDecodeError:
+                logger.warning("Skipping malformed line %d in %s", line_num, real_path)
+                continue
+
+            ein = record.get("ein")
+            status = record.get("status")
+
+            if not ein or not isinstance(ein, str):
+                logger.warning("Skipping line %d: missing/invalid ein", line_num)
+                continue
+            if status not in VALID_STATUSES:
+                logger.warning("Skipping line %d: invalid status '%s'", line_num, status)
+                continue
+
+            outcomes.append((ein, status))
+
+    return outcomes

--- a/lavandula/dashboard/pipeline/scheduler.py
+++ b/lavandula/dashboard/pipeline/scheduler.py
@@ -1,0 +1,124 @@
+"""
+Resource-aware job scheduler for the pipeline control plane.
+
+Scores job-host pairings using hard rules (gates) and soft preferences (weights).
+The highest-scoring valid pairing wins. Greedy assignment prevents double-booking.
+"""
+from __future__ import annotations
+
+from datetime import timedelta
+
+from django.db.models import Q
+from django.utils import timezone
+
+from .models import Job, Worker
+from .stages import STAGE_REGISTRY
+from .scheduler_config import SchedulerConfig, load_config
+
+
+def score_placement(job: Job, worker: Worker, config: SchedulerConfig) -> float | None:
+    """Score a job-host pairing. Returns None if a hard rule blocks placement."""
+    stage = STAGE_REGISTRY.get(job.phase)
+    if stage is None:
+        return None
+
+    stage_config = config.stage_weights.get(job.phase, {})
+    now = timezone.now()
+
+    # === HARD RULES (gates) ===
+
+    if worker.cpu_pct is not None and worker.cpu_pct > config.cpu_ceiling_pct:
+        return None
+
+    if worker.mem_pct is not None and worker.mem_pct > config.memory_ceiling_pct:
+        return None
+
+    if stage.resource_class == "heavy":
+        heavy_stages = [s.name for s in STAGE_REGISTRY.values() if s.resource_class == "heavy"]
+        running_heavy = Job.objects.filter(
+            host=worker.hostname, status="running", phase__in=heavy_stages
+        ).count()
+        if running_heavy >= config.max_concurrent_heavy:
+            return None
+
+    if stage_config.get("gpu_preferred") and not worker.has_gpu:
+        return None
+
+    if config.cool_down_after_failure_s:
+        cutoff = now - timedelta(seconds=config.cool_down_after_failure_s)
+        if Job.objects.filter(
+            host=worker.hostname, status="failed", finished_at__gte=cutoff
+        ).exists():
+            return None
+
+    # === SOFT SCORING ===
+    score = 1.0
+
+    if worker.hostname in stage_config.get("prefer_hosts", []):
+        score += 0.3
+
+    if worker.mem_pct is not None:
+        score += (100 - worker.mem_pct) / 100 * 0.5
+
+    wait_minutes = (now - job.created_at).total_seconds() / 60
+    if wait_minutes > config.starvation_boost_after_minutes:
+        score += 0.5
+
+    if config.eta_lookahead:
+        running_on_host = Job.objects.filter(host=worker.hostname, status="running")
+        for rj in running_on_host:
+            if rj.progress_total and rj.progress_current:
+                pct_done = rj.progress_current / rj.progress_total
+                if pct_done > 0.9:
+                    score += 0.2
+                    break
+
+    return score
+
+
+def select_next_jobs(
+    pending_jobs,
+    workers,
+    config: SchedulerConfig | None = None,
+) -> list[tuple[Job, Worker]]:
+    """Score all pending x worker combinations, return best pairings.
+
+    Greedy assignment: pick highest-scored pair, mark both assigned, repeat.
+    Each worker gets at most one new job per scheduling round.
+    """
+    if config is None:
+        config = load_config()
+
+    candidates = []
+    for job in pending_jobs:
+        for worker in workers:
+            s = score_placement(job, worker, config)
+            if s is not None:
+                candidates.append((s, job.pk, worker.hostname, job, worker))
+
+    candidates.sort(key=lambda x: -x[0])
+
+    assigned_workers: set[str] = set()
+    assigned_jobs: set[int] = set()
+    result = []
+
+    for _score, job_pk, hostname, job, worker in candidates:
+        if hostname not in assigned_workers and job_pk not in assigned_jobs:
+            result.append((job, worker))
+            assigned_workers.add(hostname)
+            assigned_jobs.add(job_pk)
+
+    return result
+
+
+def is_dependency_satisfied(job: Job) -> bool:
+    """Check if a job's dependency is met, following retry chains."""
+    dep = job.depends_on
+    if dep is None:
+        return True
+    current = dep
+    while current:
+        if current.status == "completed":
+            return True
+        current = current.retries.order_by("-attempt_number").first()
+    return False

--- a/lavandula/dashboard/pipeline/scheduler_config.py
+++ b/lavandula/dashboard/pipeline/scheduler_config.py
@@ -1,0 +1,87 @@
+"""
+Scheduler configuration loader with hot-reload on file change.
+
+Loads scheduler_config.yaml from a configurable path. Watches mtime
+and reloads when the file changes. Falls back to sensible defaults
+if the file is missing.
+"""
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import yaml
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_CONFIG_PATH = Path(__file__).resolve().parent.parent / "scheduler_config.yaml"
+
+
+@dataclass
+class SchedulerConfig:
+    max_concurrent_heavy: int = 2
+    memory_ceiling_pct: float = 75.0
+    cpu_ceiling_pct: float = 90.0
+    cool_down_after_failure_s: int = 300
+    starvation_boost_after_minutes: int = 60
+    eta_lookahead: bool = True
+    stage_weights: dict = field(default_factory=dict)
+
+
+_cached_config: SchedulerConfig | None = None
+_cached_mtime: float = 0.0
+_config_path: Path = _DEFAULT_CONFIG_PATH
+
+
+def set_config_path(path: str | Path) -> None:
+    global _config_path, _cached_config, _cached_mtime
+    _config_path = Path(path)
+    _cached_config = None
+    _cached_mtime = 0.0
+
+
+def load_config(force_reload: bool = False) -> SchedulerConfig:
+    """Load scheduler config, hot-reloading if the file has changed."""
+    global _cached_config, _cached_mtime
+
+    if not _config_path.exists():
+        if _cached_config is None:
+            _cached_config = SchedulerConfig()
+        return _cached_config
+
+    try:
+        mtime = os.path.getmtime(_config_path)
+    except OSError:
+        if _cached_config is None:
+            _cached_config = SchedulerConfig()
+        return _cached_config
+
+    if _cached_config is not None and mtime == _cached_mtime and not force_reload:
+        return _cached_config
+
+    try:
+        with open(_config_path) as f:
+            raw = yaml.safe_load(f) or {}
+    except (OSError, yaml.YAMLError) as exc:
+        logger.warning("Failed to load scheduler config from %s: %s", _config_path, exc)
+        if _cached_config is None:
+            _cached_config = SchedulerConfig()
+        return _cached_config
+
+    host_rules = raw.get("host_rules", {})
+    scheduling = raw.get("scheduling", {})
+
+    _cached_config = SchedulerConfig(
+        max_concurrent_heavy=host_rules.get("max_concurrent_heavy", 2),
+        memory_ceiling_pct=host_rules.get("memory_ceiling_pct", 75.0),
+        cpu_ceiling_pct=host_rules.get("cpu_ceiling_pct", 90.0),
+        cool_down_after_failure_s=host_rules.get("cool_down_after_failure_s", 300),
+        starvation_boost_after_minutes=scheduling.get("starvation_boost_after_minutes", 60),
+        eta_lookahead=scheduling.get("eta_lookahead", True),
+        stage_weights=raw.get("stage_weights", {}),
+    )
+    _cached_mtime = mtime
+    logger.info("Loaded scheduler config from %s", _config_path)
+    return _cached_config

--- a/lavandula/dashboard/pipeline/stages.py
+++ b/lavandula/dashboard/pipeline/stages.py
@@ -1,0 +1,241 @@
+"""
+Stage registry for the pipeline control plane.
+
+Each pipeline stage is declared here as a StageDefinition dataclass.
+The orchestrator, dashboard views, and job creation forms all read from STAGE_REGISTRY.
+Adding a new stage = adding an entry here + the actual stage code.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Callable
+
+
+@dataclass(frozen=True)
+class ParamSpec:
+    required: bool = False
+    type: str = "string"  # state_code, string, integer, float, boolean, choice
+    choices: list[str] | None = None
+    cli_flag: str = ""
+    min_value: int | None = None
+    max_value: int | None = None
+    pattern: str | None = None  # regex for string type
+
+
+@dataclass(frozen=True)
+class RetryPolicy:
+    max_attempts: int = 1
+    auto_retry: bool = False
+    backoff_seconds: int = 60
+    retryable_exit_codes: tuple[int, ...] = (1, 3)
+
+    def __post_init__(self):
+        if self.max_attempts > 3:
+            object.__setattr__(self, "max_attempts", 3)
+        if self.max_attempts < 1:
+            object.__setattr__(self, "max_attempts", 1)
+
+
+@dataclass(frozen=True)
+class StageDefinition:
+    name: str
+    display_name: str
+    command: list[str]
+    parameters: dict[str, ParamSpec]
+    predecessors: list[str]
+    conflict_group: str | None  # "per-state", "global", "990-family"
+    provenance_column: str | None
+    retry_policy: RetryPolicy
+    resource_class: str  # "heavy" | "medium" | "light"
+    progress_estimator: Callable | None = None
+    protocol_version: int = 0  # 0 = legacy, 1 = fd 3
+    provenance_query: Callable | None = None
+
+
+STAGE_REGISTRY: dict[str, StageDefinition] = {
+    "seed": StageDefinition(
+        name="seed",
+        display_name="Seed Enumerator",
+        command=["python3", "-m", "lavandula.nonprofits.tools.seed_enumerate"],
+        parameters={
+            "states": ParamSpec(required=True, type="state_code", cli_flag="--states"),
+            "target": ParamSpec(type="integer", cli_flag="--target", min_value=1, max_value=999999),
+            "ntee_majors": ParamSpec(type="string", cli_flag="--ntee-majors", pattern=r"^[A-Z,]+$"),
+            "revenue_min": ParamSpec(type="integer", cli_flag="--revenue-min", min_value=0),
+            "revenue_max": ParamSpec(type="integer", cli_flag="--revenue-max", min_value=0),
+        },
+        predecessors=[],
+        conflict_group="per-state",
+        provenance_column="seed_status",
+        retry_policy=RetryPolicy(max_attempts=1),
+        resource_class="light",
+    ),
+    "resolve": StageDefinition(
+        name="resolve",
+        display_name="URL Resolver",
+        command=["python3", "-m", "lavandula.nonprofits.tools.pipeline_resolve"],
+        parameters={
+            "state": ParamSpec(required=True, type="state_code", cli_flag="--state"),
+            "llm_url": ParamSpec(type="string", cli_flag="--llm-url", pattern=r"^https?://"),
+            "llm_model": ParamSpec(type="string", cli_flag="--llm-model"),
+            "llm_api_key_ssm": ParamSpec(type="string", cli_flag="--llm-api-key-ssm"),
+            "brave_qps": ParamSpec(type="float", cli_flag="--search-qps", min_value=0, max_value=50),
+            "search_engines": ParamSpec(type="string", cli_flag="--search-engines", pattern=r"^[a-z,_]+$"),
+            "search_parallelism": ParamSpec(type="integer", cli_flag="--search-parallelism", min_value=1, max_value=32),
+            "consumer_threads": ParamSpec(type="integer", cli_flag="--consumer-threads", min_value=1, max_value=16),
+            "limit": ParamSpec(type="integer", cli_flag="--limit", min_value=0, max_value=999999),
+            "fresh_only": ParamSpec(type="boolean", cli_flag="--fresh-only"),
+        },
+        predecessors=["seed"],
+        conflict_group="per-state",
+        provenance_column="resolve_status",
+        retry_policy=RetryPolicy(max_attempts=2, auto_retry=True, retryable_exit_codes=(1, 3)),
+        resource_class="light",
+    ),
+    "crawl": StageDefinition(
+        name="crawl",
+        display_name="Site Crawler",
+        command=["python3", "-m", "lavandula.reports.crawler"],
+        parameters={
+            "archive": ParamSpec(type="string", cli_flag="--archive", pattern=r"^s3://[a-z0-9][a-z0-9.\-]{1,61}[a-z0-9](/[a-zA-Z0-9._-]+)*$"),
+            "async": ParamSpec(type="boolean", cli_flag="--async"),
+            "limit": ParamSpec(type="integer", cli_flag="--limit", min_value=0, max_value=999999),
+            "max_concurrent_orgs": ParamSpec(type="integer", cli_flag="--max-concurrent-orgs", min_value=1, max_value=500),
+            "max_download_workers": ParamSpec(type="integer", cli_flag="--max-download-workers", min_value=1, max_value=100),
+            "skip_encryption_check": ParamSpec(type="boolean", cli_flag="--skip-encryption-check"),
+            "state": ParamSpec(type="state_code", cli_flag="--state"),
+            "classifier_backend": ParamSpec(type="string", cli_flag="--classifier-backend", pattern=r"^[a-z]+$"),
+        },
+        predecessors=["resolve"],
+        conflict_group="per-state",
+        provenance_column="crawl_status",
+        retry_policy=RetryPolicy(max_attempts=2, auto_retry=True, retryable_exit_codes=(1, 3)),
+        resource_class="heavy",
+    ),
+    "classify": StageDefinition(
+        name="classify",
+        display_name="Document Classifier",
+        command=["python3", "-m", "lavandula.nonprofits.tools.pipeline_classify"],
+        parameters={
+            "llm_url": ParamSpec(type="string", cli_flag="--llm-url", pattern=r"^https?://"),
+            "llm_model": ParamSpec(type="string", cli_flag="--llm-model"),
+            "llm_api_key_ssm": ParamSpec(type="string", cli_flag="--llm-api-key-ssm"),
+            "limit": ParamSpec(type="integer", cli_flag="--limit", min_value=0, max_value=999999),
+            "state": ParamSpec(type="state_code", cli_flag="--state"),
+            "re_classify": ParamSpec(type="boolean", cli_flag="--re-classify"),
+            "definition": ParamSpec(type="string", cli_flag="--definition", pattern=r"^[a-z][a-z0-9_]*$"),
+            "re_classify_definition": ParamSpec(type="string", cli_flag="--re-classify-definition", pattern=r"^[a-z][a-z0-9_]*:v\d+$"),
+        },
+        predecessors=["crawl"],
+        conflict_group="per-state",
+        provenance_column="classify_status",
+        retry_policy=RetryPolicy(max_attempts=2, auto_retry=True, retryable_exit_codes=(1, 3)),
+        resource_class="medium",
+    ),
+    "990-index": StageDefinition(
+        name="990-index",
+        display_name="990 Index Loader",
+        command=["python3", "lavandula/dashboard/manage.py", "load_990_index"],
+        parameters={
+            "ein": ParamSpec(type="string", cli_flag="--ein", pattern=r"^\d{9}$"),
+            "years": ParamSpec(type="string", cli_flag="--years", pattern=r"^\d{4}(\s*,\s*\d{4})*$"),
+            "current_year": ParamSpec(type="boolean", cli_flag="--current-year"),
+        },
+        predecessors=[],
+        conflict_group="990-family",
+        provenance_column="filing_990_status",
+        retry_policy=RetryPolicy(max_attempts=1),
+        resource_class="light",
+    ),
+    "990-parse": StageDefinition(
+        name="990-parse",
+        display_name="990 Parser",
+        command=["python3", "lavandula/dashboard/manage.py", "process_990_auto"],
+        parameters={
+            "ein": ParamSpec(type="string", cli_flag="--ein", pattern=r"^\d{9}$"),
+            "reparse": ParamSpec(type="boolean", cli_flag="--reparse"),
+            "backfill": ParamSpec(type="boolean", cli_flag="--backfill"),
+        },
+        predecessors=["990-index"],
+        conflict_group="990-family",
+        provenance_column=None,
+        retry_policy=RetryPolicy(max_attempts=2, auto_retry=True, retryable_exit_codes=(1, 3)),
+        resource_class="medium",
+    ),
+    "enrich-phone": StageDefinition(
+        name="enrich-phone",
+        display_name="Phone Enrichment",
+        command=["python3", "-m", "lavandula.nonprofits.tools.pipeline_enrich_phone"],
+        parameters={
+            "state": ParamSpec(type="state_code", cli_flag="--state"),
+            "limit": ParamSpec(type="integer", cli_flag="--limit", min_value=0, max_value=999999),
+            "search_engines": ParamSpec(type="string", cli_flag="--search-engines", pattern=r"^[a-z,_]+$"),
+        },
+        predecessors=["resolve"],
+        conflict_group="per-state",
+        provenance_column=None,
+        retry_policy=RetryPolicy(max_attempts=2, auto_retry=True, retryable_exit_codes=(1, 3)),
+        resource_class="light",
+    ),
+}
+
+
+class RegistryValidationError(Exception):
+    pass
+
+
+def validate_registry(registry: dict[str, StageDefinition] | None = None) -> list[str]:
+    """Validate the stage registry. Returns list of error messages (empty = valid)."""
+    if registry is None:
+        registry = STAGE_REGISTRY
+
+    errors = []
+
+    seen_columns = {}
+    for name, stage in registry.items():
+        if stage.name != name:
+            errors.append(f"Stage key '{name}' doesn't match stage.name '{stage.name}'")
+
+        for pred in stage.predecessors:
+            if pred not in registry:
+                errors.append(f"Stage '{name}': predecessor '{pred}' not in registry")
+
+        if stage.provenance_column:
+            if stage.provenance_column in seen_columns:
+                errors.append(
+                    f"Stage '{name}': provenance_column '{stage.provenance_column}' "
+                    f"already used by '{seen_columns[stage.provenance_column]}'"
+                )
+            seen_columns[stage.provenance_column] = name
+
+        if stage.conflict_group and stage.conflict_group not in ("per-state", "global", "990-family"):
+            errors.append(f"Stage '{name}': invalid conflict_group '{stage.conflict_group}'")
+
+        if stage.resource_class not in ("heavy", "medium", "light"):
+            errors.append(f"Stage '{name}': invalid resource_class '{stage.resource_class}'")
+
+        if stage.retry_policy.max_attempts > 3:
+            errors.append(f"Stage '{name}': retry max_attempts > 3")
+
+    # Check for circular predecessors via DFS
+    def _has_cycle(start: str, visited: set, path: set) -> bool:
+        if start in path:
+            return True
+        if start in visited:
+            return False
+        visited.add(start)
+        path.add(start)
+        if start in registry:
+            for pred in registry[start].predecessors:
+                if _has_cycle(pred, visited, path):
+                    return True
+        path.remove(start)
+        return False
+
+    visited: set[str] = set()
+    for name in registry:
+        if _has_cycle(name, visited, set()):
+            errors.append(f"Circular predecessor dependency detected involving '{name}'")
+            break
+
+    return errors

--- a/lavandula/dashboard/pipeline/summary_parser.py
+++ b/lavandula/dashboard/pipeline/summary_parser.py
@@ -1,0 +1,115 @@
+"""
+Summary parser for pipeline stage completion.
+
+Parses the structured DONE lines from each stage's log output into
+normalized summary dicts suitable for JobEvent payloads.
+
+For protocol v0 stages: extracts only exit code, duration, log file size.
+For protocol v1 stages: reads SUMMARY line from fd 3 (handled elsewhere).
+"""
+from __future__ import annotations
+
+import re
+from typing import Any
+
+
+_DONE_PATTERN = re.compile(
+    r"={3,}\s*(.*?)\s*DONE\s*={3,}"
+)
+
+_KV_PATTERN = re.compile(r"(\w+)\s*[=:]\s*([^\s,]+)")
+
+
+def parse_done_line(line: str) -> dict[str, Any]:
+    """Parse a ===...DONE=== line into a summary dict."""
+    match = _DONE_PATTERN.search(line)
+    if not match:
+        return {}
+    content = match.group(1).strip()
+    if not content:
+        return {}
+    result = {}
+    for kv_match in _KV_PATTERN.finditer(content):
+        key = kv_match.group(1).lower()
+        value = kv_match.group(2)
+        if value.isdigit():
+            result[key] = int(value)
+        elif _is_float(value):
+            result[key] = float(value)
+        else:
+            result[key] = value
+    return result
+
+
+def parse_summary_line(line: str) -> dict[str, Any]:
+    """Parse a SUMMARY: key=value line (protocol v1 format)."""
+    if not line.startswith("SUMMARY:"):
+        return {}
+    content = line[len("SUMMARY:"):].strip()
+    result = {}
+    for kv_match in _KV_PATTERN.finditer(content):
+        key = kv_match.group(1).lower()
+        value = kv_match.group(2)
+        if value.isdigit():
+            result[key] = int(value)
+        elif _is_float(value):
+            result[key] = float(value)
+        else:
+            result[key] = value
+    return result
+
+
+def parse_progress_line(line: str) -> dict[str, Any] | None:
+    """Parse a PROGRESS: key=value line (protocol v1 format)."""
+    if not line.startswith("PROGRESS:"):
+        return None
+    content = line[len("PROGRESS:"):].strip()
+    result = {}
+    for kv_match in _KV_PATTERN.finditer(content):
+        key = kv_match.group(1).lower()
+        value = kv_match.group(2)
+        if value.isdigit():
+            result[key] = int(value)
+        elif _is_float(value):
+            result[key] = float(value)
+        else:
+            result[key] = value
+    return result if result else None
+
+
+def parse_error_line(line: str) -> dict[str, str] | None:
+    """Parse an ERROR: class=NAME detail=TEXT line (protocol v1 format)."""
+    if not line.startswith("ERROR:"):
+        return None
+    content = line[len("ERROR:"):].strip()
+    result = {}
+    class_match = re.search(r"class=(\S+)", content)
+    if class_match:
+        result["error_class"] = class_match.group(1)
+    detail_match = re.search(r"detail=(.+)$", content)
+    if detail_match:
+        result["error_detail"] = detail_match.group(1).strip()
+    return result if result else None
+
+
+def build_v0_summary(exit_code: int, duration_s: float | None, log_file: str | None, log_size_bytes: int | None) -> dict:
+    """Build minimal summary for v0 (legacy) stages."""
+    summary = {
+        "exit_code": exit_code,
+        "protocol": "v0",
+    }
+    if duration_s is not None:
+        summary["duration_s"] = round(duration_s)
+    if log_file:
+        summary["log_file"] = log_file
+    if log_size_bytes is not None:
+        summary["log_size_bytes"] = log_size_bytes
+    return summary
+
+
+def _is_float(s: str) -> bool:
+    try:
+        float(s)
+        return "." in s
+    except (ValueError, TypeError):
+        return False

--- a/lavandula/dashboard/pipeline/templates/pipeline/job_detail.html
+++ b/lavandula/dashboard/pipeline/templates/pipeline/job_detail.html
@@ -13,6 +13,8 @@
   <span class="px-3 py-1 rounded text-sm bg-green-100 text-green-800">Completed</span>
   {% elif job.status == "failed" %}
   <span class="px-3 py-1 rounded text-sm bg-red-100 text-red-800">Failed</span>
+  {% elif job.status == "scheduled" %}
+  <span class="px-3 py-1 rounded text-sm bg-purple-100 text-purple-800">Scheduled</span>
   {% elif job.status == "cancelled" %}
   <span class="px-3 py-1 rounded text-sm bg-gray-100 text-gray-600">Cancelled</span>
   {% endif %}
@@ -39,6 +41,12 @@
       {% if job.depends_on %}
       <div class="flex"><dt class="w-32 text-gray-500">Depends On</dt><dd><a href="{% url 'job_detail' job.depends_on.pk %}" class="text-blue-600 hover:underline">Job #{{ job.depends_on.pk }}</a></dd></div>
       {% endif %}
+      {% if job.blocked_reason %}
+      <div class="flex"><dt class="w-32 text-gray-500">Blocked</dt><dd class="text-orange-600">{{ job.blocked_reason }}</dd></div>
+      {% endif %}
+      {% if job.retry_of %}
+      <div class="flex"><dt class="w-32 text-gray-500">Retry Of</dt><dd><a href="{% url 'job_detail' job.retry_of.pk %}" class="text-blue-600 hover:underline">Job #{{ job.retry_of.pk }}</a> (attempt {{ job.attempt_number }})</dd></div>
+      {% endif %}
       {% if job.error_message %}
       <div class="flex"><dt class="w-32 text-gray-500">Error</dt><dd class="text-red-600">{{ job.error_message }}</dd></div>
       {% endif %}
@@ -51,7 +59,7 @@
 
     <!-- Actions -->
     <div class="mt-4 flex gap-2">
-      {% if job.status == "pending" or job.status == "running" %}
+      {% if job.status == "pending" or job.status == "scheduled" or job.status == "running" %}
       <form method="post" action="{% url 'job_cancel' job.pk %}">
         {% csrf_token %}
         <button type="submit" class="bg-red-600 text-white px-4 py-2 rounded text-sm hover:bg-red-700">Cancel</button>
@@ -73,11 +81,33 @@
   </div>
 </div>
 
+<!-- Event Timeline -->
+{% if events %}
+<div class="mt-6 bg-white rounded-lg shadow p-5">
+  <h2 class="text-lg font-semibold text-gray-900 mb-3">Event Timeline</h2>
+  <div class="space-y-2 max-h-96 overflow-auto">
+    {% for event in events %}
+    <div class="flex items-start gap-3 text-sm border-l-2 pl-3 {% if event.event_type == 'error' or event.event_type == 'failed' %}border-red-400{% elif event.event_type == 'completed' %}border-green-400{% elif event.event_type == 'progress' %}border-blue-200{% elif event.event_type == 'warning' %}border-yellow-400{% else %}border-gray-200{% endif %}">
+      <span class="text-xs text-gray-400 whitespace-nowrap">{{ event.timestamp|localtime|date:"M j g:i:s A" }}</span>
+      <span class="font-medium {% if event.event_type == 'error' or event.event_type == 'failed' %}text-red-600{% elif event.event_type == 'completed' %}text-green-600{% elif event.event_type == 'warning' %}text-yellow-600{% else %}text-gray-700{% endif %}">{{ event.get_event_type_display }}</span>
+      {% if event.payload %}
+      <span class="text-gray-500 text-xs">
+        {% for key, value in event.payload.items %}{% if key != "actor" %}{{ key }}={{ value }} {% endif %}{% endfor %}
+      </span>
+      {% endif %}
+    </div>
+    {% endfor %}
+  </div>
+</div>
+{% endif %}
+
 <!-- Log Output -->
+{% if log_content %}
 <div class="mt-6 bg-white rounded-lg shadow p-5">
   <h2 class="text-lg font-semibold text-gray-900 mb-3">Log Output</h2>
   <div hx-get="{% url 'job_log' job.pk %}" hx-trigger="every 5s" hx-swap="innerHTML">
     <pre class="text-xs bg-gray-900 text-green-400 p-4 rounded overflow-auto max-h-96">{{ log_content }}</pre>
   </div>
 </div>
+{% endif %}
 {% endblock %}

--- a/lavandula/dashboard/pipeline/templates/pipeline/jobs.html
+++ b/lavandula/dashboard/pipeline/templates/pipeline/jobs.html
@@ -44,7 +44,7 @@
     <div class="overflow-x-auto">
       <table class="w-full text-sm">
         <thead><tr class="text-left text-gray-500 border-b">
-          <th class="pb-2">ID</th><th class="pb-2">Phase</th><th class="pb-2">State</th><th class="pb-2">Host</th><th class="pb-2">Depends On</th><th class="pb-2">Created</th>
+          <th class="pb-2">ID</th><th class="pb-2">Phase</th><th class="pb-2">State</th><th class="pb-2">Host</th><th class="pb-2">Depends On</th><th class="pb-2">Blocked</th><th class="pb-2">Created</th>
         </tr></thead>
         <tbody>
           {% for job in pending_jobs %}
@@ -54,6 +54,7 @@
             <td class="py-2">{{ job.state_code|default:"global" }}</td>
             <td class="py-2">{{ job.host }}</td>
             <td class="py-2">{% if job.depends_on %}<a href="{% url 'job_detail' job.depends_on.pk %}" class="text-blue-600">#{{ job.depends_on.pk }}</a>{% else %}-{% endif %}</td>
+            <td class="py-2 text-orange-600 text-xs">{{ job.blocked_reason|default:"-" }}</td>
             <td class="py-2 text-gray-500">{{ job.created_at|timesince }} ago</td>
           </tr>
           {% endfor %}

--- a/lavandula/dashboard/pipeline/templates/pipeline/provenance.html
+++ b/lavandula/dashboard/pipeline/templates/pipeline/provenance.html
@@ -1,0 +1,93 @@
+{% extends "pipeline/base.html" %}
+{% load pipeline_tags %}
+{% block title %}Org Pipeline Status — Lavandula Pipeline{% endblock %}
+{% block content %}
+<h1 class="text-2xl font-bold text-gray-900 mb-6">Org Pipeline Status</h1>
+
+<!-- Filters -->
+<form method="get" class="flex flex-wrap gap-3 mb-4 items-end">
+  <div>
+    <label class="text-xs text-gray-500">State</label>
+    <select name="state" class="border rounded px-2 py-1 text-sm">
+      <option value="">All</option>
+      {% for code in state_choices %}
+      <option value="{{ code }}" {% if request.GET.state == code %}selected{% endif %}>{{ code }}</option>
+      {% endfor %}
+    </select>
+  </div>
+  <div>
+    <label class="text-xs text-gray-500">Stage</label>
+    <select name="stage" class="border rounded px-2 py-1 text-sm">
+      <option value="">Any</option>
+      {% for stage in provenance_stages %}
+      <option value="{{ stage.name }}" {% if request.GET.stage == stage.name %}selected{% endif %}>{{ stage.display_name }}</option>
+      {% endfor %}
+    </select>
+  </div>
+  <div>
+    <label class="text-xs text-gray-500">Status</label>
+    <select name="status" class="border rounded px-2 py-1 text-sm">
+      <option value="">Any</option>
+      <option value="not_started" {% if request.GET.status == "not_started" %}selected{% endif %}>Not Started</option>
+      <option value="in_progress" {% if request.GET.status == "in_progress" %}selected{% endif %}>In Progress</option>
+      <option value="completed" {% if request.GET.status == "completed" %}selected{% endif %}>Completed</option>
+      <option value="failed" {% if request.GET.status == "failed" %}selected{% endif %}>Failed</option>
+      <option value="not_applicable" {% if request.GET.status == "not_applicable" %}selected{% endif %}>N/A</option>
+    </select>
+  </div>
+  <div>
+    <label class="text-xs text-gray-500 flex items-center gap-1">
+      <input type="checkbox" name="stuck" {% if request.GET.stuck %}checked{% endif %}>
+      Stuck (failed or in_progress > 7d)
+    </label>
+  </div>
+  <button type="submit" class="bg-blue-600 text-white px-3 py-1 rounded text-sm hover:bg-blue-700">Filter</button>
+</form>
+
+<!-- Results -->
+<div class="bg-white rounded-lg shadow overflow-x-auto">
+  <table class="w-full text-sm">
+    <thead>
+      <tr class="text-left text-gray-500 border-b">
+        <th class="px-3 py-2">EIN</th>
+        {% for stage in provenance_stages %}
+        <th class="px-3 py-2">{{ stage.display_name }}</th>
+        {% endfor %}
+        <th class="px-3 py-2">Updated</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for org in page_obj %}
+      <tr class="border-b hover:bg-gray-50">
+        <td class="px-3 py-2 font-mono text-xs">
+          <a href="{% url 'org_detail' org.ein %}" class="text-blue-600 hover:underline">{{ org.ein }}</a>
+        </td>
+        {% for stage in provenance_stages %}
+        {% with status=org|get_provenance_status:stage.provenance_column %}
+        <td class="px-3 py-2">
+          <span class="px-2 py-0.5 text-xs rounded {% if status == 'completed' %}bg-green-100 text-green-800{% elif status == 'in_progress' %}bg-yellow-100 text-yellow-800{% elif status == 'failed' %}bg-red-100 text-red-800{% elif status == 'not_applicable' %}bg-blue-100 text-blue-800{% else %}bg-gray-100 text-gray-500{% endif %}">{{ status }}</span>
+        </td>
+        {% endwith %}
+        {% endfor %}
+        <td class="px-3 py-2 text-gray-500 text-xs">{{ org.updated_at|timesince }} ago</td>
+      </tr>
+      {% empty %}
+      <tr><td colspan="99" class="px-3 py-4 text-gray-500 text-center">No results.</td></tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</div>
+
+<!-- Pagination -->
+{% if page_obj.has_other_pages %}
+<div class="flex gap-2 mt-4 justify-center">
+  {% if page_obj.has_previous %}
+  <a href="?page={{ page_obj.previous_page_number }}&{{ filter_params }}" class="px-3 py-1 border rounded text-sm hover:bg-gray-50">Prev</a>
+  {% endif %}
+  <span class="px-3 py-1 text-sm text-gray-500">Page {{ page_obj.number }} of {{ page_obj.paginator.num_pages }}</span>
+  {% if page_obj.has_next %}
+  <a href="?page={{ page_obj.next_page_number }}&{{ filter_params }}" class="px-3 py-1 border rounded text-sm hover:bg-gray-50">Next</a>
+  {% endif %}
+</div>
+{% endif %}
+{% endblock %}

--- a/lavandula/dashboard/pipeline/templatetags/pipeline_tags.py
+++ b/lavandula/dashboard/pipeline/templatetags/pipeline_tags.py
@@ -111,3 +111,11 @@ def dictget(d, key):
     if not isinstance(d, dict):
         return None
     return d.get(key)
+
+
+@register.filter
+def get_provenance_status(obj, column):
+    """Get the value of a provenance column from an OrgProvenance instance."""
+    if not column:
+        return "not_started"
+    return getattr(obj, column, "not_started")

--- a/lavandula/dashboard/pipeline/tests/test_job_events.py
+++ b/lavandula/dashboard/pipeline/tests/test_job_events.py
@@ -1,0 +1,34 @@
+"""Tests for JobEvent model and helper functions."""
+import json
+
+from django.test import SimpleTestCase
+
+from pipeline.models import PAYLOAD_MAX_BYTES, truncate_payload
+
+
+class TestTruncatePayload(SimpleTestCase):
+    def test_small_payload_unchanged(self):
+        payload = {"exit_code": 0, "duration_s": 100}
+        result = truncate_payload(payload)
+        self.assertEqual(result, payload)
+
+    def test_large_payload_truncated(self):
+        payload = {"detail": "x" * 100000}
+        result = truncate_payload(payload)
+        self.assertTrue(result.get("_truncated"))
+        self.assertLess(len(json.dumps(result)), PAYLOAD_MAX_BYTES * 2)
+
+    def test_large_string_value_capped(self):
+        # Must exceed 64KB to trigger truncation
+        payload = {"error_detail": "a" * 70000, "exit_code": 1}
+        result = truncate_payload(payload)
+        self.assertTrue(result["_truncated"])
+        self.assertLessEqual(len(result["error_detail"]), 504)
+        self.assertEqual(result["exit_code"], 1)
+
+    def test_non_string_values_preserved(self):
+        payload = {"count": 999, "nested": {"a": 1}, "flag": True}
+        result = truncate_payload(payload)
+        self.assertEqual(result["count"], 999)
+        self.assertEqual(result["nested"], {"a": 1})
+        self.assertEqual(result["flag"], True)

--- a/lavandula/dashboard/pipeline/tests/test_job_lifecycle.py
+++ b/lavandula/dashboard/pipeline/tests/test_job_lifecycle.py
@@ -1,0 +1,73 @@
+"""Tests for job lifecycle state transitions, retry chains, and cancellation."""
+from django.test import SimpleTestCase
+
+from pipeline.models import Job
+
+
+class TestJobTransitions(SimpleTestCase):
+    def _make_job(self, status="pending"):
+        job = Job.__new__(Job)
+        job.status = status
+        return job
+
+    def test_pending_to_scheduled(self):
+        job = self._make_job("pending")
+        self.assertTrue(job.can_transition_to("scheduled"))
+
+    def test_pending_to_cancelled(self):
+        job = self._make_job("pending")
+        self.assertTrue(job.can_transition_to("cancelled"))
+
+    def test_pending_to_running_blocked(self):
+        job = self._make_job("pending")
+        self.assertFalse(job.can_transition_to("running"))
+
+    def test_scheduled_to_running(self):
+        job = self._make_job("scheduled")
+        self.assertTrue(job.can_transition_to("running"))
+
+    def test_scheduled_to_failed(self):
+        job = self._make_job("scheduled")
+        self.assertTrue(job.can_transition_to("failed"))
+
+    def test_scheduled_to_pending(self):
+        job = self._make_job("scheduled")
+        self.assertTrue(job.can_transition_to("pending"))
+
+    def test_running_to_completed(self):
+        job = self._make_job("running")
+        self.assertTrue(job.can_transition_to("completed"))
+
+    def test_running_to_failed(self):
+        job = self._make_job("running")
+        self.assertTrue(job.can_transition_to("failed"))
+
+    def test_running_to_cancelled(self):
+        job = self._make_job("running")
+        self.assertTrue(job.can_transition_to("cancelled"))
+
+    def test_completed_is_terminal(self):
+        job = self._make_job("completed")
+        self.assertFalse(job.can_transition_to("running"))
+        self.assertFalse(job.can_transition_to("pending"))
+        self.assertFalse(job.can_transition_to("failed"))
+
+    def test_failed_is_terminal(self):
+        job = self._make_job("failed")
+        self.assertFalse(job.can_transition_to("running"))
+        self.assertFalse(job.can_transition_to("pending"))
+
+    def test_cancelled_is_terminal(self):
+        job = self._make_job("cancelled")
+        self.assertFalse(job.can_transition_to("running"))
+        self.assertFalse(job.can_transition_to("pending"))
+
+    def test_transition_status_raises_on_invalid(self):
+        job = self._make_job("completed")
+        with self.assertRaises(ValueError):
+            job.transition_status("running")
+
+    def test_transition_status_raises_pending_to_running(self):
+        job = self._make_job("pending")
+        with self.assertRaises(ValueError):
+            job.transition_status("running")

--- a/lavandula/dashboard/pipeline/tests/test_param_validators.py
+++ b/lavandula/dashboard/pipeline/tests/test_param_validators.py
@@ -1,0 +1,221 @@
+"""Tests for parameter validation and argv construction."""
+from django.test import SimpleTestCase
+
+from pipeline.param_validators import (
+    ValidationError,
+    build_argv,
+    build_argv_for_phase,
+    validate_config,
+    validate_param,
+)
+from pipeline.stages import ParamSpec, RetryPolicy, StageDefinition, STAGE_REGISTRY
+
+
+class TestValidateParam(SimpleTestCase):
+    def test_state_code_valid(self):
+        spec = ParamSpec(type="state_code")
+        self.assertEqual(validate_param("state", "CA", spec), "CA")
+        self.assertEqual(validate_param("state", "ca", spec), "CA")  # case insensitive
+
+    def test_state_code_invalid(self):
+        spec = ParamSpec(type="state_code")
+        with self.assertRaises(ValidationError):
+            validate_param("state", "XX", spec)
+
+    def test_state_code_territories(self):
+        spec = ParamSpec(type="state_code")
+        self.assertEqual(validate_param("state", "DC", spec), "DC")
+        self.assertEqual(validate_param("state", "PR", spec), "PR")
+        self.assertEqual(validate_param("state", "GU", spec), "GU")
+
+    def test_integer_valid(self):
+        spec = ParamSpec(type="integer", min_value=1, max_value=100)
+        self.assertEqual(validate_param("n", "50", spec), "50")
+        self.assertEqual(validate_param("n", 50, spec), "50")
+
+    def test_integer_below_min(self):
+        spec = ParamSpec(type="integer", min_value=1, max_value=100)
+        with self.assertRaises(ValidationError):
+            validate_param("n", "0", spec)
+
+    def test_integer_above_max(self):
+        spec = ParamSpec(type="integer", min_value=1, max_value=100)
+        with self.assertRaises(ValidationError):
+            validate_param("n", "101", spec)
+
+    def test_integer_not_a_number(self):
+        spec = ParamSpec(type="integer")
+        with self.assertRaises(ValidationError):
+            validate_param("n", "abc", spec)
+
+    def test_float_valid(self):
+        spec = ParamSpec(type="float", min_value=0, max_value=50)
+        self.assertEqual(validate_param("qps", "10.5", spec), "10.5")
+
+    def test_float_invalid(self):
+        spec = ParamSpec(type="float")
+        with self.assertRaises(ValidationError):
+            validate_param("qps", "not-a-float", spec)
+
+    def test_boolean_true_variants(self):
+        spec = ParamSpec(type="boolean")
+        self.assertIsNone(validate_param("flag", True, spec))
+        self.assertIsNone(validate_param("flag", "true", spec))
+        self.assertIsNone(validate_param("flag", "on", spec))
+
+    def test_boolean_false_variants(self):
+        spec = ParamSpec(type="boolean")
+        self.assertEqual(validate_param("flag", False, spec), "")
+        self.assertEqual(validate_param("flag", "false", spec), "")
+
+    def test_boolean_invalid(self):
+        spec = ParamSpec(type="boolean")
+        with self.assertRaises(ValidationError):
+            validate_param("flag", "maybe", spec)
+
+    def test_string_valid(self):
+        spec = ParamSpec(type="string")
+        self.assertEqual(validate_param("name", "hello-world", spec), "hello-world")
+
+    def test_string_shell_metachar_rejected(self):
+        spec = ParamSpec(type="string")
+        for bad in ["; rm -rf /", "$(whoami)", "`id`", "a|b", "a&b", "a\\b"]:
+            with self.assertRaises(ValidationError, msg=f"Should reject: {bad!r}"):
+                validate_param("name", bad, spec)
+
+    def test_string_null_byte_rejected(self):
+        spec = ParamSpec(type="string")
+        with self.assertRaises(ValidationError):
+            validate_param("name", "hello\x00world", spec)
+
+    def test_string_too_long(self):
+        spec = ParamSpec(type="string")
+        with self.assertRaises(ValidationError):
+            validate_param("name", "x" * 201, spec)
+
+    def test_string_pattern_match(self):
+        spec = ParamSpec(type="string", pattern=r"^\d{9}$")
+        self.assertEqual(validate_param("ein", "123456789", spec), "123456789")
+
+    def test_string_pattern_mismatch(self):
+        spec = ParamSpec(type="string", pattern=r"^\d{9}$")
+        with self.assertRaises(ValidationError):
+            validate_param("ein", "12345", spec)
+
+    def test_choice_valid(self):
+        spec = ParamSpec(type="choice", choices=["brave", "google"])
+        self.assertEqual(validate_param("engine", "brave", spec), "brave")
+
+    def test_choice_invalid(self):
+        spec = ParamSpec(type="choice", choices=["brave", "google"])
+        with self.assertRaises(ValidationError):
+            validate_param("engine", "bing", spec)
+
+    def test_unknown_type_rejected(self):
+        spec = ParamSpec(type="unknown_type")
+        with self.assertRaises(ValidationError):
+            validate_param("x", "val", spec)
+
+
+class TestValidateConfig(SimpleTestCase):
+    def test_unknown_param_rejected(self):
+        stage = STAGE_REGISTRY["resolve"]
+        with self.assertRaises(ValidationError) as ctx:
+            validate_config(stage, {"nonexistent_param": "value"})
+        self.assertIn("Unknown parameter", str(ctx.exception))
+
+    def test_required_param_missing(self):
+        stage = STAGE_REGISTRY["resolve"]
+        with self.assertRaises(ValidationError) as ctx:
+            validate_config(stage, {"limit": 100})  # missing required 'state'
+        self.assertIn("required", str(ctx.exception))
+
+    def test_valid_config(self):
+        stage = STAGE_REGISTRY["resolve"]
+        result = validate_config(stage, {"state": "CA", "limit": 100})
+        self.assertEqual(result["state"], "CA")
+        self.assertEqual(result["limit"], "100")
+
+    def test_optional_params_skipped(self):
+        stage = STAGE_REGISTRY["resolve"]
+        result = validate_config(stage, {"state": "WA"})
+        self.assertEqual(result, {"state": "WA"})
+
+
+class TestBuildArgv(SimpleTestCase):
+    def test_resolve_basic(self):
+        stage = STAGE_REGISTRY["resolve"]
+        argv = build_argv(stage, {"state": "CA"})
+        self.assertEqual(argv[:4], ["python3", "-m", "lavandula.nonprofits.tools.pipeline_resolve", "--state"])
+        self.assertIn("CA", argv)
+
+    def test_resolve_with_options(self):
+        stage = STAGE_REGISTRY["resolve"]
+        argv = build_argv(stage, {"state": "WA", "limit": 500, "fresh_only": True})
+        self.assertIn("--state", argv)
+        self.assertIn("WA", argv)
+        self.assertIn("--limit", argv)
+        self.assertIn("500", argv)
+        self.assertIn("--fresh-only", argv)
+
+    def test_boolean_false_not_in_argv(self):
+        stage = STAGE_REGISTRY["resolve"]
+        argv = build_argv(stage, {"state": "NY", "fresh_only": False})
+        self.assertNotIn("--fresh-only", argv)
+
+    def test_crawl_with_archive(self):
+        stage = STAGE_REGISTRY["crawl"]
+        argv = build_argv(stage, {"archive": "s3://lavandula-nonprofit-collaterals"})
+        self.assertIn("--archive", argv)
+        self.assertIn("s3://lavandula-nonprofit-collaterals", argv)
+
+    def test_990_index(self):
+        stage = STAGE_REGISTRY["990-index"]
+        argv = build_argv(stage, {"ein": "123456789", "current_year": True})
+        self.assertIn("--ein", argv)
+        self.assertIn("123456789", argv)
+        self.assertIn("--current-year", argv)
+
+    def test_invalid_param_raises(self):
+        stage = STAGE_REGISTRY["resolve"]
+        with self.assertRaises(ValidationError):
+            build_argv(stage, {"state": "INVALID"})
+
+    def test_shell_metachar_in_param_raises(self):
+        stage = STAGE_REGISTRY["crawl"]
+        with self.assertRaises(ValidationError):
+            build_argv(stage, {"archive": "s3://bucket; rm -rf /"})
+
+    def test_build_argv_for_phase_convenience(self):
+        argv = build_argv_for_phase("seed", {"states": "CA", "target": 1000})
+        self.assertEqual(argv[0], "python3")
+        self.assertIn("--states", argv)
+        self.assertIn("CA", argv)
+        self.assertIn("--target", argv)
+        self.assertIn("1000", argv)
+
+    def test_build_argv_unknown_phase(self):
+        with self.assertRaises(ValidationError):
+            build_argv_for_phase("nonexistent", {})
+
+    def test_command_is_list_not_string(self):
+        for stage in STAGE_REGISTRY.values():
+            argv = build_argv(stage, self._minimal_config(stage))
+            self.assertIsInstance(argv, list)
+            for element in argv:
+                self.assertIsInstance(element, str)
+
+    def _minimal_config(self, stage: StageDefinition) -> dict:
+        """Build minimal valid config with only required params."""
+        config = {}
+        for name, spec in stage.parameters.items():
+            if spec.required:
+                if spec.type == "state_code":
+                    config[name] = "CA"
+                elif spec.type == "integer":
+                    config[name] = spec.min_value or 1
+                elif spec.type == "string":
+                    config[name] = "test"
+                elif spec.type == "boolean":
+                    config[name] = True
+        return config

--- a/lavandula/dashboard/pipeline/tests/test_protocol.py
+++ b/lavandula/dashboard/pipeline/tests/test_protocol.py
@@ -1,0 +1,98 @@
+"""Tests for the pipeline_protocol emission library."""
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+from django.test import SimpleTestCase
+
+# Paths needed for subprocess imports
+_DASHBOARD_ROOT = str(Path(__file__).resolve().parents[2])
+_PROJECT_ROOT = str(Path(__file__).resolve().parents[4])
+
+
+class TestProtocolEmission(SimpleTestCase):
+    """Test emission by running in a subprocess with fd 3 properly set up."""
+
+    def _run_emission_script(self, code: str) -> str:
+        """Run Python code in a subprocess with fd 3 piped back to us."""
+        r_fd, w_fd = os.pipe()
+        script = (
+            f"import os, sys\n"
+            f"sys.path.insert(0, {_DASHBOARD_ROOT!r})\n"
+            f"sys.path.insert(0, {_PROJECT_ROOT!r})\n"
+            f"os.dup2(int(sys.argv[1]), 3)\n"
+            f"os.close(int(sys.argv[1]))\n"
+            f"import lavandula.pipeline_protocol as proto\n"
+            f"{code}\n"
+        )
+        proc = subprocess.Popen(
+            [sys.executable, "-c", script, str(w_fd)],
+            pass_fds=(w_fd,),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        os.close(w_fd)
+        proc.wait()
+        data = os.read(r_fd, 65536)
+        os.close(r_fd)
+        if proc.returncode != 0:
+            self.fail(f"Subprocess failed: {proc.stderr.read().decode()}")
+        return data.decode("utf-8")
+
+    def test_emit_progress_basic(self):
+        output = self._run_emission_script("proto.emit_progress(current=500, total=3589)")
+        self.assertIn("PROGRESS:", output)
+        self.assertIn("current=500", output)
+        self.assertIn("total=3589", output)
+
+    def test_emit_progress_with_extra_kwargs(self):
+        output = self._run_emission_script('proto.emit_progress(current=100, rate="437")')
+        self.assertIn("current=100", output)
+        self.assertIn("rate=437", output)
+
+    def test_emit_error(self):
+        output = self._run_emission_script('proto.emit_error("flush_failure", "3 unresolved")')
+        self.assertIn("ERROR:", output)
+        self.assertIn("class=flush_failure", output)
+        self.assertIn("detail=3 unresolved", output)
+
+    def test_emit_error_strips_newlines(self):
+        output = self._run_emission_script(r'proto.emit_error("test", "line1\nline2\nline3")')
+        self.assertIn("line1 line2 line3", output)
+        lines = [l for l in output.strip().split("\n") if l.startswith("ERROR:")]
+        self.assertEqual(len(lines), 1)
+
+    def test_emit_summary(self):
+        output = self._run_emission_script(
+            "proto.emit_summary(duration_s=29376, records_processed=3537)"
+        )
+        self.assertIn("SUMMARY:", output)
+        self.assertIn("duration_s=29376", output)
+        self.assertIn("records_processed=3537", output)
+
+    def test_emit_warning(self):
+        output = self._run_emission_script('proto.emit_warning("slow", "API took 30s")')
+        self.assertIn("WARNING:", output)
+        self.assertIn("class=slow", output)
+
+    def test_fd3_unavailable_noop(self):
+        """When fd 3 is not available, emit functions are no-ops (no crash)."""
+        script = (
+            f"import os, sys\n"
+            f"sys.path.insert(0, {_DASHBOARD_ROOT!r})\n"
+            f"sys.path.insert(0, {_PROJECT_ROOT!r})\n"
+            f"import lavandula.pipeline_protocol as proto\n"
+            f"proto.emit_progress(current=1)\n"
+            f"proto.emit_error('test', 'detail')\n"
+            f"proto.emit_summary(x=1)\n"
+            f"print('OK')\n"
+        )
+        proc = subprocess.Popen(
+            [sys.executable, "-c", script],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        stdout, stderr = proc.communicate()
+        self.assertEqual(proc.returncode, 0, f"Failed: {stderr.decode()}")
+        self.assertIn(b"OK", stdout)

--- a/lavandula/dashboard/pipeline/tests/test_protocol_reader.py
+++ b/lavandula/dashboard/pipeline/tests/test_protocol_reader.py
@@ -1,0 +1,88 @@
+"""Tests for the protocol reader (orchestrator side)."""
+import os
+import time
+
+from django.test import SimpleTestCase
+
+from pipeline.protocol_reader import ProtocolReader, create_protocol_pipe
+
+
+class TestProtocolReader(SimpleTestCase):
+    def _run_reader(self, write_data: bytes, **callbacks):
+        """Helper: create pipe, start reader, write data, close, wait for processing."""
+        r_fd, w_fd = create_protocol_pipe()
+        reader = ProtocolReader(r_fd, **callbacks)
+        reader.start()
+        os.write(w_fd, write_data)
+        os.close(w_fd)
+        # Wait for the reader thread to finish (pipe closed = EOF = thread exits)
+        reader._thread.join(timeout=2)
+        return reader
+
+    def test_parses_progress(self):
+        received = []
+        self._run_reader(
+            b"PROGRESS: current=100 total=500\n",
+            on_progress=lambda p: received.append(p),
+        )
+        self.assertEqual(len(received), 1)
+        self.assertEqual(received[0]["current"], 100)
+        self.assertEqual(received[0]["total"], 500)
+
+    def test_parses_error(self):
+        received = []
+        reader = self._run_reader(
+            b"ERROR: class=timeout detail=Connection timed out after 30s\n",
+            on_error=lambda e: received.append(e),
+        )
+        self.assertEqual(len(received), 1)
+        self.assertEqual(received[0]["error_class"], "timeout")
+        self.assertIn("Connection timed out", received[0]["error_detail"])
+        self.assertEqual(len(reader.errors), 1)
+
+    def test_parses_summary(self):
+        reader = self._run_reader(
+            b"SUMMARY: duration_s=100 records_processed=500\n",
+        )
+        self.assertIsNotNone(reader.last_summary)
+        self.assertEqual(reader.last_summary["duration_s"], 100)
+        self.assertEqual(reader.last_summary["records_processed"], 500)
+
+    def test_handles_malformed_lines(self):
+        received = []
+        self._run_reader(
+            b"this is not a protocol line\nPROGRESS: current=42\nalso garbage\n",
+            on_progress=lambda p: received.append(p),
+        )
+        self.assertEqual(len(received), 1)
+        self.assertEqual(received[0]["current"], 42)
+
+    def test_handles_empty_lines(self):
+        received = []
+        self._run_reader(
+            b"\n\n\nPROGRESS: current=1\n\n",
+            on_progress=lambda p: received.append(p),
+        )
+        self.assertEqual(len(received), 1)
+
+    def test_multiple_events_in_sequence(self):
+        progress_events = []
+        error_events = []
+        self._run_reader(
+            b"PROGRESS: current=10 total=100\n"
+            b"PROGRESS: current=50 total=100\n"
+            b"ERROR: class=warning detail=slow\n"
+            b"PROGRESS: current=100 total=100\n",
+            on_progress=lambda p: progress_events.append(p),
+            on_error=lambda e: error_events.append(e),
+        )
+        self.assertEqual(len(progress_events), 3)
+        self.assertEqual(len(error_events), 1)
+
+    def test_stop_idempotent(self):
+        r_fd, w_fd = create_protocol_pipe()
+        reader = ProtocolReader(r_fd)
+        reader.start()
+        os.close(w_fd)
+        reader.stop()
+        reader.stop()  # Should not raise

--- a/lavandula/dashboard/pipeline/tests/test_provenance.py
+++ b/lavandula/dashboard/pipeline/tests/test_provenance.py
@@ -1,0 +1,123 @@
+"""Tests for provenance writer and file reader."""
+import json
+import os
+import tempfile
+
+from django.test import SimpleTestCase
+
+from pipeline.provenance import (
+    VALID_STATUSES,
+    ProvenanceSecurityError,
+    read_provenance_file,
+)
+
+
+class TestValidStatuses(SimpleTestCase):
+    def test_expected_statuses(self):
+        self.assertEqual(
+            VALID_STATUSES,
+            {"not_started", "in_progress", "completed", "failed", "not_applicable"},
+        )
+
+
+class TestReadProvenanceFile(SimpleTestCase):
+    def test_read_valid_file(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            file_path = os.path.join(tmpdir, "123.jsonl")
+            with open(file_path, "w") as f:
+                f.write(json.dumps({"ein": "123456789", "status": "completed"}) + "\n")
+                f.write(json.dumps({"ein": "987654321", "status": "failed"}) + "\n")
+
+            import pipeline.provenance as prov
+            orig = prov.PROVENANCE_BASE_DIR
+            prov.PROVENANCE_BASE_DIR = tmpdir
+            try:
+                outcomes = read_provenance_file(123)
+                self.assertEqual(len(outcomes), 2)
+                self.assertEqual(outcomes[0], ("123456789", "completed"))
+                self.assertEqual(outcomes[1], ("987654321", "failed"))
+            finally:
+                prov.PROVENANCE_BASE_DIR = orig
+
+    def test_skips_invalid_status(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            file_path = os.path.join(tmpdir, "456.jsonl")
+            with open(file_path, "w") as f:
+                f.write(json.dumps({"ein": "111111111", "status": "invalid_status"}) + "\n")
+                f.write(json.dumps({"ein": "222222222", "status": "completed"}) + "\n")
+
+            import pipeline.provenance as prov
+            orig = prov.PROVENANCE_BASE_DIR
+            prov.PROVENANCE_BASE_DIR = tmpdir
+            try:
+                outcomes = read_provenance_file(456)
+                self.assertEqual(len(outcomes), 1)
+                self.assertEqual(outcomes[0], ("222222222", "completed"))
+            finally:
+                prov.PROVENANCE_BASE_DIR = orig
+
+    def test_skips_malformed_json(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            file_path = os.path.join(tmpdir, "789.jsonl")
+            with open(file_path, "w") as f:
+                f.write("not json\n")
+                f.write(json.dumps({"ein": "333333333", "status": "completed"}) + "\n")
+
+            import pipeline.provenance as prov
+            orig = prov.PROVENANCE_BASE_DIR
+            prov.PROVENANCE_BASE_DIR = tmpdir
+            try:
+                outcomes = read_provenance_file(789)
+                self.assertEqual(len(outcomes), 1)
+            finally:
+                prov.PROVENANCE_BASE_DIR = orig
+
+    def test_path_traversal_rejected(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Create a symlink pointing outside the base dir
+            import pipeline.provenance as prov
+            orig = prov.PROVENANCE_BASE_DIR
+            prov.PROVENANCE_BASE_DIR = tmpdir
+
+            try:
+                # Manually override the file path logic
+                evil_path = os.path.join(tmpdir, "..", "etc", "passwd")
+                # The function computes path from job_id, so no direct injection.
+                # But test the realpath check indirectly:
+                # Create a symlink inside base dir pointing elsewhere
+                link_path = os.path.join(tmpdir, "999.jsonl")
+                target = "/etc/hostname"
+                if os.path.exists(target):
+                    os.symlink(target, link_path)
+                    with self.assertRaises(ProvenanceSecurityError):
+                        read_provenance_file(999)
+            finally:
+                prov.PROVENANCE_BASE_DIR = orig
+
+    def test_file_not_found(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            import pipeline.provenance as prov
+            orig = prov.PROVENANCE_BASE_DIR
+            prov.PROVENANCE_BASE_DIR = tmpdir
+            try:
+                with self.assertRaises(FileNotFoundError):
+                    read_provenance_file(99999)
+            finally:
+                prov.PROVENANCE_BASE_DIR = orig
+
+    def test_skips_empty_lines(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            file_path = os.path.join(tmpdir, "100.jsonl")
+            with open(file_path, "w") as f:
+                f.write("\n")
+                f.write(json.dumps({"ein": "444444444", "status": "completed"}) + "\n")
+                f.write("\n")
+
+            import pipeline.provenance as prov
+            orig = prov.PROVENANCE_BASE_DIR
+            prov.PROVENANCE_BASE_DIR = tmpdir
+            try:
+                outcomes = read_provenance_file(100)
+                self.assertEqual(len(outcomes), 1)
+            finally:
+                prov.PROVENANCE_BASE_DIR = orig

--- a/lavandula/dashboard/pipeline/tests/test_scheduler.py
+++ b/lavandula/dashboard/pipeline/tests/test_scheduler.py
@@ -1,0 +1,165 @@
+"""Tests for the scheduler scoring function."""
+from datetime import timedelta
+from unittest.mock import MagicMock, patch
+
+from django.test import SimpleTestCase
+from django.utils import timezone
+
+from pipeline.scheduler import score_placement, select_next_jobs
+from pipeline.scheduler_config import SchedulerConfig
+
+
+def _make_job(**kwargs):
+    job = MagicMock()
+    job.phase = kwargs.get("phase", "crawl")
+    job.pk = kwargs.get("pk", 1)
+    job.created_at = kwargs.get("created_at", timezone.now())
+    job.state_code = kwargs.get("state_code", "CA")
+    return job
+
+
+def _make_worker(**kwargs):
+    worker = MagicMock()
+    worker.hostname = kwargs.get("hostname", "worker1")
+    worker.cpu_pct = kwargs.get("cpu_pct", 50.0)
+    worker.mem_pct = kwargs.get("mem_pct", 50.0)
+    worker.has_gpu = kwargs.get("has_gpu", False)
+    return worker
+
+
+class TestScorePlacement(SimpleTestCase):
+    def setUp(self):
+        self.config = SchedulerConfig()
+
+    @patch("pipeline.scheduler.Job.objects")
+    def test_cpu_ceiling_blocks(self, mock_qs):
+        job = _make_job()
+        worker = _make_worker(cpu_pct=95.0)
+        score = score_placement(job, worker, self.config)
+        self.assertIsNone(score)
+
+    @patch("pipeline.scheduler.Job.objects")
+    def test_memory_ceiling_blocks(self, mock_qs):
+        job = _make_job()
+        worker = _make_worker(mem_pct=80.0)
+        score = score_placement(job, worker, self.config)
+        self.assertIsNone(score)
+
+    @patch("pipeline.scheduler.Job.objects")
+    def test_heavy_concurrency_blocks(self, mock_qs):
+        mock_qs.filter.return_value.count.return_value = 2
+        mock_qs.filter.return_value.exists.return_value = False
+        job = _make_job(phase="crawl")
+        worker = _make_worker(mem_pct=50.0, cpu_pct=50.0)
+        score = score_placement(job, worker, self.config)
+        self.assertIsNone(score)
+
+    @patch("pipeline.scheduler.Job.objects")
+    def test_gpu_required_blocks_non_gpu(self, mock_qs):
+        mock_qs.filter.return_value.count.return_value = 0
+        mock_qs.filter.return_value.exists.return_value = False
+        config = SchedulerConfig(
+            stage_weights={"classify": {"gpu_preferred": True}}
+        )
+        job = _make_job(phase="classify")
+        worker = _make_worker(has_gpu=False)
+        score = score_placement(job, worker, config)
+        self.assertIsNone(score)
+
+    @patch("pipeline.scheduler.Job.objects")
+    def test_cool_down_blocks(self, mock_qs):
+        mock_qs.filter.return_value.count.return_value = 0
+        mock_qs.filter.return_value.exists.return_value = True
+        job = _make_job(phase="resolve")
+        worker = _make_worker(mem_pct=50.0, cpu_pct=50.0)
+        score = score_placement(job, worker, self.config)
+        self.assertIsNone(score)
+
+    @patch("pipeline.scheduler.Job.objects")
+    def test_basic_scoring(self, mock_qs):
+        mock_qs.filter.return_value.count.return_value = 0
+        mock_qs.filter.return_value.exists.return_value = False
+        job = _make_job(phase="resolve")
+        worker = _make_worker(mem_pct=30.0, cpu_pct=50.0)
+        score = score_placement(job, worker, self.config)
+        self.assertIsNotNone(score)
+        self.assertGreater(score, 1.0)
+
+    @patch("pipeline.scheduler.Job.objects")
+    def test_host_affinity_bonus(self, mock_qs):
+        mock_qs.filter.return_value.count.return_value = 0
+        mock_qs.filter.return_value.exists.return_value = False
+        config = SchedulerConfig(
+            stage_weights={"resolve": {"prefer_hosts": ["worker1"]}}
+        )
+        job = _make_job(phase="resolve")
+        worker = _make_worker(hostname="worker1", mem_pct=50.0, cpu_pct=50.0)
+        score = score_placement(job, worker, config)
+        self.assertIsNotNone(score)
+        self.assertGreater(score, 1.3)
+
+    @patch("pipeline.scheduler.Job.objects")
+    def test_starvation_boost(self, mock_qs):
+        mock_qs.filter.return_value.count.return_value = 0
+        mock_qs.filter.return_value.exists.return_value = False
+        old_job = _make_job(
+            phase="resolve",
+            created_at=timezone.now() - timedelta(hours=2),
+        )
+        recent_job = _make_job(
+            phase="resolve",
+            pk=2,
+            created_at=timezone.now(),
+        )
+        worker = _make_worker(mem_pct=50.0, cpu_pct=50.0)
+        old_score = score_placement(old_job, worker, self.config)
+        new_score = score_placement(recent_job, worker, self.config)
+        self.assertIsNotNone(old_score)
+        self.assertIsNotNone(new_score)
+        self.assertGreater(old_score, new_score)
+
+    def test_unknown_phase_returns_none(self):
+        job = _make_job(phase="nonexistent")
+        worker = _make_worker()
+        score = score_placement(job, worker, self.config)
+        self.assertIsNone(score)
+
+    @patch("pipeline.scheduler.Job.objects")
+    def test_null_metrics_allowed(self, mock_qs):
+        mock_qs.filter.return_value.count.return_value = 0
+        mock_qs.filter.return_value.exists.return_value = False
+        job = _make_job(phase="resolve")
+        worker = _make_worker(cpu_pct=None, mem_pct=None)
+        score = score_placement(job, worker, self.config)
+        self.assertIsNotNone(score)
+
+
+class TestSelectNextJobs(SimpleTestCase):
+    @patch("pipeline.scheduler.score_placement")
+    def test_greedy_assignment(self, mock_score):
+        mock_score.return_value = 1.0
+        jobs = [_make_job(pk=1, phase="resolve"), _make_job(pk=2, phase="crawl")]
+        workers = [_make_worker(hostname="w1"), _make_worker(hostname="w2")]
+        config = SchedulerConfig()
+        result = select_next_jobs(jobs, workers, config)
+        self.assertEqual(len(result), 2)
+        assigned_hosts = {w.hostname for _, w in result}
+        self.assertEqual(len(assigned_hosts), 2)
+
+    @patch("pipeline.scheduler.score_placement")
+    def test_no_double_assignment(self, mock_score):
+        mock_score.return_value = 1.0
+        jobs = [_make_job(pk=1), _make_job(pk=2)]
+        workers = [_make_worker(hostname="w1")]
+        config = SchedulerConfig()
+        result = select_next_jobs(jobs, workers, config)
+        self.assertEqual(len(result), 1)
+
+    @patch("pipeline.scheduler.score_placement")
+    def test_blocked_jobs_excluded(self, mock_score):
+        mock_score.return_value = None
+        jobs = [_make_job(pk=1)]
+        workers = [_make_worker(hostname="w1")]
+        config = SchedulerConfig()
+        result = select_next_jobs(jobs, workers, config)
+        self.assertEqual(len(result), 0)

--- a/lavandula/dashboard/pipeline/tests/test_scheduler_config.py
+++ b/lavandula/dashboard/pipeline/tests/test_scheduler_config.py
@@ -1,0 +1,81 @@
+"""Tests for scheduler config loading and hot-reload."""
+import tempfile
+from pathlib import Path
+
+from django.test import SimpleTestCase
+
+from pipeline.scheduler_config import (
+    SchedulerConfig,
+    load_config,
+    set_config_path,
+)
+
+
+class TestSchedulerConfig(SimpleTestCase):
+    def test_default_config(self):
+        config = SchedulerConfig()
+        self.assertEqual(config.max_concurrent_heavy, 2)
+        self.assertEqual(config.memory_ceiling_pct, 75.0)
+        self.assertEqual(config.cpu_ceiling_pct, 90.0)
+        self.assertEqual(config.cool_down_after_failure_s, 300)
+        self.assertEqual(config.starvation_boost_after_minutes, 60)
+        self.assertTrue(config.eta_lookahead)
+
+    def test_missing_file_returns_defaults(self):
+        set_config_path("/nonexistent/path/config.yaml")
+        config = load_config(force_reload=True)
+        self.assertEqual(config.max_concurrent_heavy, 2)
+
+    def test_load_yaml_config(self):
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            f.write("""
+host_rules:
+  max_concurrent_heavy: 4
+  memory_ceiling_pct: 80
+  cpu_ceiling_pct: 95
+  cool_down_after_failure_s: 600
+stage_weights:
+  crawl:
+    prefer_hosts: [cloud1]
+scheduling:
+  starvation_boost_after_minutes: 120
+  eta_lookahead: false
+""")
+            f.flush()
+            set_config_path(f.name)
+            config = load_config(force_reload=True)
+            self.assertEqual(config.max_concurrent_heavy, 4)
+            self.assertEqual(config.memory_ceiling_pct, 80)
+            self.assertEqual(config.cpu_ceiling_pct, 95)
+            self.assertEqual(config.cool_down_after_failure_s, 600)
+            self.assertEqual(config.starvation_boost_after_minutes, 120)
+            self.assertFalse(config.eta_lookahead)
+            self.assertEqual(config.stage_weights["crawl"]["prefer_hosts"], ["cloud1"])
+
+    def test_hot_reload_on_mtime_change(self):
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            f.write("host_rules:\n  max_concurrent_heavy: 2\n")
+            f.flush()
+            set_config_path(f.name)
+            config1 = load_config(force_reload=True)
+            self.assertEqual(config1.max_concurrent_heavy, 2)
+
+            # Overwrite file
+            import os
+            import time
+            time.sleep(0.1)
+            with open(f.name, "w") as f2:
+                f2.write("host_rules:\n  max_concurrent_heavy: 5\n")
+            # Touch to ensure mtime changes
+            os.utime(f.name, None)
+
+            config2 = load_config()
+            self.assertEqual(config2.max_concurrent_heavy, 5)
+
+    def test_invalid_yaml_returns_defaults(self):
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            f.write("{{not valid yaml")
+            f.flush()
+            set_config_path(f.name)
+            config = load_config(force_reload=True)
+            self.assertEqual(config.max_concurrent_heavy, 2)

--- a/lavandula/dashboard/pipeline/tests/test_stages.py
+++ b/lavandula/dashboard/pipeline/tests/test_stages.py
@@ -1,0 +1,137 @@
+"""Tests for the stage registry."""
+from copy import deepcopy
+from dataclasses import replace
+
+from django.test import SimpleTestCase
+
+from pipeline.stages import (
+    ParamSpec,
+    RetryPolicy,
+    STAGE_REGISTRY,
+    StageDefinition,
+    validate_registry,
+)
+
+
+class TestStageRegistry(SimpleTestCase):
+    def test_registry_is_valid(self):
+        errors = validate_registry()
+        self.assertEqual(errors, [], f"Registry validation errors: {errors}")
+
+    def test_all_existing_stages_registered(self):
+        expected = {"seed", "resolve", "crawl", "classify", "990-index", "990-parse", "enrich-phone"}
+        self.assertEqual(set(STAGE_REGISTRY.keys()), expected)
+
+    def test_stage_names_match_keys(self):
+        for key, stage in STAGE_REGISTRY.items():
+            self.assertEqual(key, stage.name)
+
+    def test_all_stages_have_commands(self):
+        for stage in STAGE_REGISTRY.values():
+            self.assertIsInstance(stage.command, list)
+            self.assertTrue(len(stage.command) >= 1)
+
+    def test_all_stages_have_valid_resource_class(self):
+        for stage in STAGE_REGISTRY.values():
+            self.assertIn(stage.resource_class, ("heavy", "medium", "light"))
+
+    def test_provenance_columns_unique(self):
+        columns = [s.provenance_column for s in STAGE_REGISTRY.values() if s.provenance_column]
+        self.assertEqual(len(columns), len(set(columns)))
+
+
+class TestRegistryValidation(SimpleTestCase):
+    def _make_registry(self, **overrides):
+        reg = deepcopy(STAGE_REGISTRY)
+        reg.update(overrides)
+        return reg
+
+    def test_missing_predecessor(self):
+        bad_stage = StageDefinition(
+            name="bad",
+            display_name="Bad",
+            command=["echo"],
+            parameters={},
+            predecessors=["nonexistent"],
+            conflict_group=None,
+            provenance_column=None,
+            retry_policy=RetryPolicy(),
+            resource_class="light",
+        )
+        reg = self._make_registry(bad=bad_stage)
+        errors = validate_registry(reg)
+        self.assertTrue(any("nonexistent" in e for e in errors))
+
+    def test_duplicate_provenance_column(self):
+        dupe = StageDefinition(
+            name="dupe",
+            display_name="Dupe",
+            command=["echo"],
+            parameters={},
+            predecessors=[],
+            conflict_group=None,
+            provenance_column="seed_status",  # already used by seed
+            retry_policy=RetryPolicy(),
+            resource_class="light",
+        )
+        reg = self._make_registry(dupe=dupe)
+        errors = validate_registry(reg)
+        self.assertTrue(any("seed_status" in e for e in errors))
+
+    def test_circular_predecessors(self):
+        a = StageDefinition(
+            name="a", display_name="A", command=["echo"], parameters={},
+            predecessors=["b"], conflict_group=None, provenance_column=None,
+            retry_policy=RetryPolicy(), resource_class="light",
+        )
+        b = StageDefinition(
+            name="b", display_name="B", command=["echo"], parameters={},
+            predecessors=["a"], conflict_group=None, provenance_column=None,
+            retry_policy=RetryPolicy(), resource_class="light",
+        )
+        errors = validate_registry({"a": a, "b": b})
+        self.assertTrue(any("Circular" in e for e in errors))
+
+    def test_invalid_conflict_group(self):
+        bad = StageDefinition(
+            name="bad", display_name="Bad", command=["echo"], parameters={},
+            predecessors=[], conflict_group="invalid-group", provenance_column=None,
+            retry_policy=RetryPolicy(), resource_class="light",
+        )
+        errors = validate_registry({"bad": bad})
+        self.assertTrue(any("conflict_group" in e for e in errors))
+
+    def test_invalid_resource_class(self):
+        bad = StageDefinition(
+            name="bad", display_name="Bad", command=["echo"], parameters={},
+            predecessors=[], conflict_group=None, provenance_column=None,
+            retry_policy=RetryPolicy(), resource_class="enormous",
+        )
+        errors = validate_registry({"bad": bad})
+        self.assertTrue(any("resource_class" in e for e in errors))
+
+    def test_key_name_mismatch(self):
+        stage = StageDefinition(
+            name="actual_name", display_name="X", command=["echo"], parameters={},
+            predecessors=[], conflict_group=None, provenance_column=None,
+            retry_policy=RetryPolicy(), resource_class="light",
+        )
+        errors = validate_registry({"wrong_key": stage})
+        self.assertTrue(any("doesn't match" in e for e in errors))
+
+
+class TestRetryPolicy(SimpleTestCase):
+    def test_max_attempts_capped_at_3(self):
+        policy = RetryPolicy(max_attempts=10)
+        self.assertEqual(policy.max_attempts, 3)
+
+    def test_min_attempts_is_1(self):
+        policy = RetryPolicy(max_attempts=0)
+        self.assertEqual(policy.max_attempts, 1)
+
+    def test_default_policy(self):
+        policy = RetryPolicy()
+        self.assertEqual(policy.max_attempts, 1)
+        self.assertFalse(policy.auto_retry)
+        self.assertEqual(policy.backoff_seconds, 60)
+        self.assertEqual(policy.retryable_exit_codes, (1, 3))

--- a/lavandula/dashboard/pipeline/tests/test_summary_parser.py
+++ b/lavandula/dashboard/pipeline/tests/test_summary_parser.py
@@ -1,0 +1,113 @@
+"""Tests for summary parsing."""
+from django.test import SimpleTestCase
+
+from pipeline.summary_parser import (
+    build_v0_summary,
+    parse_done_line,
+    parse_error_line,
+    parse_progress_line,
+    parse_summary_line,
+)
+
+
+class TestParseDoneLine(SimpleTestCase):
+    def test_basic_done_line(self):
+        line = "=== records_processed=3537 records_failed=50 DONE ==="
+        result = parse_done_line(line)
+        self.assertEqual(result["records_processed"], 3537)
+        self.assertEqual(result["records_failed"], 50)
+
+    def test_done_with_colons(self):
+        line = "=== processed: 100 failed: 5 DONE ==="
+        result = parse_done_line(line)
+        self.assertEqual(result["processed"], 100)
+        self.assertEqual(result["failed"], 5)
+
+    def test_empty_done(self):
+        line = "=== DONE ==="
+        result = parse_done_line(line)
+        self.assertEqual(result, {})
+
+    def test_no_match(self):
+        line = "Just a regular log line"
+        result = parse_done_line(line)
+        self.assertEqual(result, {})
+
+
+class TestParseSummaryLine(SimpleTestCase):
+    def test_basic_summary(self):
+        line = "SUMMARY: duration_s=29376 records_processed=3537 records_failed=50"
+        result = parse_summary_line(line)
+        self.assertEqual(result["duration_s"], 29376)
+        self.assertEqual(result["records_processed"], 3537)
+        self.assertEqual(result["records_failed"], 50)
+
+    def test_with_floats(self):
+        line = "SUMMARY: duration_s=100.5 rate=437.2"
+        result = parse_summary_line(line)
+        self.assertEqual(result["duration_s"], 100.5)
+        self.assertEqual(result["rate"], 437.2)
+
+    def test_non_summary_line(self):
+        line = "This is not a summary"
+        result = parse_summary_line(line)
+        self.assertEqual(result, {})
+
+
+class TestParseProgressLine(SimpleTestCase):
+    def test_basic_progress(self):
+        line = "PROGRESS: current=500 total=3589 rate=437"
+        result = parse_progress_line(line)
+        self.assertIsNotNone(result)
+        self.assertEqual(result["current"], 500)
+        self.assertEqual(result["total"], 3589)
+        self.assertEqual(result["rate"], 437)
+
+    def test_partial_progress(self):
+        line = "PROGRESS: current=100"
+        result = parse_progress_line(line)
+        self.assertIsNotNone(result)
+        self.assertEqual(result["current"], 100)
+        self.assertNotIn("total", result)
+
+    def test_non_progress_line(self):
+        line = "Regular log output"
+        result = parse_progress_line(line)
+        self.assertIsNone(result)
+
+
+class TestParseErrorLine(SimpleTestCase):
+    def test_basic_error(self):
+        line = "ERROR: class=flush_failure detail=3 unresolved flush failures"
+        result = parse_error_line(line)
+        self.assertIsNotNone(result)
+        self.assertEqual(result["error_class"], "flush_failure")
+        self.assertEqual(result["error_detail"], "3 unresolved flush failures")
+
+    def test_class_only(self):
+        line = "ERROR: class=timeout"
+        result = parse_error_line(line)
+        self.assertIsNotNone(result)
+        self.assertEqual(result["error_class"], "timeout")
+
+    def test_non_error_line(self):
+        line = "WARNING: something happened"
+        result = parse_error_line(line)
+        self.assertIsNone(result)
+
+
+class TestBuildV0Summary(SimpleTestCase):
+    def test_basic_summary(self):
+        result = build_v0_summary(0, 100.5, "/var/log/test.log", 4096)
+        self.assertEqual(result["exit_code"], 0)
+        self.assertEqual(result["duration_s"], 100)
+        self.assertEqual(result["log_file"], "/var/log/test.log")
+        self.assertEqual(result["log_size_bytes"], 4096)
+        self.assertEqual(result["protocol"], "v0")
+
+    def test_none_values_excluded(self):
+        result = build_v0_summary(1, None, None, None)
+        self.assertEqual(result["exit_code"], 1)
+        self.assertNotIn("duration_s", result)
+        self.assertNotIn("log_file", result)
+        self.assertNotIn("log_size_bytes", result)

--- a/lavandula/dashboard/pipeline/urls.py
+++ b/lavandula/dashboard/pipeline/urls.py
@@ -48,6 +48,9 @@ urlpatterns = [
     path("orgs/", views.OrgListView.as_view(), name="org_list"),
     path("orgs/<str:pk>/", views.OrgDetailView.as_view(), name="org_detail"),
 
+    # Provenance
+    path("provenance/", views.ProvenanceView.as_view(), name="provenance"),
+
     # Reports Browser
     path("reports/", views.ReportListView.as_view(), name="report_list"),
     path("reports/<str:sha>/", views.ReportDetailView.as_view(), name="report_detail"),

--- a/lavandula/dashboard/pipeline/views.py
+++ b/lavandula/dashboard/pipeline/views.py
@@ -27,7 +27,9 @@ from .models import (
     FilingIndex,
     IndexRefreshLog,
     Job,
+    JobEvent,
     NonprofitSeed,
+    OrgProvenance,
     Person,
     PipelineAuditLog,
     PipelineProcess,
@@ -1164,3 +1166,57 @@ class ReportDownloadView(LoginRequiredMixin, View):
             ExpiresIn=300,
         )
         return HttpResponseRedirect(url)
+
+
+class ProvenanceView(LoginRequiredMixin, ListView):
+    model = OrgProvenance
+    template_name = "pipeline/provenance.html"
+    context_object_name = "orgs"
+    paginate_by = 50
+
+    def get_queryset(self):
+        from datetime import timedelta
+        from .stages import STAGE_REGISTRY
+        from .orchestrator import US_STATES
+
+        qs = OrgProvenance.objects.all()
+
+        state = self.request.GET.get("state")
+        if state and state in US_STATES:
+            qs = qs.filter(ein__in=NonprofitSeed.objects.filter(state=state).values("ein"))
+
+        stage_name = self.request.GET.get("stage")
+        status_filter = self.request.GET.get("status")
+        if stage_name and stage_name in STAGE_REGISTRY:
+            stage = STAGE_REGISTRY[stage_name]
+            if stage.provenance_column and status_filter:
+                qs = qs.filter(**{stage.provenance_column: status_filter})
+
+        stuck = self.request.GET.get("stuck")
+        if stuck:
+            from django.db.models import Q
+            seven_days_ago = timezone.now() - timedelta(days=7)
+            stuck_q = Q()
+            for stage in STAGE_REGISTRY.values():
+                col = stage.provenance_column
+                if col:
+                    stuck_q |= Q(**{col: "failed"})
+                    stuck_q |= Q(**{col: "in_progress", "updated_at__lt": seven_days_ago})
+            qs = qs.filter(stuck_q)
+
+        return qs.order_by("-updated_at")
+
+    def get_context_data(self, **kwargs):
+        ctx = super().get_context_data(**kwargs)
+        from .stages import STAGE_REGISTRY
+        from .orchestrator import US_STATES
+
+        ctx["provenance_stages"] = [
+            s for s in STAGE_REGISTRY.values() if s.provenance_column
+        ]
+        ctx["state_choices"] = US_STATES
+        # Preserve filter params for pagination links
+        params = self.request.GET.copy()
+        params.pop("page", None)
+        ctx["filter_params"] = params.urlencode()
+        return ctx

--- a/lavandula/dashboard/pipeline/views.py
+++ b/lavandula/dashboard/pipeline/views.py
@@ -351,6 +351,8 @@ class JobDetailView(LoginRequiredMixin, DetailView):
         ctx = super().get_context_data(**kwargs)
         ctx["log_content"] = read_log_tail(self.object.log_file)
         ctx["hostname"] = _get_hostname()
+        from .models import JobEvent
+        ctx["events"] = JobEvent.objects.filter(job=self.object).order_by("-timestamp")[:200]
         return ctx
 
 

--- a/lavandula/dashboard/scheduler_config.yaml
+++ b/lavandula/dashboard/scheduler_config.yaml
@@ -1,0 +1,23 @@
+host_rules:
+  max_concurrent_heavy: 2
+  memory_ceiling_pct: 75
+  cpu_ceiling_pct: 90
+  cool_down_after_failure_s: 300
+
+stage_weights:
+  crawl:
+    resource_class: heavy
+    io_weight: heavy
+    prefer_hosts: []
+  resolve:
+    resource_class: light
+  classify:
+    resource_class: medium
+    gpu_preferred: false
+  enrich-phone:
+    resource_class: light
+    api_bound: true
+
+scheduling:
+  starvation_boost_after_minutes: 60
+  eta_lookahead: true

--- a/lavandula/migrations/rds/013_org_provenance.sql
+++ b/lavandula/migrations/rds/013_org_provenance.sql
@@ -1,0 +1,30 @@
+-- Migration 013: Org Provenance Table
+-- Unified pipeline status tracking per EIN across all stages.
+-- Lives in lava_pipeline schema (operational, not data).
+
+CREATE SCHEMA IF NOT EXISTS lava_pipeline;
+
+CREATE TABLE lava_pipeline.org_provenance (
+    ein TEXT PRIMARY KEY,
+    seed_status TEXT NOT NULL DEFAULT 'not_started'
+        CHECK (seed_status IN ('not_started','in_progress','completed','failed','not_applicable')),
+    seed_completed_at TIMESTAMPTZ,
+    resolve_status TEXT NOT NULL DEFAULT 'not_started'
+        CHECK (resolve_status IN ('not_started','in_progress','completed','failed','not_applicable')),
+    resolve_completed_at TIMESTAMPTZ,
+    crawl_status TEXT NOT NULL DEFAULT 'not_started'
+        CHECK (crawl_status IN ('not_started','in_progress','completed','failed','not_applicable')),
+    crawl_completed_at TIMESTAMPTZ,
+    classify_status TEXT NOT NULL DEFAULT 'not_started'
+        CHECK (classify_status IN ('not_started','in_progress','completed','failed','not_applicable')),
+    classify_completed_at TIMESTAMPTZ,
+    filing_990_status TEXT NOT NULL DEFAULT 'not_started'
+        CHECK (filing_990_status IN ('not_started','in_progress','completed','failed','not_applicable')),
+    filing_990_completed_at TIMESTAMPTZ,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_provenance_resolve ON lava_pipeline.org_provenance(resolve_status);
+CREATE INDEX idx_provenance_crawl ON lava_pipeline.org_provenance(crawl_status);
+CREATE INDEX idx_provenance_classify ON lava_pipeline.org_provenance(classify_status);
+CREATE INDEX idx_provenance_updated ON lava_pipeline.org_provenance(updated_at);

--- a/lavandula/pipeline_protocol.py
+++ b/lavandula/pipeline_protocol.py
@@ -1,0 +1,101 @@
+"""
+Structured progress protocol for pipeline stages.
+
+Stages emit structured events via file descriptor 3 (separate from
+stdout/stderr). The orchestrator reads fd 3 for structured events
+and captures stdout/stderr only for the raw log file.
+
+This prevents untrusted content in stdout (org names, error traces)
+from being parsed as structured events.
+
+Usage in a pipeline stage:
+    from lavandula.pipeline_protocol import emit_progress, emit_error, emit_summary
+
+    emit_progress(current=500, total=3589, rate="437 orgs/hr")
+    emit_error("flush_failure", "3 unresolved flush failures")
+    emit_summary(duration_s=29376, records_processed=3537, records_failed=50)
+"""
+from __future__ import annotations
+
+import os
+import sys
+
+_fd3 = None
+_fd3_checked = False
+
+
+def _get_fd3():
+    global _fd3, _fd3_checked
+    if _fd3_checked:
+        return _fd3
+    _fd3_checked = True
+    try:
+        _fd3 = os.fdopen(3, "w", buffering=1)  # line-buffered
+    except OSError:
+        _fd3 = None
+    return _fd3
+
+
+def emit_progress(current: int, total: int | None = None, **kwargs) -> None:
+    """Emit a PROGRESS event on fd 3."""
+    fd = _get_fd3()
+    if fd is None:
+        return
+    parts = [f"current={current}"]
+    if total is not None:
+        parts.append(f"total={total}")
+    for k, v in kwargs.items():
+        parts.append(f"{k}={v}")
+    try:
+        fd.write(f"PROGRESS: {' '.join(parts)}\n")
+    except (OSError, ValueError):
+        pass
+
+
+def emit_error(error_class: str, detail: str) -> None:
+    """Emit an ERROR event on fd 3."""
+    fd = _get_fd3()
+    if fd is None:
+        return
+    detail_safe = detail.replace("\n", " ").replace("\r", "")[:1000]
+    try:
+        fd.write(f"ERROR: class={error_class} detail={detail_safe}\n")
+    except (OSError, ValueError):
+        pass
+
+
+def emit_warning(warning_class: str, detail: str) -> None:
+    """Emit a WARNING event on fd 3."""
+    fd = _get_fd3()
+    if fd is None:
+        return
+    detail_safe = detail.replace("\n", " ").replace("\r", "")[:1000]
+    try:
+        fd.write(f"WARNING: class={warning_class} detail={detail_safe}\n")
+    except (OSError, ValueError):
+        pass
+
+
+def emit_summary(**kwargs) -> None:
+    """Emit a SUMMARY event on fd 3 (should be the last emission before exit)."""
+    fd = _get_fd3()
+    if fd is None:
+        return
+    parts = [f"{k}={v}" for k, v in kwargs.items()]
+    try:
+        fd.write(f"SUMMARY: {' '.join(parts)}\n")
+        fd.flush()
+    except (OSError, ValueError):
+        pass
+
+
+def reset():
+    """Reset fd 3 state (for testing)."""
+    global _fd3, _fd3_checked
+    if _fd3 is not None:
+        try:
+            _fd3.close()
+        except (OSError, ValueError):
+            pass
+    _fd3 = None
+    _fd3_checked = False

--- a/locard/plans/0034-pipeline-control-plane.md
+++ b/locard/plans/0034-pipeline-control-plane.md
@@ -2,11 +2,15 @@
 
 ## Overview
 
-Implementation plan for Spec 0034. Four phases, each independently shippable. Phases 1-2 don't change pipeline stage code. Phase 3 adds data model. Phase 4 migrates each stage to the structured protocol.
+Implementation plan for Spec 0034. Five phases (Phase 1 split into 1A/1B for risk bounding), each independently shippable. Phases 1-2 don't change pipeline stage code. Phase 3 adds data model. Phase 4 migrates each stage to the structured protocol.
 
-**Estimated effort:** ~3-4 days agentic time across all phases.
+**Estimated effort:** ~4-5 days agentic time across all phases.
 
-## Phase 1: Stage Registry + Job Lifecycle (Foundation)
+**Status enum (canonical):** `not_started | in_progress | completed | failed | not_applicable`
+
+(The spec's original mention of "skipped" is superseded by the security review decision to use `not_applicable` — semantically clearer and consistent with the CHECK constraints.)
+
+## Phase 1A: Stage Registry + Parameter Validation (Low Risk)
 
 ### 1.1 Stage Registry Module
 
@@ -46,10 +50,12 @@ class StageDefinition:
     resource_class: str  # "heavy" | "medium" | "light"
     progress_estimator: str | None = None
     protocol_version: int = 0  # 0 = legacy, 1 = fd 3
-    provenance_query: str | None = None  # SQL template for fallback provenance
+    provenance_query: callable | None = None  # (config_json) -> list[(ein, status)]
 
 STAGE_REGISTRY: dict[str, StageDefinition] = { ... }
 ```
+
+The `provenance_query` is a Python callable (not a SQL string) because per-stage outcome derivation requires stage-specific logic (e.g., classify checks all documents for an org, not just a simple SELECT). Each stage defines its own function; the registry just holds the reference.
 
 Register existing stages: seed, resolve, crawl, classify, 990-index, 990-parse, enrich-phone.
 
@@ -59,6 +65,7 @@ Register existing stages: seed, resolve, crawl, classify, 990-index, 990-parse, 
 - No duplicate provenance_column values
 - All conflict_groups are valid
 - RetryPolicy.max_attempts ≤ 3
+- Each stage's provenance_column matches pattern `{stage_name}_status`
 
 ### 1.2 Parameter Validation
 
@@ -84,7 +91,23 @@ def build_argv(stage: StageDefinition, config_json: dict) -> list[str]:
     return argv
 ```
 
-### 1.3 Job Model Migration
+### 1.3 Tests (Phase 1A)
+
+- `tests/test_stages.py`: Registry validation (circular deps, missing predecessors, duplicate columns)
+- `tests/test_param_validators.py`: Each type validator, shell metachar rejection, argv construction
+
+**Acceptance Criteria (Phase 1A):**
+- [ ] AC1: Stage registry contains all existing stages with correct commands
+- [ ] AC2: `validate_registry()` passes; invalid registries rejected with clear errors
+- [ ] AC3: `build_argv()` produces correct argv for each stage
+- [ ] AC4: Parameter validation rejects shell metacharacters, invalid states, out-of-range integers
+- [ ] AC5: Existing orchestrator still works (registry coexists with COMMAND_MAP during transition)
+
+---
+
+## Phase 1B: Job Lifecycle, Scheduler, Crash Recovery (Higher Risk)
+
+### 1B.1 Job Model Migration
 
 **Migration:** `lavandula/dashboard/pipeline/migrations/XXXX_job_lifecycle_v2.py`
 
@@ -93,8 +116,9 @@ Add fields to Job model:
 - `blocked_reason` (TextField, nullable)
 - `retry_of` (ForeignKey to Job, nullable, related_name="retries")
 - `attempt_number` (IntegerField, default=1)
+- `started_at_precise` (DateTimeField, nullable) — records actual process start for PID reconciliation
 
-### 1.4 Orchestrator Refactor
+### 1B.2 Orchestrator Refactor
 
 **File:** `lavandula/dashboard/pipeline/management/commands/run_orchestrator.py`
 
@@ -109,48 +133,96 @@ Refactor to use stage registry:
 6. Add `blocked_reason` updates in eligibility check loop
 7. Add retry logic: on retryable failure, clone job + rebound dependents
 
-### 1.5 Scheduler Scoring Function
+### 1B.3 Scheduler Scoring Function
 
 **File:** `lavandula/dashboard/pipeline/scheduler.py` (NEW)
 
 ```python
 def score_placement(job: Job, worker: Worker, config: SchedulerConfig) -> float | None:
-    """Score a job-host pairing. Returns None if hard-rule blocked."""
-    # Hard rules (gates)
-    if worker.cpu_pct and worker.cpu_pct > config.cpu_ceiling_pct:
-        return None
-    if worker.mem_pct and worker.mem_pct > config.memory_ceiling_pct:
-        return None
-    running_heavy = Job.objects.filter(host=worker.hostname, status="running", phase__in=heavy_phases).count()
-    if running_heavy >= config.max_concurrent_heavy:
-        return None
-
-    # Soft scoring
-    score = 1.0
+    """Score a job-host pairing. Returns None if hard-rule blocked (gate)."""
     stage = STAGE_REGISTRY[job.phase]
     stage_config = config.stage_weights.get(job.phase, {})
+
+    # === HARD RULES (gates — return None to block) ===
+    
+    # Resource ceilings
+    if worker.cpu_pct and worker.cpu_pct > config.host_rules.cpu_ceiling_pct:
+        return None
+    if worker.mem_pct and worker.mem_pct > config.host_rules.memory_ceiling_pct:
+        return None
+    
+    # Per-host concurrency limit for heavy stages
+    if stage.resource_class == "heavy":
+        running_heavy = Job.objects.filter(
+            host=worker.hostname, status="running",
+            phase__in=[s.name for s in STAGE_REGISTRY.values() if s.resource_class == "heavy"]
+        ).count()
+        if running_heavy >= config.host_rules.max_concurrent_heavy:
+            return None
+    
+    # GPU requirement
+    if stage_config.get("gpu_preferred") and not worker.has_gpu:
+        return None  # hard gate if gpu_preferred AND no GPU on host
+    
+    # Cool-down after failure on this host
+    cool_down_s = config.host_rules.cool_down_after_failure_s
+    if cool_down_s:
+        recent_failure = Job.objects.filter(
+            host=worker.hostname, status="failed",
+            finished_at__gte=now() - timedelta(seconds=cool_down_s)
+        ).exists()
+        if recent_failure:
+            return None
+
+    # === SOFT SCORING (preferences — higher = better) ===
+    score = 1.0
     
     # Host affinity
     if worker.hostname in stage_config.get("prefer_hosts", []):
         score += 0.3
     
-    # Memory headroom bonus
+    # Memory headroom bonus (more headroom = higher score)
     if worker.mem_pct:
         score += (100 - worker.mem_pct) / 100 * 0.5
     
-    # Starvation boost
+    # Starvation boost (long-waiting jobs get priority)
     wait_minutes = (now() - job.created_at).total_seconds() / 60
-    if wait_minutes > config.starvation_boost_after_minutes:
+    if wait_minutes > config.scheduling.starvation_boost_after_minutes:
         score += 0.5
+    
+    # ETA lookahead: if a running heavy job is near completion, boost this host
+    if config.scheduling.eta_lookahead:
+        running_on_host = Job.objects.filter(host=worker.hostname, status="running")
+        for rj in running_on_host:
+            if rj.progress_total and rj.progress_current:
+                pct_done = rj.progress_current / rj.progress_total
+                if pct_done > 0.9:  # >90% done, about to free up
+                    score += 0.2
     
     return score
 
-def select_next_job(pending_jobs, workers, config) -> tuple[Job, Worker] | None:
-    """Pick the best job-host pair from all candidates."""
-    ...
+def select_next_jobs(pending_jobs, workers, config) -> list[tuple[Job, Worker]]:
+    """Score all pending × worker combinations, return best pairings."""
+    candidates = []
+    for job in pending_jobs:
+        for worker in workers:
+            s = score_placement(job, worker, config)
+            if s is not None:
+                candidates.append((s, job, worker))
+    candidates.sort(key=lambda x: -x[0])
+    # Greedy assignment: pick best pair, mark worker busy, repeat
+    assigned_workers = set()
+    result = []
+    for score, job, worker in candidates:
+        if worker.hostname not in assigned_workers:
+            result.append((job, worker))
+            assigned_workers.add(worker.hostname)
+    return result
 ```
 
-### 1.6 Scheduler Config
+The `api_bound` flag in stage config is informational — it means the bottleneck is an external API rate limit, not host resources. The scheduler treats `api_bound` stages as `resource_class=light` for scoring purposes (they don't compete for host CPU/RAM).
+
+### 1B.4 Scheduler Config
 
 **File:** `lavandula/dashboard/pipeline/scheduler_config.py` (NEW)
 
@@ -160,34 +232,77 @@ Loads `scheduler_config.yaml` from a configurable path. Watches file mtime and r
 
 Initial config with conservative defaults based on current operational knowledge.
 
-### 1.7 Dashboard Updates (Minimal)
+### 1B.5 Retry Chain Satisfaction
+
+The orchestrator's eligibility check must follow retry chains. When checking if `job.depends_on` is satisfied:
+
+```python
+def is_dependency_satisfied(job: Job) -> bool:
+    dep = job.depends_on
+    if dep is None:
+        return True
+    # Walk the retry chain: if any retry of dep completed, dep is satisfied
+    current = dep
+    while current:
+        if current.status == "completed":
+            return True
+        current = current.retries.order_by("-attempt_number").first()
+    return False
+```
+
+This ensures that if job A depends on job B, and B fails but B' (retry of B) succeeds, A can proceed.
+
+### 1B.6 Cancellation
+
+Jobs can be cancelled from any non-terminal state:
+- `pending → cancelled`: immediate, no side effects
+- `scheduled → cancelled`: immediate (subprocess not yet spawned)
+- `running → cancelled`: send SIGTERM to the process group, wait 10s, SIGKILL if needed. Mark `cancelled` after process exits.
+
+Each cancellation creates `JobEvent(event_type="cancelled", payload={"from_status": "...", "actor": "operator"})`.
+
+### 1B.7 Progress Estimator Wiring
+
+On job creation, the orchestrator calls the stage's `progress_estimator` (if defined) and writes the result to `Job.progress_total`:
+
+```python
+stage = STAGE_REGISTRY[job.phase]
+if stage.progress_estimator:
+    job.progress_total = stage.progress_estimator(job.config_json)
+    job.save(update_fields=["progress_total"])
+```
+
+### 1B.8 Dashboard Updates (Minimal)
 
 - Job list: show `blocked_reason` in a tooltip/column for pending jobs
 - Job list: show `scheduled` status with distinct color
 - Job creation forms: read stage parameters from registry (replaces hardcoded form fields)
 
-### 1.8 Tests
+### 1B.9 Tests (Phase 1B)
 
-- `tests/test_stages.py`: Registry validation, param validation, argv construction
-- `tests/test_scheduler.py`: Scoring function unit tests, hard-rule gates, starvation boost
-- `tests/test_job_lifecycle.py`: State transitions, retry+rebound, crash recovery
+- `tests/test_scheduler.py`: Scoring function unit tests — hard gates (memory ceiling, concurrent heavy, cool_down, gpu), soft weights (affinity, headroom, starvation, ETA), greedy assignment
+- `tests/test_job_lifecycle.py`: State transitions (valid + invalid rejected), retry chain creation + dependent rebinding, retry chain satisfaction check, cancellation from each non-terminal state
+- `tests/test_crash_recovery.py`: `scheduled` reset, PID alive + matching start time (resume), PID gone (orphan), PID alive + wrong start time (orphan)
+- `tests/test_scheduler_config.py`: YAML loading, hot-reload on mtime change, missing file uses defaults
 
-**Acceptance Criteria (Phase 1):**
-- [ ] AC1: Stage registry contains all existing stages with correct commands
-- [ ] AC2: `validate_registry()` passes; invalid registries rejected
-- [ ] AC3: `build_argv()` produces correct argv for each stage
-- [ ] AC4: Parameter validation rejects shell metacharacters, invalid states
-- [ ] AC5: Job model has `scheduled` status, `blocked_reason`, `retry_of` fields
-- [ ] AC6: Orchestrator acquires advisory lock; second instance exits cleanly
-- [ ] AC7: Jobs transition through `pending → scheduled → running → completed`
-- [ ] AC8: Blocked reason populated and visible on dashboard
-- [ ] AC9: Crash recovery: `scheduled` reset to `pending` on restart
-- [ ] AC10: Crash recovery: `running` jobs reconciled via PID + start time
-- [ ] AC11: Retry: failed job with retryable code spawns retry, dependents rebound
-- [ ] AC12: Scheduler scoring respects memory ceiling (hard rule)
-- [ ] AC13: Scheduler scoring applies host affinity preference (soft weight)
-- [ ] AC14: `scheduler_config.yaml` hot-reload on file change
-- [ ] AC15: Dashboard shows blocked reason and scheduled status
+**Acceptance Criteria (Phase 1B):**
+- [ ] AC6: Job model has `scheduled` status, `blocked_reason`, `retry_of`, `attempt_number` fields
+- [ ] AC7: Orchestrator acquires advisory lock; second instance exits cleanly
+- [ ] AC8: Jobs transition through `pending → scheduled → running → completed`
+- [ ] AC9: Invalid transitions rejected (e.g., `completed → running`)
+- [ ] AC10: Blocked reason populated and visible on dashboard
+- [ ] AC11: Crash recovery: `scheduled` reset to `pending` on restart
+- [ ] AC12: Crash recovery: `running` jobs reconciled via PID + start time
+- [ ] AC13: Retry: failed job with retryable code spawns retry, dependents rebound
+- [ ] AC14: Retry chain satisfaction: dependent on failed job proceeds when retry completes
+- [ ] AC15: Cancellation works from pending, scheduled, and running states
+- [ ] AC16: Scheduler scoring respects memory ceiling (hard rule)
+- [ ] AC17: Scheduler scoring respects cool_down_after_failure_s (hard rule)
+- [ ] AC18: Scheduler scoring applies host affinity, ETA lookahead (soft weights)
+- [ ] AC19: `scheduler_config.yaml` hot-reload on file change
+- [ ] AC20: Dashboard shows blocked reason and scheduled status
+- [ ] AC21: Progress estimator populates `progress_total` on job creation
+- [ ] AC22: Orchestrator uses registry-based dispatch (COMMAND_MAP kept as 1-week fallback)
 
 ---
 
@@ -246,11 +361,21 @@ Replace the current `log_tail` display with a timeline of `JobEvent` records:
 
 **Security:** All payload values rendered via `{{ value }}` (autoescaped). No `|safe` filter anywhere in job detail templates.
 
-### 2.6 Deprecate log_tail
+### 2.6 Legacy v0 Stage Handling (Spec Reconciliation)
 
-- Stop writing `log_tail` on job completion (orchestrator no longer reads log files for dashboard display)
-- Leave the field on the model for now (remove in a future cleanup)
-- Dashboard no longer reads `log_tail`; reads `job.events.all()` instead
+Per spec's security review: v0 stages get NO structured event parsing from logs. The orchestrator captures only:
+- Exit code (from subprocess return)
+- Log file path and size (for operator reference)
+- Duration (from started_at to finished_at)
+
+These three values are written as the `completed`/`failed` JobEvent payload for v0 stages:
+```json
+{"exit_code": 1, "duration_s": 29376, "log_file": "/var/log/.../crawl_WA_..._234.log", "log_size_bytes": 4521088, "protocol": "v0"}
+```
+
+The dashboard shows this minimal info for v0 jobs. No progress events, no error classification, no structured summary. This is intentionally degraded — it creates pressure to migrate stages to v1.
+
+**log_tail field:** Stop writing on job completion. Leave on model (nullable, unused for new jobs). Dashboard falls back to `log_tail` only for historical jobs created before Phase 2 deployment. New jobs show event timeline only.
 
 ### 2.7 Tests
 
@@ -258,15 +383,18 @@ Replace the current `log_tail` display with a timeline of `JobEvent` records:
 - `tests/test_summary_parser.py`: Parse each stage's DONE line format
 - `tests/test_job_detail_view.py`: Timeline renders correctly, XSS safety
 
+**Actor attribution:** Every JobEvent includes an `actor` field in the payload: `"orchestrator"`, `"operator"` (for manual actions like cancel), or `"system"` (for crash recovery resets). This satisfies the spec requirement that state changes record "timestamp, reason, and actor."
+
 **Acceptance Criteria (Phase 2):**
-- [ ] AC16: JobEvent model created with indexes
-- [ ] AC17: Every state transition creates a corresponding event
-- [ ] AC18: Completed/failed events contain structured summary payload
-- [ ] AC19: Payloads exceeding 64KB are truncated with `_truncated` flag
-- [ ] AC20: Dashboard job detail shows event timeline
-- [ ] AC21: No `|safe` filter used on any event-derived content
-- [ ] AC22: Progress events created from heartbeat polling
-- [ ] AC23: log_tail field no longer written (backward compat: still readable if populated)
+- [ ] AC23: JobEvent model created with indexes
+- [ ] AC24: Every state transition creates a corresponding event with actor attribution
+- [ ] AC25: Completed/failed events contain structured summary payload
+- [ ] AC26: v0 stages get minimal completion events (exit code + duration + log path only)
+- [ ] AC27: Payloads exceeding 64KB are truncated with `_truncated` flag
+- [ ] AC28: Dashboard job detail shows event timeline (new jobs) or log_tail (historical)
+- [ ] AC29: No `|safe` filter used on any event-derived content
+- [ ] AC30: `dependency_rebound` events recorded when dependents are rebound (from Phase 1B)
+- [ ] AC31: log_tail field no longer written for new jobs
 
 ---
 
@@ -383,12 +511,20 @@ UPDATE lava_pipeline.org_provenance SET
     END;
 ```
 
-### 3.6 Dashboard: Provenance Page
+### 3.6 Dashboard: Provenance Page (Registry-Driven)
 
 **Template:** `pipeline/templates/pipeline/provenance.html` (NEW)
 
-Table with columns: EIN, Org Name, State, NTEE, Seed, Resolve, Crawl, Classify, 990.
-Each stage cell color-coded: green=completed, yellow=in_progress, red=failed, gray=not_started.
+The provenance page renders columns **dynamically from the stage registry** — not hardcoded. The view queries `STAGE_REGISTRY` for all stages with a `provenance_column`, and the template iterates over them to build headers and cells. When a new stage is added (with a provenance column), it appears automatically on this page.
+
+```python
+# In view:
+provenance_stages = [s for s in STAGE_REGISTRY.values() if s.provenance_column]
+# Template iterates: {% for stage in provenance_stages %} <th>{{ stage.display_name }}</th>
+```
+
+Table columns: EIN, Org Name, State, NTEE, then one column per registered stage.
+Each stage cell color-coded: green=completed, yellow=in_progress, red=failed, gray=not_started, blue=not_applicable.
 Filters: state dropdown, status dropdown per stage, "stuck" checkbox (failed or in_progress > 7 days).
 Paginated (50 per page).
 
@@ -403,15 +539,16 @@ New view `provenance_list` with queryset filters.
 - `tests/test_provenance_views.py`: Dashboard page renders, filters work, XSS safe
 
 **Acceptance Criteria (Phase 3):**
-- [ ] AC24: `org_provenance` table created with CHECK constraints
-- [ ] AC25: Backfill populates correct status for orgs at each pipeline stage
-- [ ] AC26: `update_org_provenance` writes correct per-EIN outcomes
-- [ ] AC27: Column ownership enforced — stage can only write its own column
-- [ ] AC28: Provenance file path validated (realpath + prefix check)
-- [ ] AC29: Fallback to `provenance_query` when no file exists
-- [ ] AC30: Dashboard provenance page renders with color-coded statuses
-- [ ] AC31: Filters (state, status, stuck) produce correct results
-- [ ] AC32: Performance: provenance queries < 100ms at 100K rows
+- [ ] AC32: `org_provenance` table created with CHECK constraints on all status columns
+- [ ] AC33: Backfill populates correct status for orgs at each pipeline stage (spot-check 20 orgs)
+- [ ] AC34: `update_org_provenance` writes correct per-EIN outcomes for partial success
+- [ ] AC35: Column ownership enforced — attempt to write wrong column raises error + security event log
+- [ ] AC36: Provenance file path validated (realpath + prefix check); path traversal rejected
+- [ ] AC37: Fallback to `provenance_query` callable when no file exists
+- [ ] AC38: Dashboard provenance page renders dynamically from registry (columns auto-discovered)
+- [ ] AC39: Filters (state, status, stuck) produce correct results
+- [ ] AC40: Performance: provenance filter queries < 100ms at 100K rows
+- [ ] AC41: Concurrent writes on different columns for same EIN succeed without conflict
 
 ---
 
@@ -497,16 +634,18 @@ Each stage migration is an independent commit, independently testable.
 - `tests/test_protocol_integration.py`: Full cycle — subprocess emits, orchestrator captures events
 
 **Acceptance Criteria (Phase 4):**
-- [ ] AC33: `pipeline_protocol.py` library emits correct format on fd 3
-- [ ] AC34: Library gracefully handles fd 3 unavailable (no-op)
-- [ ] AC35: Orchestrator opens pipe, passes as fd 3, reads structured lines
-- [ ] AC36: Parsed lines create JobEvents with correct payloads
-- [ ] AC37: Malformed lines logged as warnings, don't crash orchestrator
-- [ ] AC38: Crawler stage migrated to v1, emits progress/error/summary
-- [ ] AC39: Resolver stage migrated to v1
-- [ ] AC40: Classifier stage migrated to v1
-- [ ] AC41: All stages write provenance JSONL at assigned path
-- [ ] AC42: Legacy v0 stages still work (exit code only, no event parsing)
+- [ ] AC42: `pipeline_protocol.py` library emits correct format on fd 3
+- [ ] AC43: Library gracefully handles fd 3 unavailable (no-op, no crash)
+- [ ] AC44: Orchestrator opens pipe, passes as fd 3, reads in non-blocking thread
+- [ ] AC45: Parsed lines create JobEvents with correct payloads
+- [ ] AC46: Malformed lines logged as warnings, don't crash orchestrator or create spurious events
+- [ ] AC47: Untrusted content on stdout does NOT produce events (fd 3 isolation verified)
+- [ ] AC48: Crawler stage migrated to v1, emits progress/error/summary
+- [ ] AC49: Resolver stage migrated to v1
+- [ ] AC50: Classifier stage migrated to v1
+- [ ] AC51: All v1 stages write provenance JSONL at orchestrator-assigned path
+- [ ] AC52: Legacy v0 stages still work (exit code + duration only)
+- [ ] AC53: Pipe buffer exhaustion handled (non-blocking thread drains continuously)
 
 ---
 
@@ -580,4 +719,4 @@ Each stage migration is an independent commit, independently testable.
 
 3. **fd 3 pipe exhaustion** — if a stage writes faster than the orchestrator reads, the pipe buffer fills (default 64KB on Linux). The stage's `emit_*` calls will block. Mitigate: orchestrator reads fd 3 in a non-blocking thread, not just on heartbeat ticks.
 
-4. **Advisory lock prevents legitimate restart** — if the orchestrator crashes without releasing the lock, the lock persists until the DB connection is cleaned up (typically immediate on process death, but verify). Add a `--force` flag that issues `pg_advisory_unlock_all()` before acquiring.
+4. **Advisory lock prevents legitimate restart** — Postgres session-level advisory locks are released automatically when the connection drops (which happens when the process dies). No `--force` flag needed — if the orchestrator crashes, the lock is released within the `idle_in_transaction_session_timeout` window (default: immediate on TCP RST). If a stale connection persists (rare), the operator can terminate it via `pg_terminate_backend()` targeting the specific PID. This is safer than a blanket `pg_advisory_unlock_all()` which could release unrelated locks.

--- a/locard/plans/0034-pipeline-control-plane.md
+++ b/locard/plans/0034-pipeline-control-plane.md
@@ -737,3 +737,14 @@ Each stage migration is an independent commit, independently testable.
 3. **fd 3 pipe exhaustion** — if a stage writes faster than the orchestrator reads, the pipe buffer fills (default 64KB on Linux). The stage's `emit_*` calls will block. Mitigate: orchestrator reads fd 3 in a non-blocking thread, not just on heartbeat ticks.
 
 4. **Advisory lock prevents legitimate restart** — Postgres session-level advisory locks are released automatically when the connection drops (which happens when the process dies). No `--force` flag needed — if the orchestrator crashes, the lock is released within the `idle_in_transaction_session_timeout` window (default: immediate on TCP RST). If a stale connection persists (rare), the operator can terminate it via `pg_terminate_backend()` targeting the specific PID. This is safer than a blanket `pg_advisory_unlock_all()` which could release unrelated locks.
+
+## Consultation Log
+
+| Round | Model | Type | Verdict | Key Findings |
+|-------|-------|------|---------|--------------|
+| 1 | Codex | plan-review | REQUEST_CHANGES | Phase 1 too large, legacy v0 handling conflicts with spec, forward-compat not registry-driven, retry satisfaction incomplete |
+| 1 | Claude | plan-review | REQUEST_CHANGES | Phase 1 oversized, progress_estimator wiring missing, ALLOWED_COLUMNS undefined, scheduler config gaps |
+| 2 | Codex | red-team-plan | REQUEST_CHANGES | Legacy parsing regression, greedy scheduler double-assignment, PID fingerprint for remote reconciliation |
+| 2 | Claude | red-team-plan | REQUEST_CHANGES | assert for authz (CRITICAL), YAML loader RCE, cancellation PID-reuse, provenance file transport undefined |
+
+All findings addressed in commits bde1a94, 3a9ba31, and a2fb16e.

--- a/locard/plans/0034-pipeline-control-plane.md
+++ b/locard/plans/0034-pipeline-control-plane.md
@@ -145,10 +145,13 @@ def score_placement(job: Job, worker: Worker, config: SchedulerConfig) -> float 
 
     # === HARD RULES (gates — return None to block) ===
     
-    # Resource ceilings
-    if worker.cpu_pct and worker.cpu_pct > config.host_rules.cpu_ceiling_pct:
-        return None
-    if worker.mem_pct and worker.mem_pct > config.host_rules.memory_ceiling_pct:
+    # Resource ceilings (None metrics = no data = assume at ceiling, don't bypass)
+    if worker.cpu_pct is None or worker.cpu_pct > config.host_rules.cpu_ceiling_pct:
+        if worker.cpu_pct is None and worker.last_heartbeat:
+            pass  # Have heartbeat but no CPU data = allow (metrics optional)
+        elif worker.cpu_pct is not None and worker.cpu_pct > config.host_rules.cpu_ceiling_pct:
+            return None
+    if worker.mem_pct is not None and worker.mem_pct > config.host_rules.memory_ceiling_pct:
         return None
     
     # Per-host concurrency limit for heavy stages
@@ -210,13 +213,15 @@ def select_next_jobs(pending_jobs, workers, config) -> list[tuple[Job, Worker]]:
             if s is not None:
                 candidates.append((s, job, worker))
     candidates.sort(key=lambda x: -x[0])
-    # Greedy assignment: pick best pair, mark worker busy, repeat
+    # Greedy assignment: pick best pair, mark worker and job assigned, repeat
     assigned_workers = set()
+    assigned_jobs = set()
     result = []
     for score, job, worker in candidates:
-        if worker.hostname not in assigned_workers:
+        if worker.hostname not in assigned_workers and job.pk not in assigned_jobs:
             result.append((job, worker))
             assigned_workers.add(worker.hostname)
+            assigned_jobs.add(job.pk)
     return result
 ```
 
@@ -226,7 +231,7 @@ The `api_bound` flag in stage config is informational — it means the bottlenec
 
 **File:** `lavandula/dashboard/pipeline/scheduler_config.py` (NEW)
 
-Loads `scheduler_config.yaml` from a configurable path. Watches file mtime and reloads on change. Provides sensible defaults if file is missing.
+Loads `scheduler_config.yaml` from a configurable path using `yaml.safe_load()` (NEVER `yaml.load()` — RCE risk from untrusted YAML). Watches file mtime and reloads on change. Provides sensible defaults if file is missing.
 
 **File:** `lavandula/dashboard/scheduler_config.yaml` (NEW)
 
@@ -257,7 +262,7 @@ This ensures that if job A depends on job B, and B fails but B' (retry of B) suc
 Jobs can be cancelled from any non-terminal state:
 - `pending → cancelled`: immediate, no side effects
 - `scheduled → cancelled`: immediate (subprocess not yet spawned)
-- `running → cancelled`: send SIGTERM to the process group, wait 10s, SIGKILL if needed. Mark `cancelled` after process exits.
+- `running → cancelled`: verify PID + start time (same check as crash recovery) before sending signals. If PID matches, send SIGTERM to the process group, wait 10s, SIGKILL if needed. Mark `cancelled` after process exits. If PID doesn't match (stale), mark cancelled without signaling.
 
 Each cancellation creates `JobEvent(event_type="cancelled", payload={"from_status": "...", "actor": "operator"})`.
 
@@ -449,8 +454,12 @@ def update_org_provenance(stage_name: str, outcomes: list[tuple[str, str]]) -> i
     column = stage.provenance_column
     if not column:
         return 0
-    # Validate column ownership
-    assert column == f"{stage_name}_status" or column in ALLOWED_COLUMNS[stage_name]
+    # Validate column ownership (never use assert — disabled under python -O)
+    expected_column = f"{stage_name}_status"
+    if column != expected_column:
+        logger.error("SECURITY: stage %s attempted write to column %s (expected %s)",
+                     stage_name, column, expected_column)
+        raise PermissionError(f"Stage {stage_name} cannot write to {column}")
     # Batch UPDATE
     ...
 ```
@@ -459,14 +468,22 @@ def update_org_provenance(stage_name: str, outcomes: list[tuple[str, str]]) -> i
 
 On job dispatch, orchestrator passes `--provenance-out /var/lib/lava/provenance/<job_id>.jsonl`.
 
-On job completion:
-1. Check if provenance file exists at the pre-assigned path
-2. Validate: `os.path.realpath(path).startswith(PROVENANCE_BASE_DIR)`
-3. Parse JSONL, validate each `{"ein": str, "status": str}`
-4. Call `update_org_provenance(stage, outcomes)`
-5. Delete provenance file after successful ingestion
+**Provenance file transport (worker → orchestrator):**
 
-If no file exists, call `stage.provenance_query(config_json)` to determine outcomes from source tables.
+The provenance file is written on the worker host. The orchestrator retrieves it via `scp` (same SSH channel used for dispatch) after the job completes:
+```
+scp -o StrictHostKeyChecking=yes worker:/var/lib/lava/provenance/<job_id>.jsonl /var/lib/lava/provenance/<job_id>.jsonl
+```
+
+On job completion:
+1. SCP the provenance file from worker to orchestrator's local `PROVENANCE_BASE_DIR`
+2. Validate local path: `os.path.realpath(path).startswith(PROVENANCE_BASE_DIR)`
+3. Parse JSONL, validate each line: `{"ein": str, "status": str}` — reject lines with unexpected keys or status values not in the canonical enum
+4. Call `update_org_provenance(stage, outcomes)`
+5. Delete local provenance file after successful ingestion
+6. Delete remote provenance file on worker via SSH
+
+If SCP fails or no file exists on worker, call `stage.provenance_query(config_json)` to determine outcomes from source tables (RDS).
 
 ### 3.5 Backfill Migration
 

--- a/locard/plans/0034-pipeline-control-plane.md
+++ b/locard/plans/0034-pipeline-control-plane.md
@@ -1,0 +1,583 @@
+# Plan 0034: Pipeline Control Plane & Org Provenance
+
+## Overview
+
+Implementation plan for Spec 0034. Four phases, each independently shippable. Phases 1-2 don't change pipeline stage code. Phase 3 adds data model. Phase 4 migrates each stage to the structured protocol.
+
+**Estimated effort:** ~3-4 days agentic time across all phases.
+
+## Phase 1: Stage Registry + Job Lifecycle (Foundation)
+
+### 1.1 Stage Registry Module
+
+**File:** `lavandula/dashboard/pipeline/stages.py` (NEW)
+
+Create the stage registry with dataclasses and register all existing stages:
+
+```python
+from dataclasses import dataclass, field
+
+@dataclass
+class ParamSpec:
+    required: bool = False
+    type: str = "string"
+    choices: list[str] | None = None
+    cli_flag: str = ""
+    min_value: int | None = None
+    max_value: int | None = None
+
+@dataclass
+class RetryPolicy:
+    max_attempts: int = 1
+    auto_retry: bool = False
+    backoff_seconds: int = 60
+    retryable_exit_codes: list[int] = field(default_factory=lambda: [1, 3])
+
+@dataclass
+class StageDefinition:
+    name: str
+    display_name: str
+    command: list[str]
+    parameters: dict[str, ParamSpec]
+    predecessors: list[str]
+    conflict_group: str | None
+    provenance_column: str | None
+    retry_policy: RetryPolicy
+    resource_class: str  # "heavy" | "medium" | "light"
+    progress_estimator: str | None = None
+    protocol_version: int = 0  # 0 = legacy, 1 = fd 3
+    provenance_query: str | None = None  # SQL template for fallback provenance
+
+STAGE_REGISTRY: dict[str, StageDefinition] = { ... }
+```
+
+Register existing stages: seed, resolve, crawl, classify, 990-index, 990-parse, enrich-phone.
+
+**Validation function:** `validate_registry()` checks:
+- No circular predecessors
+- All predecessor names exist in registry
+- No duplicate provenance_column values
+- All conflict_groups are valid
+- RetryPolicy.max_attempts ≤ 3
+
+### 1.2 Parameter Validation
+
+**File:** `lavandula/dashboard/pipeline/param_validators.py` (NEW)
+
+```python
+US_STATES = {"AL", "AK", "AZ", ...}  # All 50 + DC + territories
+
+def validate_param(value: str, spec: ParamSpec) -> str:
+    """Validate and return cleaned value. Raises ValueError on invalid."""
+    ...
+
+def build_argv(stage: StageDefinition, config_json: dict) -> list[str]:
+    """Build subprocess argv from stage command + validated params."""
+    argv = list(stage.command)
+    for name, spec in stage.parameters.items():
+        if name in config_json:
+            clean = validate_param(config_json[name], spec)
+            if spec.type == "boolean" and clean == "true":
+                argv.append(spec.cli_flag)
+            elif spec.type != "boolean":
+                argv.extend([spec.cli_flag, clean])
+    return argv
+```
+
+### 1.3 Job Model Migration
+
+**Migration:** `lavandula/dashboard/pipeline/migrations/XXXX_job_lifecycle_v2.py`
+
+Add fields to Job model:
+- `status` choices: add `"scheduled"` 
+- `blocked_reason` (TextField, nullable)
+- `retry_of` (ForeignKey to Job, nullable, related_name="retries")
+- `attempt_number` (IntegerField, default=1)
+
+### 1.4 Orchestrator Refactor
+
+**File:** `lavandula/dashboard/pipeline/management/commands/run_orchestrator.py`
+
+Refactor to use stage registry:
+1. Replace `COMMAND_MAP` imports with `from pipeline.stages import STAGE_REGISTRY`
+2. Replace `build_argv()` calls with registry-based version
+3. Add advisory lock on startup: `SELECT pg_try_advisory_lock(34001)` — exit if lock not acquired
+4. Add `scheduled` state: job moves to `scheduled` before spawn attempt
+5. Add crash recovery on startup:
+   - `scheduled` jobs → reset to `pending`
+   - `running` jobs → verify PID+start-time, mark orphaned if dead
+6. Add `blocked_reason` updates in eligibility check loop
+7. Add retry logic: on retryable failure, clone job + rebound dependents
+
+### 1.5 Scheduler Scoring Function
+
+**File:** `lavandula/dashboard/pipeline/scheduler.py` (NEW)
+
+```python
+def score_placement(job: Job, worker: Worker, config: SchedulerConfig) -> float | None:
+    """Score a job-host pairing. Returns None if hard-rule blocked."""
+    # Hard rules (gates)
+    if worker.cpu_pct and worker.cpu_pct > config.cpu_ceiling_pct:
+        return None
+    if worker.mem_pct and worker.mem_pct > config.memory_ceiling_pct:
+        return None
+    running_heavy = Job.objects.filter(host=worker.hostname, status="running", phase__in=heavy_phases).count()
+    if running_heavy >= config.max_concurrent_heavy:
+        return None
+
+    # Soft scoring
+    score = 1.0
+    stage = STAGE_REGISTRY[job.phase]
+    stage_config = config.stage_weights.get(job.phase, {})
+    
+    # Host affinity
+    if worker.hostname in stage_config.get("prefer_hosts", []):
+        score += 0.3
+    
+    # Memory headroom bonus
+    if worker.mem_pct:
+        score += (100 - worker.mem_pct) / 100 * 0.5
+    
+    # Starvation boost
+    wait_minutes = (now() - job.created_at).total_seconds() / 60
+    if wait_minutes > config.starvation_boost_after_minutes:
+        score += 0.5
+    
+    return score
+
+def select_next_job(pending_jobs, workers, config) -> tuple[Job, Worker] | None:
+    """Pick the best job-host pair from all candidates."""
+    ...
+```
+
+### 1.6 Scheduler Config
+
+**File:** `lavandula/dashboard/pipeline/scheduler_config.py` (NEW)
+
+Loads `scheduler_config.yaml` from a configurable path. Watches file mtime and reloads on change. Provides sensible defaults if file is missing.
+
+**File:** `lavandula/dashboard/scheduler_config.yaml` (NEW)
+
+Initial config with conservative defaults based on current operational knowledge.
+
+### 1.7 Dashboard Updates (Minimal)
+
+- Job list: show `blocked_reason` in a tooltip/column for pending jobs
+- Job list: show `scheduled` status with distinct color
+- Job creation forms: read stage parameters from registry (replaces hardcoded form fields)
+
+### 1.8 Tests
+
+- `tests/test_stages.py`: Registry validation, param validation, argv construction
+- `tests/test_scheduler.py`: Scoring function unit tests, hard-rule gates, starvation boost
+- `tests/test_job_lifecycle.py`: State transitions, retry+rebound, crash recovery
+
+**Acceptance Criteria (Phase 1):**
+- [ ] AC1: Stage registry contains all existing stages with correct commands
+- [ ] AC2: `validate_registry()` passes; invalid registries rejected
+- [ ] AC3: `build_argv()` produces correct argv for each stage
+- [ ] AC4: Parameter validation rejects shell metacharacters, invalid states
+- [ ] AC5: Job model has `scheduled` status, `blocked_reason`, `retry_of` fields
+- [ ] AC6: Orchestrator acquires advisory lock; second instance exits cleanly
+- [ ] AC7: Jobs transition through `pending → scheduled → running → completed`
+- [ ] AC8: Blocked reason populated and visible on dashboard
+- [ ] AC9: Crash recovery: `scheduled` reset to `pending` on restart
+- [ ] AC10: Crash recovery: `running` jobs reconciled via PID + start time
+- [ ] AC11: Retry: failed job with retryable code spawns retry, dependents rebound
+- [ ] AC12: Scheduler scoring respects memory ceiling (hard rule)
+- [ ] AC13: Scheduler scoring applies host affinity preference (soft weight)
+- [ ] AC14: `scheduler_config.yaml` hot-reload on file change
+- [ ] AC15: Dashboard shows blocked reason and scheduled status
+
+---
+
+## Phase 2: Event Log + Structured Summaries
+
+### 2.1 JobEvent Model
+
+**Migration:** `lavandula/dashboard/pipeline/migrations/XXXX_job_event.py`
+
+```python
+class JobEvent(models.Model):
+    job = models.ForeignKey(Job, on_delete=models.CASCADE, related_name="events")
+    timestamp = models.DateTimeField(auto_now_add=True)
+    event_type = models.CharField(max_length=20, choices=EVENT_TYPE_CHOICES, db_index=True)
+    payload = models.JSONField(default=dict)
+
+    class Meta:
+        ordering = ["timestamp"]
+        indexes = [
+            models.Index(fields=["job", "timestamp"]),
+            models.Index(fields=["event_type", "timestamp"]),
+        ]
+```
+
+### 2.2 Event Emission in Orchestrator
+
+Refactor `run_orchestrator.py` to emit events at each state transition:
+- Job created → `JobEvent(event_type="created")`
+- Eligibility check fails → `JobEvent(event_type="blocked", payload={"reason": ...})`
+- Job scheduled → `JobEvent(event_type="scheduled")`
+- Job started → `JobEvent(event_type="started", payload={"pid": ..., "host": ...})`
+- Job completed → `JobEvent(event_type="completed", payload={summary})`
+- Job failed → `JobEvent(event_type="failed", payload={summary + error})`
+
+### 2.3 Summary Parsing
+
+**File:** `lavandula/dashboard/pipeline/summary_parser.py` (NEW)
+
+Parses the final `=== ... DONE ===` line from each stage's log into the structured summary payload. Each stage has a slightly different format; the parser handles known formats and produces a normalized dict.
+
+For protocol v1 stages (Phase 4), this is replaced by fd 3 SUMMARY parsing.
+
+### 2.4 Payload Size Enforcement
+
+All event payloads pass through `truncate_payload(payload, max_bytes=65536)` before save.
+
+### 2.5 Dashboard: Job Detail Timeline
+
+**Template:** `pipeline/templates/pipeline/job_detail.html` (MODIFY)
+
+Replace the current `log_tail` display with a timeline of `JobEvent` records:
+- Vertical timeline, most recent at top
+- Each event shows: timestamp, type badge (color-coded), payload summary
+- Progress events collapsed by default (expandable)
+- Error events highlighted in red
+
+**Security:** All payload values rendered via `{{ value }}` (autoescaped). No `|safe` filter anywhere in job detail templates.
+
+### 2.6 Deprecate log_tail
+
+- Stop writing `log_tail` on job completion (orchestrator no longer reads log files for dashboard display)
+- Leave the field on the model for now (remove in a future cleanup)
+- Dashboard no longer reads `log_tail`; reads `job.events.all()` instead
+
+### 2.7 Tests
+
+- `tests/test_job_events.py`: Event creation on each transition, payload structure, truncation
+- `tests/test_summary_parser.py`: Parse each stage's DONE line format
+- `tests/test_job_detail_view.py`: Timeline renders correctly, XSS safety
+
+**Acceptance Criteria (Phase 2):**
+- [ ] AC16: JobEvent model created with indexes
+- [ ] AC17: Every state transition creates a corresponding event
+- [ ] AC18: Completed/failed events contain structured summary payload
+- [ ] AC19: Payloads exceeding 64KB are truncated with `_truncated` flag
+- [ ] AC20: Dashboard job detail shows event timeline
+- [ ] AC21: No `|safe` filter used on any event-derived content
+- [ ] AC22: Progress events created from heartbeat polling
+- [ ] AC23: log_tail field no longer written (backward compat: still readable if populated)
+
+---
+
+## Phase 3: Org Provenance
+
+### 3.1 Provenance Table Migration
+
+**Migration:** `lavandula/migrations/rds/0XX_org_provenance.sql`
+
+```sql
+CREATE SCHEMA IF NOT EXISTS lava_pipeline;
+
+CREATE TABLE lava_pipeline.org_provenance (
+    ein TEXT PRIMARY KEY,
+    seed_status TEXT NOT NULL DEFAULT 'not_started'
+        CHECK (seed_status IN ('not_started','in_progress','completed','failed','not_applicable')),
+    seed_completed_at TIMESTAMPTZ,
+    resolve_status TEXT NOT NULL DEFAULT 'not_started'
+        CHECK (resolve_status IN ('not_started','in_progress','completed','failed','not_applicable')),
+    resolve_completed_at TIMESTAMPTZ,
+    crawl_status TEXT NOT NULL DEFAULT 'not_started'
+        CHECK (crawl_status IN ('not_started','in_progress','completed','failed','not_applicable')),
+    crawl_completed_at TIMESTAMPTZ,
+    classify_status TEXT NOT NULL DEFAULT 'not_started'
+        CHECK (classify_status IN ('not_started','in_progress','completed','failed','not_applicable')),
+    classify_completed_at TIMESTAMPTZ,
+    filing_990_status TEXT NOT NULL DEFAULT 'not_started'
+        CHECK (filing_990_status IN ('not_started','in_progress','completed','failed','not_applicable')),
+    filing_990_completed_at TIMESTAMPTZ,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_provenance_resolve ON lava_pipeline.org_provenance(resolve_status);
+CREATE INDEX idx_provenance_crawl ON lava_pipeline.org_provenance(crawl_status);
+CREATE INDEX idx_provenance_classify ON lava_pipeline.org_provenance(classify_status);
+```
+
+### 3.2 Django Model
+
+**File:** `lavandula/dashboard/pipeline/models.py` (MODIFY)
+
+Add `OrgProvenance` model pointing to the `lava_pipeline.org_provenance` table. Managed=False (migrations via raw SQL, not Django ORM).
+
+### 3.3 Provenance Writer
+
+**File:** `lavandula/dashboard/pipeline/provenance.py` (NEW)
+
+```python
+def update_org_provenance(stage_name: str, outcomes: list[tuple[str, str]]) -> int:
+    """Update provenance for a batch of EINs. Returns count updated."""
+    stage = STAGE_REGISTRY[stage_name]
+    column = stage.provenance_column
+    if not column:
+        return 0
+    # Validate column ownership
+    assert column == f"{stage_name}_status" or column in ALLOWED_COLUMNS[stage_name]
+    # Batch UPDATE
+    ...
+```
+
+### 3.4 Provenance File Handling
+
+On job dispatch, orchestrator passes `--provenance-out /var/lib/lava/provenance/<job_id>.jsonl`.
+
+On job completion:
+1. Check if provenance file exists at the pre-assigned path
+2. Validate: `os.path.realpath(path).startswith(PROVENANCE_BASE_DIR)`
+3. Parse JSONL, validate each `{"ein": str, "status": str}`
+4. Call `update_org_provenance(stage, outcomes)`
+5. Delete provenance file after successful ingestion
+
+If no file exists, call `stage.provenance_query(config_json)` to determine outcomes from source tables.
+
+### 3.5 Backfill Migration
+
+**File:** `lavandula/dashboard/pipeline/management/commands/backfill_provenance.py` (NEW)
+
+One-time command that reads existing tables and populates `org_provenance`:
+
+```sql
+-- Seed: all EINs in nonprofits_seed
+INSERT INTO lava_pipeline.org_provenance (ein, seed_status, seed_completed_at)
+SELECT ein, 'completed', created_at FROM lava_impact.nonprofits_seed
+ON CONFLICT (ein) DO NOTHING;
+
+-- Resolve: from resolver_status
+UPDATE lava_pipeline.org_provenance SET
+    resolve_status = CASE
+        WHEN s.resolver_status IN ('resolved', 'accepted') THEN 'completed'
+        WHEN s.resolver_status IN ('rejected', 'error') THEN 'failed'
+        ELSE 'not_started'
+    END
+FROM lava_impact.nonprofits_seed s WHERE org_provenance.ein = s.ein;
+
+-- Crawl: from crawled_orgs
+UPDATE lava_pipeline.org_provenance SET
+    crawl_status = CASE
+        WHEN co.status = 'ok' THEN 'completed'
+        WHEN co.status = 'permanent_skip' THEN 'failed'
+        WHEN co.status = 'transient' THEN 'in_progress'
+        ELSE 'not_started'
+    END,
+    crawl_completed_at = co.last_crawled_at
+FROM lava_impact.crawled_orgs co WHERE org_provenance.ein = co.ein;
+
+-- Classify: completed if all documents for org are classified
+UPDATE lava_pipeline.org_provenance SET
+    classify_status = CASE
+        WHEN NOT EXISTS (SELECT 1 FROM lava_corpus.corpus c
+            WHERE c.source_org_ein = org_provenance.ein) THEN 'not_applicable'
+        WHEN NOT EXISTS (SELECT 1 FROM lava_corpus.corpus c
+            WHERE c.source_org_ein = org_provenance.ein AND c.material_type IS NULL) THEN 'completed'
+        ELSE 'in_progress'
+    END;
+```
+
+### 3.6 Dashboard: Provenance Page
+
+**Template:** `pipeline/templates/pipeline/provenance.html` (NEW)
+
+Table with columns: EIN, Org Name, State, NTEE, Seed, Resolve, Crawl, Classify, 990.
+Each stage cell color-coded: green=completed, yellow=in_progress, red=failed, gray=not_started.
+Filters: state dropdown, status dropdown per stage, "stuck" checkbox (failed or in_progress > 7 days).
+Paginated (50 per page).
+
+**View:** `lavandula/dashboard/pipeline/views.py` (MODIFY)
+
+New view `provenance_list` with queryset filters.
+
+### 3.7 Tests
+
+- `tests/test_provenance.py`: Write outcomes, column ownership enforcement, partial success
+- `tests/test_backfill.py`: Backfill produces correct state for test fixtures
+- `tests/test_provenance_views.py`: Dashboard page renders, filters work, XSS safe
+
+**Acceptance Criteria (Phase 3):**
+- [ ] AC24: `org_provenance` table created with CHECK constraints
+- [ ] AC25: Backfill populates correct status for orgs at each pipeline stage
+- [ ] AC26: `update_org_provenance` writes correct per-EIN outcomes
+- [ ] AC27: Column ownership enforced — stage can only write its own column
+- [ ] AC28: Provenance file path validated (realpath + prefix check)
+- [ ] AC29: Fallback to `provenance_query` when no file exists
+- [ ] AC30: Dashboard provenance page renders with color-coded statuses
+- [ ] AC31: Filters (state, status, stuck) produce correct results
+- [ ] AC32: Performance: provenance queries < 100ms at 100K rows
+
+---
+
+## Phase 4: Structured Progress Protocol
+
+### 4.1 Protocol Library
+
+**File:** `lavandula/pipeline_protocol.py` (NEW)
+
+```python
+import os
+import sys
+
+_FD3 = None
+
+def _get_fd3():
+    global _FD3
+    if _FD3 is None:
+        try:
+            _FD3 = os.fdopen(3, 'w', buffering=1)  # line-buffered
+        except OSError:
+            _FD3 = False  # fd 3 not available
+    return _FD3 if _FD3 else None
+
+def emit_progress(current: int, total: int | None = None, **kwargs):
+    fd = _get_fd3()
+    if fd:
+        parts = [f"current={current}"]
+        if total is not None:
+            parts.append(f"total={total}")
+        parts.extend(f"{k}={v}" for k, v in kwargs.items())
+        fd.write(f"PROGRESS: {' '.join(parts)}\n")
+
+def emit_error(error_class: str, detail: str):
+    fd = _get_fd3()
+    if fd:
+        detail_safe = detail.replace('\n', ' ')[:1000]
+        fd.write(f"ERROR: class={error_class} detail={detail_safe}\n")
+
+def emit_summary(**kwargs):
+    fd = _get_fd3()
+    if fd:
+        parts = [f"{k}={v}" for k, v in kwargs.items()]
+        fd.write(f"SUMMARY: {' '.join(parts)}\n")
+```
+
+### 4.2 Orchestrator fd 3 Reader
+
+**File:** `lavandula/dashboard/pipeline/protocol_reader.py` (NEW)
+
+When spawning a protocol v1 stage, the orchestrator:
+1. Creates a pipe: `r_fd, w_fd = os.pipe()`
+2. Passes `w_fd` as fd 3 to the subprocess (via `pass_fds=(w_fd,)` + pre-exec dup2)
+3. Reads from `r_fd` in the heartbeat loop, parsing structured lines
+4. Each parsed line becomes a `JobEvent`
+
+For protocol v0 stages: fd 3 is not opened. No structured event parsing. Exit code + log file size only.
+
+### 4.3 Stage Migrations (one per stage)
+
+Migrate each existing stage to protocol v1. For each:
+1. Add `from lavandula.pipeline_protocol import emit_progress, emit_error, emit_summary` 
+2. Replace periodic print statements with `emit_progress()`
+3. Add `emit_error()` at exception handlers
+4. Add `emit_summary()` as final action before exit
+5. Write provenance JSONL file at `--provenance-out` path
+6. Update stage registry: `protocol_version=1`
+
+**Order of migration:**
+1. `crawl` (most complex, highest value — eliminates "Exit 1" mystery)
+2. `resolve` (second most frequent)
+3. `classify` (simple, few progress points)
+4. `seed` (rare, simple)
+5. `990-index`, `990-parse` (group together)
+6. `enrich-phone`
+
+Each stage migration is an independent commit, independently testable.
+
+### 4.4 Tests
+
+- `tests/test_protocol.py`: emit_* functions write correct format to fd 3
+- `tests/test_protocol_reader.py`: Reader parses well-formed lines, handles malformed
+- `tests/test_protocol_integration.py`: Full cycle — subprocess emits, orchestrator captures events
+
+**Acceptance Criteria (Phase 4):**
+- [ ] AC33: `pipeline_protocol.py` library emits correct format on fd 3
+- [ ] AC34: Library gracefully handles fd 3 unavailable (no-op)
+- [ ] AC35: Orchestrator opens pipe, passes as fd 3, reads structured lines
+- [ ] AC36: Parsed lines create JobEvents with correct payloads
+- [ ] AC37: Malformed lines logged as warnings, don't crash orchestrator
+- [ ] AC38: Crawler stage migrated to v1, emits progress/error/summary
+- [ ] AC39: Resolver stage migrated to v1
+- [ ] AC40: Classifier stage migrated to v1
+- [ ] AC41: All stages write provenance JSONL at assigned path
+- [ ] AC42: Legacy v0 stages still work (exit code only, no event parsing)
+
+---
+
+## File Summary
+
+### New Files (13)
+| File | Phase | Purpose |
+|------|-------|---------|
+| `pipeline/stages.py` | 1 | Stage registry definitions |
+| `pipeline/param_validators.py` | 1 | Parameter validation + argv construction |
+| `pipeline/scheduler.py` | 1 | Scoring function for job-host placement |
+| `pipeline/scheduler_config.py` | 1 | YAML config loader with hot-reload |
+| `dashboard/scheduler_config.yaml` | 1 | Operator-tunable scheduling weights |
+| `pipeline/summary_parser.py` | 2 | Parse stage DONE lines into summary payload |
+| `pipeline/provenance.py` | 3 | Provenance writer with ownership enforcement |
+| `pipeline/management/commands/backfill_provenance.py` | 3 | One-time backfill from existing tables |
+| `pipeline/templates/pipeline/provenance.html` | 3 | Provenance dashboard page |
+| `lavandula/pipeline_protocol.py` | 4 | Structured event emission library |
+| `pipeline/protocol_reader.py` | 4 | fd 3 pipe reader for orchestrator |
+| `migrations/rds/0XX_org_provenance.sql` | 3 | Provenance table DDL |
+| `pipeline/migrations/XXXX_*.py` | 1,2 | Django model migrations |
+
+### Modified Files (8)
+| File | Phase | Changes |
+|------|-------|---------|
+| `pipeline/models.py` | 1,2,3 | Job fields, JobEvent model, OrgProvenance |
+| `pipeline/management/commands/run_orchestrator.py` | 1,2,4 | Registry-based dispatch, events, fd 3 reader |
+| `pipeline/orchestrator.py` | 1 | Remove COMMAND_MAP, delegate to stages.py |
+| `pipeline/views.py` | 1,3 | Provenance page, registry-driven forms |
+| `pipeline/templates/pipeline/job_list.html` | 1 | Blocked reason, scheduled status |
+| `pipeline/templates/pipeline/job_detail.html` | 2 | Event timeline replaces log_tail |
+| `reports/crawler.py` | 4 | Protocol v1 migration |
+| `nonprofits/tools/pipeline_resolve.py` | 4 | Protocol v1 migration |
+
+---
+
+## Deployment Notes
+
+### Phase 1 Deployment
+1. Run Django migration for new Job fields
+2. Deploy code
+3. Restart orchestrator (will acquire advisory lock)
+4. Verify: create a job, observe `pending → scheduled → running`
+
+### Phase 2 Deployment
+1. Run Django migration for JobEvent model
+2. Deploy code
+3. Restart orchestrator
+4. Historical jobs won't have events (they retain `log_tail`)
+5. New jobs will have event timelines on dashboard
+
+### Phase 3 Deployment
+1. Run RDS migration for `org_provenance` table
+2. Deploy code
+3. Run `python manage.py backfill_provenance`
+4. Verify: spot-check 10 orgs across different pipeline stages
+5. Create `/var/lib/lava/provenance/` directory on each worker
+
+### Phase 4 Deployment
+- Per-stage: update code, update registry entry (`protocol_version=0→1`), deploy, restart orchestrator
+- Each stage can be migrated independently
+- Verify: run a job for the migrated stage, confirm events appear in dashboard
+
+---
+
+## Risk Mitigation
+
+1. **Phase 1 is the riskiest** (touches the orchestrator's core dispatch loop). Mitigate by keeping the existing `COMMAND_MAP` as a fallback for 1 week: if `STAGE_REGISTRY` is missing a stage, fall back to COMMAND_MAP + log a deprecation warning.
+
+2. **Backfill accuracy** — run backfill on a staging DB first, spot-check against known orgs. The backfill is idempotent (INSERT ON CONFLICT DO NOTHING + UPDATE WHERE).
+
+3. **fd 3 pipe exhaustion** — if a stage writes faster than the orchestrator reads, the pipe buffer fills (default 64KB on Linux). The stage's `emit_*` calls will block. Mitigate: orchestrator reads fd 3 in a non-blocking thread, not just on heartbeat ticks.
+
+4. **Advisory lock prevents legitimate restart** — if the orchestrator crashes without releasing the lock, the lock persists until the DB connection is cleaned up (typically immediate on process death, but verify). Add a `--force` flag that issues `pg_advisory_unlock_all()` before acquiring.

--- a/locard/projectlist.md
+++ b/locard/projectlist.md
@@ -539,9 +539,22 @@ projects:
     tags: [infrastructure, orchestration, multi-host, national-scale, operations]
     notes: "Motivated by national ingest bottleneck shifting from API rate limits to ops throughput. Job model already has host field, orchestrator already filters by hostname. Need registry, health, UI routing, and auto-distribution. Spec approved 2026-05-03. Plan approved 2026-05-03. PR #28 merged 2026-05-03. 20 files, +890/-32. Awaiting operator: Django migration + gunicorn reload + setup_worker on each host."
 
+  - id: "0034"
+    title: "Pipeline Control Plane & Org Provenance"
+    summary: "Re-engineer job lifecycle (scheduler, dependency resolution, structured logging), unified org provenance tracking (single view of where each org is across all pipeline stages), and extensible stage registry so future stages (extract, aggregate, report) plug in without re-engineering."
+    status: conceived
+    priority: high
+    files:
+      spec: locard/specs/0034-pipeline-control-plane.md
+      plan: null
+      review: null
+    dependencies: ["0019", "0033"]
+    tags: [infrastructure, orchestration, observability, pipeline, architecture]
+    notes: "Motivated by 2026-05-05 observation: jobs silently fail to start, exit codes require log spelunking, org pipeline status spread across multiple tables with no unified view. Current system grew organically — needs a proper control plane before adding extract/aggregate/report stages."
+
 ## Next Available Number
 
-**0034** - Reserve this number for your next project
+**0035** - Reserve this number for your next project
 
 ---
 

--- a/locard/projectlist.md
+++ b/locard/projectlist.md
@@ -542,15 +542,15 @@ projects:
   - id: "0034"
     title: "Pipeline Control Plane & Org Provenance"
     summary: "Re-engineer job lifecycle (scheduler, dependency resolution, structured logging), unified org provenance tracking (single view of where each org is across all pipeline stages), and extensible stage registry so future stages (extract, aggregate, report) plug in without re-engineering."
-    status: conceived
+    status: implementing
     priority: high
     files:
       spec: locard/specs/0034-pipeline-control-plane.md
-      plan: null
+      plan: locard/plans/0034-pipeline-control-plane.md
       review: null
     dependencies: ["0019", "0033"]
     tags: [infrastructure, orchestration, observability, pipeline, architecture]
-    notes: "Motivated by 2026-05-05 observation: jobs silently fail to start, exit codes require log spelunking, org pipeline status spread across multiple tables with no unified view. Current system grew organically — needs a proper control plane before adding extract/aggregate/report stages."
+    notes: "Motivated by 2026-05-05 observation: jobs silently fail to start, exit codes require log spelunking, org pipeline status spread across multiple tables with no unified view. Current system grew organically — needs a proper control plane before adding extract/aggregate/report stages. Spec approved 2026-05-06 after 4 review rounds (spec+red-team, Codex+Claude). Plan approved 2026-05-06 after 4 review rounds (plan+red-team, Codex+Claude). 53 ACs, 5 phases."
 
 ## Next Available Number
 

--- a/locard/specs/0034-pipeline-control-plane.md
+++ b/locard/specs/0034-pipeline-control-plane.md
@@ -448,3 +448,14 @@ Phases 1-2 can ship without changing any pipeline stage code. Phase 3 changes th
 3. **Event log: no retention policy initially.** Estimated volume: < 500K events/month at national scale. Reassess after Phase 4 (structured progress protocol) adds per-stage progress events — if volume exceeds 5M/month, add a 90-day TTL on `progress` events only, keeping lifecycle events indefinitely.
 
 4. **Dashboard rendering security.** All event payloads and `blocked_reason` text must be rendered through Django's autoescaping. Plan must explicitly prohibit `|safe` filter on any user-facing field derived from job events or log content.
+
+## Consultation Log
+
+| Round | Model | Type | Verdict | Key Findings |
+|-------|-------|------|---------|--------------|
+| 1 | Codex | spec-review | REQUEST_CHANGES | Host availability underspecified, cancellation/recovery missing, test gaps |
+| 1 | Claude | spec-review | REQUEST_CHANGES | Single vs multi-orchestrator unspecified, per-EIN provenance shape, heartbeat undefined, progress injection |
+| 2 | Codex | red-team-spec | REQUEST_CHANGES | Provenance status enum inconsistent, retry semantics fragile, PID-only recovery insufficient |
+| 2 | Claude | red-team-spec | REQUEST_CHANGES | 2 CRITICAL (legacy log-tail fallback injection, attacker-controlled provenance path), 5 HIGH |
+
+All findings addressed in commits 957cca0 and 30fbf08.

--- a/locard/specs/0034-pipeline-control-plane.md
+++ b/locard/specs/0034-pipeline-control-plane.md
@@ -36,6 +36,40 @@ The pipeline grew organically from a single-host crawl tool into a multi-host, m
 
 9. **Org provenance history.** Not just current status but when each stage completed for each org. Enables "how long does crawl take per org?" and "which orgs have been stuck in resolve for 7+ days?"
 
+### Should Have (continued)
+
+12. **Resource-aware scheduling.** The scheduler scores candidate job-host pairings rather than running the first eligible job. Worker heartbeats report CPU/memory/disk utilization. Scheduling decisions consider current load, stage resource profiles, concurrency limits per host, and projected completion of running jobs.
+
+13. **Operator-tunable scheduling weights.** A `scheduler_config.yaml` file (hot-reloaded on mtime change) controls scheduling behavior without code changes. Includes per-host concurrency limits, resource ceilings, per-stage resource weights, host affinity, starvation boost timers, and cool-down periods after failures. The operator adjusts these as real patterns emerge during national ingest — "crawl + classify on the same box OOMs" becomes a config line, not a code PR.
+
+    ```yaml
+    host_rules:
+      max_concurrent_heavy: 2
+      memory_ceiling_pct: 75
+      cpu_ceiling_pct: 90
+      cool_down_after_failure_s: 300
+
+    stage_weights:
+      crawl:
+        resource_class: heavy      # heavy | medium | light
+        io_weight: heavy
+        prefer_hosts: [cloud1]
+      resolve:
+        resource_class: light
+      classify:
+        resource_class: medium
+        gpu_preferred: true
+      extract-vocab:
+        resource_class: light
+        api_bound: true            # bottleneck is external API, not host
+
+    scheduling:
+      starvation_boost_after_minutes: 60
+      eta_lookahead: true
+    ```
+
+    The scoring function is simple Python (not a constraint solver): for each pending job × available host, compute a score from weight config + current utilization + ETA projection. Highest score wins. ~50 lines of logic, easily debuggable.
+
 ### Nice to Have
 
 10. **Stage DAG visualization.** Dashboard page showing the pipeline as a directed graph with per-stage org counts (how many orgs are at each stage).
@@ -121,7 +155,9 @@ class StageDefinition:
     conflict_group: str | None         # "per-state" or "global" or "990-family"
     provenance_column: str | None      # "resolve_status" — column in org_provenance this stage writes
     retry_policy: RetryPolicy          # max_attempts, backoff, auto_retry
+    resource_class: str                # "heavy" | "medium" | "light" — base cost for scheduling
     progress_estimator: str | None     # "count_unresolved" — function name for progress_total
+    protocol_version: int              # 0 = legacy (no structured events), 1 = fd 3 protocol
 ```
 
 **ParamSpec types** define the validation vocabulary for stage parameters:

--- a/locard/specs/0034-pipeline-control-plane.md
+++ b/locard/specs/0034-pipeline-control-plane.md
@@ -56,9 +56,15 @@ One `run_orchestrator` process runs on the dashboard host, polling RDS for eligi
 
 This means:
 - **"Scheduled" = the central orchestrator picked up the job and is about to SSH-dispatch it.** The gap between `scheduled` and `running` is the SSH + process spawn latency.
-- **Locking is centralized** — only one process reads/writes job state, so no distributed lock needed.
+- **Locking is centralized** — only one process reads/writes job state, so no distributed lock needed. The orchestrator acquires a Postgres advisory lock on startup; a second instance attempting to start will detect the lock and exit. This prevents split-brain from accidental double-launch.
 - **Worker liveness** is determined by the orchestrator polling `Worker.last_heartbeat`. Workers update this via a lightweight cron or the running subprocess itself.
 - **If the orchestrator dies**, no new jobs are scheduled. Running subprocesses continue on their workers. On restart, the orchestrator reclaims `scheduled` jobs (moves them back to `pending`) and reconciles `running` jobs by checking PIDs on their target hosts.
+
+**SSH dispatch security:**
+- Workers are pre-registered in the `Worker` table with their SSH hostname and key fingerprint.
+- The orchestrator connects via SSH key authentication (no passwords), using `ssh -o StrictHostKeyChecking=yes` with host keys pinned in `~/.ssh/known_hosts`.
+- Remote commands are constructed as explicit argv arrays (`ssh host python3 -m module --arg value`) — never passed through a remote shell. The orchestrator uses `subprocess.Popen(["ssh", host, "--"] + argv)` with `shell=False`.
+- Workers do not need inbound SSH access to the orchestrator — communication is one-directional (orchestrator → worker).
 
 ### org_provenance Schema: `lava_pipeline`
 
@@ -110,13 +116,33 @@ class StageDefinition:
     name: str                          # "resolve", "crawl", "classify", "extract-vocab"
     display_name: str                  # "URL Resolver", "Site Crawler"
     command: list[str]                 # ["python3", "-m", "lavandula.nonprofits.tools.pipeline_resolve"]
-    parameters: dict[str, ParamSpec]   # {"state": ParamSpec(required=True, type="state_code"), ...}
+    parameters: dict[str, ParamSpec]   # see ParamSpec types below
     predecessors: list[str]            # ["seed"] — stages that must be complete before this one
     conflict_group: str | None         # "per-state" or "global" or "990-family"
     provenance_column: str | None      # "resolve_status" — column in org_provenance this stage writes
     retry_policy: RetryPolicy          # max_attempts, backoff, auto_retry
     progress_estimator: str | None     # "count_unresolved" — function name for progress_total
 ```
+
+**ParamSpec types** define the validation vocabulary for stage parameters:
+
+```python
+@dataclass
+class ParamSpec:
+    required: bool = False
+    type: str = "string"  # one of: state_code, string, integer, boolean, choice
+    choices: list[str] | None = None  # for type="choice"
+    cli_flag: str = ""  # e.g., "--state" — how the param maps to argv
+```
+
+Type validators:
+- `state_code`: 2-letter uppercase US state abbreviation, validated against a fixed list
+- `string`: Non-empty, max 200 chars, alphanumeric + hyphens/underscores only (no shell metacharacters)
+- `integer`: Parseable as int, within optional min/max bounds
+- `boolean`: Emitted as a flag (`--re-classify`) when true, omitted when false
+- `choice`: Value must be in the `choices` list
+
+Parameters are validated BEFORE command construction. Invalid parameters reject the job with a `JobEvent(event_type="failed", payload={"error_class": "invalid_params", ...})`.
 
 The `progress_estimator` is a callable `(config_json: dict) -> int | None` that returns the expected total record count for a job with the given config. For example, for `resolve`, it queries `SELECT COUNT(*) FROM nonprofits_seed WHERE state = :state AND resolver_status IS NULL`. Returns `None` if unknown. Called once at job creation to set `Job.progress_total`.
 
@@ -153,7 +179,7 @@ The field holds the *current* reason. Each change is also recorded as a `JobEven
 
 On orchestrator restart:
 - Jobs in `scheduled` status (picked up but never spawned) are moved back to `pending` with a `JobEvent(event_type="reset", payload={"reason": "orchestrator restart"})`.
-- Jobs in `running` status are reconciled: the orchestrator checks the target host for the recorded PID. If the process is still alive, tracking resumes. If the PID is gone, the job is marked `failed` with `error_class="orphaned"`.
+- Jobs in `running` status are reconciled: the orchestrator checks the target host for the recorded PID AND verifies the process start time matches `Job.started_at` (within 5s tolerance) using `/proc/<pid>/stat` or `ps -o lstart`. This prevents PID-reuse false positives. If the PID is alive with matching start time, tracking resumes. If the PID is gone or start time mismatches, the job is marked `failed` with `error_class="orphaned"`.
 - `Popen` spawn failures (binary missing, fork error, OS limit) transition directly from `scheduled` → `failed` with the exception recorded in the event log.
 
 ### 3. Job Event Log
@@ -217,7 +243,8 @@ New table `org_provenance` in `lava_pipeline` schema:
 ```sql
 CREATE TABLE lava_pipeline.org_provenance (
     ein TEXT PRIMARY KEY,
-    -- Stage statuses (enum: not_started, in_progress, completed, failed, skipped)
+    -- Stage statuses (enum: not_started, in_progress, completed, failed, not_applicable)
+    -- CHECK constraint enforces valid values per column
     seed_status       TEXT NOT NULL DEFAULT 'not_started',
     seed_completed_at TIMESTAMPTZ,
     resolve_status       TEXT NOT NULL DEFAULT 'not_started',
@@ -237,7 +264,7 @@ CREATE TABLE lava_pipeline.org_provenance (
 
 **Population strategy:** Each pipeline stage, on completion, reports per-EIN outcomes. The orchestrator's `_finish_job()` handler calls `update_org_provenance(stage, outcomes)` where `outcomes` is a list of `(ein, status)` tuples — not a single status for the whole batch. This handles partial success: a crawl job that processes 3,537 orgs successfully and 50 with transient failures writes `completed` for 3,537 and `failed` for 50.
 
-Stages report outcomes via the SUMMARY line: `SUMMARY: ... provenance_completed=3537 provenance_failed=50 provenance_file=/tmp/provenance_12345.jsonl`. The provenance file is a JSONL of `{"ein": "...", "status": "completed|failed|skipped"}` records. If no provenance file is emitted, the orchestrator falls back to marking all EINs in the job's scope with the job-level status.
+The orchestrator assigns each job a provenance output path at dispatch time: `--provenance-out /var/lib/lava/provenance/<job_id>.jsonl`. The stage writes per-EIN outcomes to this file as JSONL: `{"ein": "...", "status": "completed|failed|not_applicable"}`. The orchestrator reads ONLY from this pre-assigned path (validated with `os.path.realpath` + prefix check against the configured base directory). Stages cannot specify an arbitrary provenance path — this prevents path traversal attacks. If the provenance file does not exist at job completion, the orchestrator queries the stage's source tables directly to determine per-EIN outcomes (stage-specific query defined in the stage registry's `provenance_query` callable).
 
 **Seed stage special case:** Seed creates EINs — the `org_provenance` row is created by the seed stage itself (INSERT with all other columns defaulting to `not_started`). Orgs with zero documents after crawl have `classify_status = not_applicable`.
 
@@ -277,7 +304,11 @@ SUMMARY: duration_s=N records_processed=N records_failed=N [key=value ...]
 
 This is intentionally simple — not JSON, not protobuf. It's `key=value` pairs on tagged lines that can be parsed with a regex and are still human-readable in raw logs.
 
-**Injection safety:** Structured lines (`PROGRESS:`, `ERROR:`, `SUMMARY:`) are emitted via a dedicated helper (`from lavandula.pipeline_protocol import emit_progress, emit_error, emit_summary`) that writes to a separate file descriptor (fd 3) rather than stdout/stderr. The orchestrator reads fd 3 for structured events and captures stdout/stderr only for the raw log file. This prevents untrusted content in stdout (org names, error traces from crawl targets) from being parsed as structured events. If fd 3 is unavailable (legacy stages), the orchestrator falls back to log-tail parsing — structured protocol is opt-in per stage.
+**Injection safety:** Structured lines (`PROGRESS:`, `ERROR:`, `SUMMARY:`) are emitted via a dedicated helper (`from lavandula.pipeline_protocol import emit_progress, emit_error, emit_summary`) that writes to a separate file descriptor (fd 3) rather than stdout/stderr. The orchestrator reads fd 3 for structured events and captures stdout/stderr only for the raw log file. This prevents untrusted content in stdout (org names, error traces from crawl targets) from being parsed as structured events.
+
+**Legacy stage handling:** Stages are explicitly marked `protocol_version: 1` (fd 3) or `protocol_version: 0` (legacy) in the stage registry. Legacy stages (v0) do NOT get structured event parsing at all — the orchestrator reads only exit code and log file size for them. No log-tail parsing for structured data. This eliminates the injection vector entirely. All existing stages must be migrated to protocol v1 before the legacy fallback is removed; the stage registry tracks migration status. Target: all stages at v1 by end of Phase 4.
+
+**Provenance column ownership:** Each stage's `provenance_column` in the registry is enforced at write time. The `update_org_provenance()` function validates that the calling stage is writing only to its own column. Attempts to write to another stage's column raise an error and log a security event.
 
 **Payload size cap:** Event payloads are capped at 64KB. Payloads exceeding this are truncated with a `"_truncated": true` flag.
 
@@ -299,7 +330,8 @@ When a job fails with a retryable exit code:
 2. Cloned fields: phase, state_code, host, config_json. Not cloned: depends_on, log_file, pid, events.
 3. Write `JobEvent(event_type="retried", payload={"original_job_id": N, "attempt": M, "retry_job_id": R})` on the original job
 4. The failed job stays in `failed` status (preserving its events/logs)
-5. **Dependent rebinding:** Any jobs whose `depends_on` pointed to the failed job are updated to point to the retry job. This ensures downstream jobs wait on the retry, not the failed original. A `JobEvent(event_type="dependency_rebound")` is recorded on each affected dependent.
+5. **Dependent rebinding:** Any `pending` jobs whose `depends_on` pointed to the failed job are updated to point to the retry job. Only pending dependents are rebound — running or completed dependents are not touched. The retry job's `retry_of` FK (new field) links back to the original, forming a chain. The eligibility check follows `retry_of` chains: a dependent waiting on job X is also satisfied if any retry of X completed. A `JobEvent(event_type="dependency_rebound")` is recorded on each affected dependent.
+6. **Max retry cap:** `max_attempts` is capped at 3 in the `RetryPolicy` dataclass validation. This prevents infinite retry loops from misconfiguration.
 
 This replaces the current exit-code-3 special case in the orchestrator.
 

--- a/locard/specs/0034-pipeline-control-plane.md
+++ b/locard/specs/0034-pipeline-control-plane.md
@@ -26,7 +26,7 @@ The pipeline grew organically from a single-host crawl tool into a multi-host, m
 
 5. **Dependency resolution with diagnostics.** When a job can't start, the system records *why* (dependency not met, phase conflict, host unavailable, predecessor failed). Visible on the dashboard job detail page.
 
-6. **Forward-compatible for extract/aggregate/report.** The design must accommodate stages that don't exist yet without requiring schema changes to the control plane itself. A new `extract-vocab` stage should only need: (a) a stage registry entry, (b) a management command or script, (c) an org_provenance column.
+6. **Forward-compatible for extract/aggregate/report.** The control plane core (Job, JobEvent, orchestrator, dashboard templates) requires zero changes when adding a new stage. A new `extract-vocab` stage needs only: (a) a stage registry entry in `stages.py`, (b) a management command or script, (c) a migration adding its columns to `org_provenance`. The provenance migration is a lightweight `ALTER TABLE ADD COLUMN` — not a control-plane schema change, but a data-model extension that the stage itself owns.
 
 ### Should Have
 
@@ -47,6 +47,26 @@ The pipeline grew organically from a single-host crawl tool into a multi-host, m
 - **Workflow engine replacement** (Airflow, Prefect, Dagster). This is a lightweight control plane for a single-operator system, not an enterprise orchestrator. The complexity budget is "Django models + management commands," not "install and maintain a workflow platform."
 - **Real-time streaming logs.** The dashboard shows job summaries and event logs, not live log tails. Operators who need live logs use `tail -f` on the host.
 - **Multi-tenant isolation.** Single operator (ronp), single RDS instance. No role-based access, no team permissions.
+
+## Architecture Decisions
+
+### Orchestrator Topology: Single Central Orchestrator
+
+One `run_orchestrator` process runs on the dashboard host, polling RDS for eligible jobs. It dispatches jobs to remote workers via SSH (already established in Spec 0033's multi-host model). Workers execute subprocesses locally; the orchestrator monitors via heartbeat rows in the `Worker` table.
+
+This means:
+- **"Scheduled" = the central orchestrator picked up the job and is about to SSH-dispatch it.** The gap between `scheduled` and `running` is the SSH + process spawn latency.
+- **Locking is centralized** — only one process reads/writes job state, so no distributed lock needed.
+- **Worker liveness** is determined by the orchestrator polling `Worker.last_heartbeat`. Workers update this via a lightweight cron or the running subprocess itself.
+- **If the orchestrator dies**, no new jobs are scheduled. Running subprocesses continue on their workers. On restart, the orchestrator reclaims `scheduled` jobs (moves them back to `pending`) and reconciles `running` jobs by checking PIDs on their target hosts.
+
+### org_provenance Schema: `lava_pipeline`
+
+This is a pipeline control table, not a data table. It lives in `lava_pipeline` alongside `Job`, `JobEvent`, and `Worker`.
+
+### PipelineAuditLog: Superseded by JobEvent
+
+The unused `PipelineAuditLog` model is dropped. `JobEvent` covers its intended purpose with better structure.
 
 ## Current State
 
@@ -98,7 +118,11 @@ class StageDefinition:
     progress_estimator: str | None     # "count_unresolved" — function name for progress_total
 ```
 
+The `progress_estimator` is a callable `(config_json: dict) -> int | None` that returns the expected total record count for a job with the given config. For example, for `resolve`, it queries `SELECT COUNT(*) FROM nonprofits_seed WHERE state = :state AND resolver_status IS NULL`. Returns `None` if unknown. Called once at job creation to set `Job.progress_total`.
+
 The registry is a module-level dict in `lavandula/dashboard/pipeline/stages.py`. Adding a new stage = adding an entry. The orchestrator, dashboard views, and job creation forms all read from the registry.
+
+**Command dispatch safety:** All stage commands are executed via `subprocess.Popen(argv, ...)` with `shell=False`. Parameters from `config_json` are validated against the stage's `ParamSpec` definitions and passed as explicit argv elements — never interpolated into strings.
 
 ### 2. Job Lifecycle Enhancement
 
@@ -123,7 +147,14 @@ New field `blocked_reason` (nullable text) on Job, set by the scheduler when a j
 - "Host cloud1 not responding (last heartbeat 15m ago)"
 - "Predecessor stage 'resolve' not complete for state WA"
 
-Cleared when the job becomes eligible.
+The field holds the *current* reason. Each change is also recorded as a `JobEvent(event_type="blocked", payload={"reason": "..."})` so the full blocking history is preserved in the event log. The field is cleared when the job becomes eligible.
+
+**Crash recovery:**
+
+On orchestrator restart:
+- Jobs in `scheduled` status (picked up but never spawned) are moved back to `pending` with a `JobEvent(event_type="reset", payload={"reason": "orchestrator restart"})`.
+- Jobs in `running` status are reconciled: the orchestrator checks the target host for the recorded PID. If the process is still alive, tracking resumes. If the PID is gone, the job is marked `failed` with `error_class="orphaned"`.
+- `Popen` spawn failures (binary missing, fork error, OS limit) transition directly from `scheduled` → `failed` with the exception recorded in the event log.
 
 ### 3. Job Event Log
 
@@ -204,7 +235,11 @@ CREATE TABLE lava_pipeline.org_provenance (
 );
 ```
 
-**Population strategy:** Each pipeline stage, on completion, updates its corresponding column. The orchestrator's `_finish_job()` handler calls `update_org_provenance(stage, ein_list, status)` with the list of EINs processed.
+**Population strategy:** Each pipeline stage, on completion, reports per-EIN outcomes. The orchestrator's `_finish_job()` handler calls `update_org_provenance(stage, outcomes)` where `outcomes` is a list of `(ein, status)` tuples — not a single status for the whole batch. This handles partial success: a crawl job that processes 3,537 orgs successfully and 50 with transient failures writes `completed` for 3,537 and `failed` for 50.
+
+Stages report outcomes via the SUMMARY line: `SUMMARY: ... provenance_completed=3537 provenance_failed=50 provenance_file=/tmp/provenance_12345.jsonl`. The provenance file is a JSONL of `{"ein": "...", "status": "completed|failed|skipped"}` records. If no provenance file is emitted, the orchestrator falls back to marking all EINs in the job's scope with the job-level status.
+
+**Seed stage special case:** Seed creates EINs — the `org_provenance` row is created by the seed stage itself (INSERT with all other columns defaulting to `not_started`). Orgs with zero documents after crawl have `classify_status = not_applicable`.
 
 **Backfill:** One-time migration reads existing `nonprofits_seed`, `crawled_orgs`, and `corpus` tables to populate initial provenance state.
 
@@ -242,6 +277,10 @@ SUMMARY: duration_s=N records_processed=N records_failed=N [key=value ...]
 
 This is intentionally simple — not JSON, not protobuf. It's `key=value` pairs on tagged lines that can be parsed with a regex and are still human-readable in raw logs.
 
+**Injection safety:** Structured lines (`PROGRESS:`, `ERROR:`, `SUMMARY:`) are emitted via a dedicated helper (`from lavandula.pipeline_protocol import emit_progress, emit_error, emit_summary`) that writes to a separate file descriptor (fd 3) rather than stdout/stderr. The orchestrator reads fd 3 for structured events and captures stdout/stderr only for the raw log file. This prevents untrusted content in stdout (org names, error traces from crawl targets) from being parsed as structured events. If fd 3 is unavailable (legacy stages), the orchestrator falls back to log-tail parsing — structured protocol is opt-in per stage.
+
+**Payload size cap:** Event payloads are capped at 64KB. Payloads exceeding this are truncated with a `"_truncated": true` flag.
+
 ### 8. Retry Policy
 
 Per-stage retry configuration:
@@ -256,9 +295,11 @@ class RetryPolicy:
 ```
 
 When a job fails with a retryable exit code:
-1. If `attempts < max_attempts`, create a new job (clone of the failed one) with `depends_on=None`, status `pending`
-2. Write `JobEvent(event_type="retried", payload={"original_job_id": N, "attempt": M})`
-3. The failed job stays in `failed` status (preserving its events/logs)
+1. If `attempts < max_attempts`, create a new job (clone of the failed one) with status `pending`
+2. Cloned fields: phase, state_code, host, config_json. Not cloned: depends_on, log_file, pid, events.
+3. Write `JobEvent(event_type="retried", payload={"original_job_id": N, "attempt": M, "retry_job_id": R})` on the original job
+4. The failed job stays in `failed` status (preserving its events/logs)
+5. **Dependent rebinding:** Any jobs whose `depends_on` pointed to the failed job are updated to point to the retry job. This ensures downstream jobs wait on the retry, not the failed original. A `JobEvent(event_type="dependency_rebound")` is recorded on each affected dependent.
 
 This replaces the current exit-code-3 special case in the orchestrator.
 
@@ -290,17 +331,52 @@ Phases 1-2 can ship without changing any pipeline stage code. Phase 3 changes th
 
 ## Testing Requirements
 
+**State machine & registry:**
 - Unit tests for stage registry validation (missing predecessors, circular dependencies, invalid parameters)
-- Unit tests for job lifecycle state machine (valid/invalid transitions)
+- Unit tests for job lifecycle state machine (valid/invalid transitions, e.g. `completed` → `running` rejected)
 - Unit tests for event log creation on each state transition
-- Integration test: job creation → dependency block → dependency met → scheduled → running → completed, verifying events at each step
-- Integration test: job failure → auto-retry → new job created with correct linkage
-- Migration test: backfill org_provenance from existing tables produces correct status for sampled orgs
+- Unit tests for command construction from stage registry (never `shell=True`, proper argv splatting)
 
-## Open Questions
+**Job lifecycle integration:**
+- Job creation → dependency block → dependency met → scheduled → running → completed, verifying events at each step
+- Job failure → auto-retry → new job created with correct linkage → dependents rebound to retry
+- Job cancellation from each non-terminal state
 
-1. **Should `org_provenance` live in `lava_pipeline` or `lava_impact`?** It's a pipeline control table, but it's keyed by EIN which is a data concept. Recommend `lava_pipeline` since it's operationally focused.
+**Crash recovery:**
+- Orchestrator restart with jobs in `scheduled` state (should reset to `pending`)
+- Orchestrator restart with jobs in `running` state, PID alive (should resume tracking)
+- Orchestrator restart with jobs in `running` state, PID gone (should mark `failed`/`orphaned`)
+- Spawn failure (binary not found) from `scheduled` state (should mark `failed`)
 
-2. **How granular should classify provenance be?** Currently classification is per-document, not per-org. An org might have 10 documents, 7 classified and 3 pending. Should provenance track "all documents classified" or "at least one classified"? Recommend: `classify_status = completed` when all known documents for that org are classified.
+**Progress protocol:**
+- Well-formed PROGRESS/ERROR/SUMMARY lines parsed correctly
+- Malformed lines (missing fields, partial writes, embedded newlines) handled gracefully
+- Lines exceeding 64KB payload cap are truncated with `_truncated` flag
+- Untrusted content on stdout does NOT produce spurious events (fd 3 isolation)
+- Legacy stages (no fd 3) fall back to log-tail parsing
 
-3. **Should the event log have a retention policy?** At 1 event per heartbeat (30s) per running job, a 24-hour crawl generates ~2,880 events. Across 50 states with parallel jobs, that's manageable (< 500K events/month). Probably fine to keep indefinitely for the first year, then add TTL if needed.
+**Org provenance:**
+- Backfill migration produces correct status for orgs at various pipeline stages
+- Partial-success provenance: job completes with mixed EIN outcomes, each written correctly
+- Seed stage creates provenance row; subsequent stages update it
+- Orgs with zero documents get `classify_status = not_applicable`
+- Concurrent provenance writes on different columns for same EIN (last-writer-wins, no conflict)
+
+**Dashboard rendering:**
+- Event payloads rendered safely (no XSS via `blocked_reason` or `error_detail`)
+- Job detail page shows full event timeline including blocked/rebound events
+
+**Performance smoke:**
+- `org_provenance` filter queries at 100K rows < 100ms
+- Event log queries for a long-running job (~3K events) < 200ms
+- Dashboard job list with 500+ historical jobs renders < 2s
+
+## Resolved Decisions
+
+1. **`org_provenance` lives in `lava_pipeline`.** It's operationally focused — tracks where orgs are in the pipeline, not domain data about them.
+
+2. **Classify provenance = "all known documents classified."** An org with 10 documents, 7 classified and 3 pending, has `classify_status = in_progress`. When all 10 are done, `completed`. An org with zero documents after crawl has `classify_status = not_applicable`.
+
+3. **Event log: no retention policy initially.** Estimated volume: < 500K events/month at national scale. Reassess after Phase 4 (structured progress protocol) adds per-stage progress events — if volume exceeds 5M/month, add a 90-day TTL on `progress` events only, keeping lifecycle events indefinitely.
+
+4. **Dashboard rendering security.** All event payloads and `blocked_reason` text must be rendered through Django's autoescaping. Plan must explicitly prohibit `|safe` filter on any user-facing field derived from job events or log content.

--- a/locard/specs/0034-pipeline-control-plane.md
+++ b/locard/specs/0034-pipeline-control-plane.md
@@ -1,0 +1,306 @@
+# Spec 0034: Pipeline Control Plane & Org Provenance
+
+## Problem Statement
+
+The pipeline grew organically from a single-host crawl tool into a multi-host, multi-phase national ingest system. Each phase was engineered independently, and the "control plane" — job lifecycle, org status tracking, logging — was bolted on after the fact. The result:
+
+1. **Jobs silently fail to start.** Dependency resolution is a single FK check with no visibility into *why* a job is blocked. No scheduler log, no "waiting on job #X" feedback.
+
+2. **Exit codes require detective work.** A failed job shows "Exit 1: partial failure" — but understanding what actually happened requires reading raw log files. There's no structured job summary.
+
+3. **Org pipeline status is fragmented.** Knowing "where is EIN 12-3456789 in the pipeline?" requires joining `nonprofits_seed.resolver_status`, `crawled_orgs.status`, `corpus.classification`, `filing_index.status`, and `people` — each with its own conventions.
+
+4. **New stages can't plug in cleanly.** The coming vocabulary extraction, aggregation, and report generation stages will each need their own status tracking, job types, and logging. The current pattern of adding a new COMMAND_MAP entry and hoping everything fits is not sustainable.
+
+## Goals
+
+### Must Have
+
+1. **Job lifecycle with clear state transitions and audit trail.** Every state change (pending → scheduled → running → completed/failed/cancelled) is logged with timestamp, reason, and actor. "Scheduled" is a new state: the job has been picked up by the scheduler but the subprocess hasn't started yet — this is where "silently didn't start" becomes visible.
+
+2. **Structured job summaries.** When a job finishes, the orchestrator writes a machine-readable summary (JSON) alongside the log: duration, records processed, records failed, exit code, error classification, last meaningful error line. The dashboard reads the summary, not the log tail.
+
+3. **Unified org provenance view.** A single materialized table (or view) that answers "where is this org in the pipeline?" across all stages. One row per org, one column per stage, value = status enum (not_started | in_progress | completed | failed | skipped). Updated as each stage completes.
+
+4. **Stage registry.** Pipeline stages declared as configuration (not hardcoded in COMMAND_MAP). Each stage declares: name, command template, required parameters, valid predecessor stages, phase conflict rules, and the status column it writes. Adding a new stage = adding a config entry + the actual code.
+
+5. **Dependency resolution with diagnostics.** When a job can't start, the system records *why* (dependency not met, phase conflict, host unavailable, predecessor failed). Visible on the dashboard job detail page.
+
+6. **Forward-compatible for extract/aggregate/report.** The design must accommodate stages that don't exist yet without requiring schema changes to the control plane itself. A new `extract-vocab` stage should only need: (a) a stage registry entry, (b) a management command or script, (c) an org_provenance column.
+
+### Should Have
+
+7. **Job event log.** A time-series table of job events (created, scheduled, started, heartbeat, progress, warning, error, completed). Replaces log-tail scraping for dashboard display. Events are structured (JSON payload) not free-text.
+
+8. **Retry policy per stage.** Configurable: how many times to retry a failed job, backoff strategy, whether to auto-retry or require manual intervention. Currently only exit-code-3 (lock busy) retries — everything else is terminal.
+
+9. **Org provenance history.** Not just current status but when each stage completed for each org. Enables "how long does crawl take per org?" and "which orgs have been stuck in resolve for 7+ days?"
+
+### Nice to Have
+
+10. **Stage DAG visualization.** Dashboard page showing the pipeline as a directed graph with per-stage org counts (how many orgs are at each stage).
+
+11. **Alerting hooks.** When a job fails or an org is stuck, emit a webhook/notification. Not critical for single-operator but useful as complexity grows.
+
+## Non-Goals
+
+- **Workflow engine replacement** (Airflow, Prefect, Dagster). This is a lightweight control plane for a single-operator system, not an enterprise orchestrator. The complexity budget is "Django models + management commands," not "install and maintain a workflow platform."
+- **Real-time streaming logs.** The dashboard shows job summaries and event logs, not live log tails. Operators who need live logs use `tail -f` on the host.
+- **Multi-tenant isolation.** Single operator (ronp), single RDS instance. No role-based access, no team permissions.
+
+## Current State
+
+### Job Model (pipeline/models.py)
+- Status: pending → running → completed | failed | cancelled
+- `depends_on` FK for simple chaining
+- `log_tail` (last 16KB of log file, unstructured text)
+- `error_message` (single line extracted by regex from log)
+- `config_json` (phase parameters, validated by COMMAND_MAP)
+
+### Orchestrator (run_orchestrator.py)
+- Polls every 30s for eligible jobs
+- Spawns subprocess, tracks PID
+- On completion: reads log tail, extracts error line, sets status
+- Exit code hints: hardcoded dict mapping codes to human-readable strings
+- Phase conflict: prevents two jobs of same phase+state from running simultaneously
+
+### Org Status (fragmented)
+- `nonprofits_seed.resolver_status`: null | resolved | rejected | error
+- `crawled_orgs.status`: ok | transient | permanent_skip (+ attempts counter)
+- `corpus.classification`: null | annual | impact | newsletter | ... (per-document, not per-org)
+- `filing_index.status`: indexed | downloaded | parsed (per-filing, not per-org)
+- `people`: exists or doesn't (per-filing)
+- No unified view. No way to answer "show me all orgs that are resolved but not yet crawled" without a multi-table join.
+
+### Logging
+- `logging_utils.py`: RotatingFileHandler, sanitized, format string based
+- `decisions_log.py`: Structured JSONL for crawler decisions (per-candidate)
+- Job logs: raw subprocess stdout/stderr captured to files
+- `PipelineAuditLog` model: exists but unused
+
+## Technical Design
+
+### 1. Stage Registry
+
+Replace `COMMAND_MAP` with a declarative stage registry. Each stage is a Python dataclass (not YAML — it needs to be importable for validation and IDE support).
+
+```python
+@dataclass
+class StageDefinition:
+    name: str                          # "resolve", "crawl", "classify", "extract-vocab"
+    display_name: str                  # "URL Resolver", "Site Crawler"
+    command: list[str]                 # ["python3", "-m", "lavandula.nonprofits.tools.pipeline_resolve"]
+    parameters: dict[str, ParamSpec]   # {"state": ParamSpec(required=True, type="state_code"), ...}
+    predecessors: list[str]            # ["seed"] — stages that must be complete before this one
+    conflict_group: str | None         # "per-state" or "global" or "990-family"
+    provenance_column: str | None      # "resolve_status" — column in org_provenance this stage writes
+    retry_policy: RetryPolicy          # max_attempts, backoff, auto_retry
+    progress_estimator: str | None     # "count_unresolved" — function name for progress_total
+```
+
+The registry is a module-level dict in `lavandula/dashboard/pipeline/stages.py`. Adding a new stage = adding an entry. The orchestrator, dashboard views, and job creation forms all read from the registry.
+
+### 2. Job Lifecycle Enhancement
+
+**New status: `scheduled`**
+
+```
+pending → scheduled → running → completed
+                              → failed → (auto-retry) → pending
+                              → cancelled
+```
+
+- `pending`: Created, waiting for dependencies and eligibility
+- `scheduled`: Picked up by scheduler, pre-launch checks passed. This is the window where "silently didn't start" currently hides.
+- `running`: Subprocess spawned, PID recorded
+- `completed` / `failed` / `cancelled`: Terminal states
+
+**Blocked reason tracking:**
+
+New field `blocked_reason` (nullable text) on Job, set by the scheduler when a job can't transition from pending → scheduled:
+- "Waiting on job #231 (crawl CA) to complete"
+- "Phase conflict: resolve WA already running (job #245)"
+- "Host cloud1 not responding (last heartbeat 15m ago)"
+- "Predecessor stage 'resolve' not complete for state WA"
+
+Cleared when the job becomes eligible.
+
+### 3. Job Event Log
+
+New model `JobEvent`:
+
+```python
+class JobEvent(models.Model):
+    job = models.ForeignKey(Job, related_name="events")
+    timestamp = models.DateTimeField(auto_now_add=True)
+    event_type = models.CharField(choices=[
+        ("created", "Created"),
+        ("scheduled", "Scheduled"),
+        ("started", "Started"),
+        ("progress", "Progress"),
+        ("warning", "Warning"),
+        ("error", "Error"),
+        ("completed", "Completed"),
+        ("failed", "Failed"),
+        ("cancelled", "Cancelled"),
+        ("retried", "Retried"),
+    ])
+    payload = models.JSONField(default=dict)
+    # payload examples:
+    # {"blocked_reason": "Waiting on job #231"}
+    # {"progress_current": 500, "progress_total": 3589, "rate": "437 orgs/hr"}
+    # {"exit_code": 1, "error_class": "flush_failure", "error_detail": "3 unresolved flush failures"}
+    # {"duration_s": 29376, "records_processed": 3537, "records_failed": 50}
+```
+
+The orchestrator writes events instead of updating `log_tail`. The dashboard reads events for the job detail page. Progress updates are events (replacing log-line parsing).
+
+### 4. Structured Job Summary
+
+When a job completes or fails, the orchestrator writes a `JobEvent` with `event_type="completed"` or `"failed"` and a payload containing:
+
+```json
+{
+    "duration_s": 29376,
+    "exit_code": 0,
+    "records_processed": 3537,
+    "records_failed": 50,
+    "records_skipped": 2,
+    "error_class": null,
+    "error_detail": null,
+    "peak_rss_kb": 894032,
+    "artifacts": {
+        "pdfs_fetched": 9235,
+        "bytes_downloaded": 32443967082,
+        "wayback_recoveries": 47
+    }
+}
+```
+
+The `artifacts` dict is stage-specific (each stage reports its own metrics). The fixed fields (duration, exit_code, records_*) are common across all stages. The summary is parsed from the final log line of each stage (which already emits structured `===DONE===` lines) and from the exit code.
+
+### 5. Org Provenance Table
+
+New table `org_provenance` in `lava_pipeline` schema:
+
+```sql
+CREATE TABLE lava_pipeline.org_provenance (
+    ein TEXT PRIMARY KEY,
+    -- Stage statuses (enum: not_started, in_progress, completed, failed, skipped)
+    seed_status       TEXT NOT NULL DEFAULT 'not_started',
+    seed_completed_at TIMESTAMPTZ,
+    resolve_status       TEXT NOT NULL DEFAULT 'not_started',
+    resolve_completed_at TIMESTAMPTZ,
+    crawl_status       TEXT NOT NULL DEFAULT 'not_started',
+    crawl_completed_at TIMESTAMPTZ,
+    classify_status       TEXT NOT NULL DEFAULT 'not_started',
+    classify_completed_at TIMESTAMPTZ,
+    filing_990_status       TEXT NOT NULL DEFAULT 'not_started',
+    filing_990_completed_at TIMESTAMPTZ,
+    -- Future stages — added via ALTER TABLE when stage is registered
+    -- extract_vocab_status, aggregate_status, report_status, etc.
+    
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+```
+
+**Population strategy:** Each pipeline stage, on completion, updates its corresponding column. The orchestrator's `_finish_job()` handler calls `update_org_provenance(stage, ein_list, status)` with the list of EINs processed.
+
+**Backfill:** One-time migration reads existing `nonprofits_seed`, `crawled_orgs`, and `corpus` tables to populate initial provenance state.
+
+**Dashboard view:** New "Org Pipeline Status" page shows a filterable table: one row per org, columns for each stage, color-coded by status. Filter by state, NTEE code, or "stuck" (any stage failed or in_progress for > N days).
+
+### 6. Forward Compatibility
+
+When a new stage (e.g., `extract-vocab`) is added:
+
+1. **Add to stage registry** in `stages.py`
+2. **Add migration** `ALTER TABLE org_provenance ADD COLUMN extract_vocab_status TEXT DEFAULT 'not_started', ADD COLUMN extract_vocab_completed_at TIMESTAMPTZ;`
+3. **Write the stage code** (management command or script) that does the work and emits structured `===DONE===` lines
+4. **The rest is automatic:** The orchestrator knows how to dispatch it, the dashboard knows how to show it, the provenance table knows how to track it.
+
+No changes to the orchestrator, job model, event log, or dashboard templates. The stage registry drives everything.
+
+### 7. Logging Rationalization
+
+**Eliminate log-tail scraping.** The orchestrator no longer reads log files to extract error information. Instead:
+
+- Progress: pipeline stages emit structured progress to stdout in a known format (e.g., `PROGRESS: current=500 total=3589 rate=437`). The orchestrator's heartbeat loop parses this and writes `JobEvent(event_type="progress")`.
+- Errors: stages emit `ERROR: class=flush_failure detail=3 unresolved flush failures` to stderr. The orchestrator captures these as `JobEvent(event_type="error")`.
+- Summary: stages emit `SUMMARY: records_processed=3537 records_failed=50 ...` as their final line. The orchestrator parses this into the completion event.
+
+The raw log file still exists (for debugging), but the dashboard never reads it directly.
+
+**Structured progress protocol:** A simple line-based protocol that all stages follow:
+
+```
+PROGRESS: current=N total=M [key=value ...]
+ERROR: class=NAME detail=TEXT
+WARNING: class=NAME detail=TEXT  
+SUMMARY: duration_s=N records_processed=N records_failed=N [key=value ...]
+```
+
+This is intentionally simple — not JSON, not protobuf. It's `key=value` pairs on tagged lines that can be parsed with a regex and are still human-readable in raw logs.
+
+### 8. Retry Policy
+
+Per-stage retry configuration:
+
+```python
+@dataclass
+class RetryPolicy:
+    max_attempts: int = 1         # 1 = no retry
+    auto_retry: bool = False      # True = orchestrator retries automatically
+    backoff_seconds: int = 60     # Wait between retries
+    retryable_exit_codes: list[int] = field(default_factory=lambda: [1, 3])
+```
+
+When a job fails with a retryable exit code:
+1. If `attempts < max_attempts`, create a new job (clone of the failed one) with `depends_on=None`, status `pending`
+2. Write `JobEvent(event_type="retried", payload={"original_job_id": N, "attempt": M})`
+3. The failed job stays in `failed` status (preserving its events/logs)
+
+This replaces the current exit-code-3 special case in the orchestrator.
+
+## Migration Path
+
+This is a significant refactor touching the orchestrator, job model, and dashboard. Phase it:
+
+**Phase 1: Stage registry + job lifecycle** — Replace COMMAND_MAP with registry, add `scheduled` status, add `blocked_reason`. Minimal dashboard changes (show blocked reason on job list).
+
+**Phase 2: Event log + structured summaries** — Add `JobEvent` model, refactor orchestrator to write events, update dashboard job detail to show events. Remove log-tail scraping.
+
+**Phase 3: Org provenance** — New table, backfill migration, dashboard provenance page. Pipeline stages updated to write provenance on completion.
+
+**Phase 4: Structured progress protocol** — Update each pipeline stage to emit PROGRESS/ERROR/SUMMARY lines. Orchestrator heartbeat parses them into events.
+
+Phases 1-2 can ship without changing any pipeline stage code. Phase 3 changes the data model. Phase 4 changes every pipeline stage (but each stage can be migrated independently).
+
+## Traps to Avoid
+
+1. **Don't over-engineer the stage registry.** It should be a Python dict of dataclasses, not a plugin system with dynamic loading. We have ~10 stages, not 100.
+
+2. **Don't migrate all stages to the progress protocol at once.** The orchestrator should gracefully handle stages that don't emit structured lines (fall back to log-tail parsing for legacy stages).
+
+3. **Don't make org_provenance a view.** It needs to be a table (materialized) because the source tables have different schemas and the join is expensive at 100K+ orgs. Write-through on stage completion, not computed on read.
+
+4. **Don't add real-time log streaming.** The temptation will be strong. Resist it. Structured events + raw log files cover all use cases without the WebSocket complexity.
+
+5. **The provenance table will need new columns as stages are added.** This is fine — `ALTER TABLE ADD COLUMN` is cheap in Postgres. Don't try to make it "schema-free" with a JSON column; explicit columns are queryable and type-safe.
+
+## Testing Requirements
+
+- Unit tests for stage registry validation (missing predecessors, circular dependencies, invalid parameters)
+- Unit tests for job lifecycle state machine (valid/invalid transitions)
+- Unit tests for event log creation on each state transition
+- Integration test: job creation → dependency block → dependency met → scheduled → running → completed, verifying events at each step
+- Integration test: job failure → auto-retry → new job created with correct linkage
+- Migration test: backfill org_provenance from existing tables produces correct status for sampled orgs
+
+## Open Questions
+
+1. **Should `org_provenance` live in `lava_pipeline` or `lava_impact`?** It's a pipeline control table, but it's keyed by EIN which is a data concept. Recommend `lava_pipeline` since it's operationally focused.
+
+2. **How granular should classify provenance be?** Currently classification is per-document, not per-org. An org might have 10 documents, 7 classified and 3 pending. Should provenance track "all documents classified" or "at least one classified"? Recommend: `classify_status = completed` when all known documents for that org are classified.
+
+3. **Should the event log have a retention policy?** At 1 event per heartbeat (30s) per running job, a 24-hour crawl generates ~2,880 events. Across 50 states with parallel jobs, that's manageable (< 500K events/month). Probably fine to keep indefinitely for the first year, then add TTL if needed.


### PR DESCRIPTION
## Summary

Implements the pipeline control plane (Spec 0034) across all 4 phases:

- **Phase 1A**: Declarative stage registry replacing hardcoded COMMAND_MAP. Parameter validation with shell metachar rejection.
- **Phase 1B**: Job lifecycle (pending→scheduled→running→terminal), resource-aware scheduler with scoring function, advisory lock, crash recovery, auto-retry with dependent rebinding, scheduler_config.yaml with hot-reload.
- **Phase 2**: JobEvent model for structured audit trail. Summary parser. Dashboard event timeline. Payload truncation at 64KB.
- **Phase 3**: org_provenance table (per-EIN, per-stage status). Provenance writer with column ownership enforcement. Backfill command. Registry-driven dashboard page with filters.
- **Phase 4**: Structured progress protocol via fd 3 (isolated from stdout). pipeline_protocol.py emission library. ProtocolReader background thread for orchestrator.

### Key Design Decisions
- Stage registry is a Python dict of frozen dataclasses (not YAML/plugins)
- Legacy COMMAND_MAP kept as 1-week fallback during transition
- v0 stages get NO structured event parsing (exit code + duration only)
- Provenance file path validated with realpath + prefix check
- Scheduler scoring: hard gates (CPU/mem ceiling, concurrency, cool-down) + soft weights (affinity, headroom, starvation boost, ETA lookahead)

### New Files (13)
| File | Purpose |
|------|---------|
| `pipeline/stages.py` | Stage registry definitions |
| `pipeline/param_validators.py` | Parameter validation + argv construction |
| `pipeline/scheduler.py` | Scoring function for job-host placement |
| `pipeline/scheduler_config.py` | YAML config loader with hot-reload |
| `scheduler_config.yaml` | Operator-tunable scheduling weights |
| `pipeline/summary_parser.py` | Parse stage DONE lines into summary payload |
| `pipeline/provenance.py` | Provenance writer with ownership enforcement |
| `pipeline/protocol_reader.py` | fd 3 pipe reader for orchestrator |
| `pipeline_protocol.py` | Structured event emission library |
| `pipeline/management/commands/backfill_provenance.py` | One-time backfill |
| `pipeline/templates/pipeline/provenance.html` | Provenance dashboard page |
| `migrations/rds/013_org_provenance.sql` | Provenance table DDL |
| `pipeline/migrations/0007_*.py`, `0008_*.py` | Django model migrations |

## Test plan

- [x] 122 unit tests passing (all SimpleTestCase, no DB required)
- [ ] Deploy Phase 1: run migration 0007, restart orchestrator, verify pending→scheduled→running
- [ ] Deploy Phase 2: run migration 0008, verify event timeline on job detail page
- [ ] Deploy Phase 3: run RDS migration 013, run backfill_provenance, spot-check provenance page
- [ ] Deploy Phase 4: migrate one stage to v1, verify progress events appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)