### PR TITLE
[Spec 0037] Rename RDS roles: app_user1→research_app, ro_user1→research_ro

### DIFF
--- a/lavandula/common/tests/conftest.py
+++ b/lavandula/common/tests/conftest.py
@@ -28,14 +28,14 @@ def _apply_migrations(engine) -> None:
     """Apply lavandula/migrations/rds/*.sql against `engine`.
 
     The production migrations assume the `lava_corpus` schema and the
-    `app_user1` / `ro_user1` roles already exist (created outside of
+    `research_app` / `research_ro` roles already exist (created outside of
     migrations on the real RDS instance). For a fresh testing.postgresql
     cluster we stand those up first.
     """
     from sqlalchemy import text
     with engine.begin() as conn:
         conn.execute(text("CREATE SCHEMA IF NOT EXISTS lava_corpus"))
-        for role in ("app_user1", "ro_user1"):
+        for role in ("research_app", "research_ro"):
             conn.execute(text(
                 f"DO $$BEGIN "
                 f"IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname='{role}') "

--- a/lavandula/common/tests/unit/test_db_adapter_0013.py
+++ b/lavandula/common/tests/unit/test_db_adapter_0013.py
@@ -33,7 +33,7 @@ def _make_mgr(clock, tokens=("tok-1", "tok-2", "tok-3")):
         region="us-east-1",
         host="db.example",
         port=5432,
-        user="app_user1",
+        user="research_app",
         rds_client=rds,
         clock=clock,
     )
@@ -74,7 +74,7 @@ def test_token_generate_call_arguments():
     rds.generate_db_auth_token.assert_called_once_with(
         DBHostname="db.example",
         Port=5432,
-        DBUsername="app_user1",
+        DBUsername="research_app",
         Region="us-east-1",
     )
 
@@ -124,11 +124,11 @@ def test_engine_url_has_no_password_and_requires_ssl():
         host="db.example",
         port=5432,
         database="lava_prod1",
-        user="app_user1",
+        user="research_app",
         token_manager=mgr,
     )
     url = str(engine.url)
-    assert "app_user1@db.example:5432/lava_prod1" in url
+    assert "research_app@db.example:5432/lava_prod1" in url
     # SQLAlchemy masks passwords; assert the render-with-password is empty
     assert engine.url.password is None
     assert engine.url.query.get("sslmode") == "require"
@@ -208,8 +208,8 @@ def test_ssm_based_factory_wiring(monkeypatch):
         "rds-port": "5432",
         "rds-database": "lava_prod1",
         "rds-schema": "lava_corpus",
-        "rds-app-user": "app_user1",
-        "rds-ro-user": "ro_user1",
+        "rds-app-user": "research_app",
+        "rds-ro-user": "research_ro",
     }
     secretsmod.clear_cache()
     monkeypatch.setattr(
@@ -225,7 +225,7 @@ def test_ssm_based_factory_wiring(monkeypatch):
     monkeypatch.setattr(dbmod, "make_engine", fake_make_engine)
 
     assert dbmod.make_app_engine() == "ENGINE"
-    assert captured["user"] == "app_user1"
+    assert captured["user"] == "research_app"
     assert captured["host"] == "db.prod.example"
     assert captured["port"] == 5432
     assert captured["database"] == "lava_prod1"
@@ -234,7 +234,7 @@ def test_ssm_based_factory_wiring(monkeypatch):
 
     captured.clear()
     assert dbmod.make_ro_engine() == "ENGINE"
-    assert captured["user"] == "ro_user1"
+    assert captured["user"] == "research_ro"
 
 
 def test_ro_engine_uses_ro_user(monkeypatch):
@@ -256,14 +256,14 @@ def test_ro_engine_uses_ro_user(monkeypatch):
             "rds-port": "5432",
             "rds-database": "d",
             "rds-schema": "s",
-            "rds-ro-user": "ro_user1",
-            "rds-app-user": "app_user1",
+            "rds-ro-user": "research_ro",
+            "rds-app-user": "research_app",
         }[name]),
     )
     monkeypatch.setattr(dbmod, "make_engine", lambda **kw: kw)
 
     kw = dbmod.make_ro_engine()
-    assert kw["user"] == "ro_user1"
+    assert kw["user"] == "research_ro"
     assert "rds-ro-user" in asked
     assert "rds-app-user" not in asked
 
@@ -278,7 +278,7 @@ def test_ro_engine_uses_ro_user(monkeypatch):
 def test_live_rds_app_engine_select_1():
     """AC5: real make_app_engine() connects and runs SELECT 1.
 
-    Requires the EC2 IAM role to have rds-db:connect for app_user1 and
+    Requires the EC2 IAM role to have rds-db:connect for research_app and
     the SSM parameters to be populated. Run manually after deployment.
     """
     from sqlalchemy import text

--- a/lavandula/migrations/rds/001_initial_schema.sql
+++ b/lavandula/migrations/rds/001_initial_schema.sql
@@ -23,17 +23,17 @@ CREATE TABLE IF NOT EXISTS schema_version (
 
 -- =========================================================================
 -- Default privileges — makes every table created by postgres auto-grant
--- CRUD to app_user1 and SELECT to ro_user1. Must be set BEFORE CREATE TABLE
+-- CRUD to research_app and SELECT to research_ro. Must be set BEFORE CREATE TABLE
 -- so the newly-created objects inherit the grants.
 -- =========================================================================
 ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA lava_impact
-  GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO app_user1;
+  GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO research_app;
 ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA lava_impact
-  GRANT SELECT ON TABLES TO ro_user1;
+  GRANT SELECT ON TABLES TO research_ro;
 ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA lava_impact
-  GRANT USAGE, SELECT ON SEQUENCES TO app_user1;
+  GRANT USAGE, SELECT ON SEQUENCES TO research_app;
 ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA lava_impact
-  GRANT SELECT ON SEQUENCES TO ro_user1;
+  GRANT SELECT ON SEQUENCES TO research_ro;
 
 -- =========================================================================
 -- nonprofits_seed — seed list of nonprofit orgs with resolver output
@@ -249,10 +249,10 @@ CREATE INDEX IF NOT EXISTS idx_budget_ledger_at ON budget_ledger(at_timestamp);
 -- Explicit grants on existing objects (defensive; default privileges above
 -- handle NEW objects, these cover tables just created in this transaction).
 -- =========================================================================
-GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA lava_impact TO app_user1;
-GRANT SELECT ON ALL TABLES IN SCHEMA lava_impact TO ro_user1;
-GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA lava_impact TO app_user1;
-GRANT SELECT ON ALL SEQUENCES IN SCHEMA lava_impact TO ro_user1;
+GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA lava_impact TO research_app;
+GRANT SELECT ON ALL TABLES IN SCHEMA lava_impact TO research_ro;
+GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA lava_impact TO research_app;
+GRANT SELECT ON ALL SEQUENCES IN SCHEMA lava_impact TO research_ro;
 
 -- =========================================================================
 -- Record this migration

--- a/lavandula/migrations/rds/002_attribution_helper.sql
+++ b/lavandula/migrations/rds/002_attribution_helper.sql
@@ -22,7 +22,7 @@ LANGUAGE SQL IMMUTABLE AS $$
 $$;
 
 GRANT EXECUTE ON FUNCTION lava_impact.attribution_rank(TEXT)
-  TO app_user1, ro_user1;
+  TO research_app, research_ro;
 
 INSERT INTO schema_version (version, name)
   VALUES (2, 'attribution_rank_helper')

--- a/lavandula/migrations/rds/010_990_people_filing_index.sql
+++ b/lavandula/migrations/rds/010_990_people_filing_index.sql
@@ -64,10 +64,10 @@ CREATE INDEX IF NOT EXISTS idx_people_ein_period ON lava_corpus.people(ein, tax_
 CREATE UNIQUE INDEX IF NOT EXISTS idx_people_dedup ON lava_corpus.people(ein, object_id, person_name, person_type);
 
 -- GRANTs
-GRANT SELECT, INSERT, UPDATE, DELETE ON lava_corpus.people TO app_user1;
-GRANT SELECT, INSERT, UPDATE, DELETE ON lava_corpus.filing_index TO app_user1;
-GRANT SELECT ON lava_corpus.people TO ro_user1;
-GRANT SELECT ON lava_corpus.filing_index TO ro_user1;
-GRANT USAGE, SELECT ON SEQUENCE lava_corpus.people_id_seq TO app_user1;
+GRANT SELECT, INSERT, UPDATE, DELETE ON lava_corpus.people TO research_app;
+GRANT SELECT, INSERT, UPDATE, DELETE ON lava_corpus.filing_index TO research_app;
+GRANT SELECT ON lava_corpus.people TO research_ro;
+GRANT SELECT ON lava_corpus.filing_index TO research_ro;
+GRANT USAGE, SELECT ON SEQUENCE lava_corpus.people_id_seq TO research_app;
 
 COMMIT;

--- a/lavandula/migrations/rds/migration_011_990_index_automation.sql
+++ b/lavandula/migrations/rds/migration_011_990_index_automation.sql
@@ -53,12 +53,12 @@ CREATE TABLE IF NOT EXISTS lava_corpus.filing_status_audit (
 );
 
 -- GRANTs
-GRANT SELECT, INSERT ON lava_corpus.index_refresh_log TO app_user1;
-GRANT SELECT ON lava_corpus.index_refresh_log TO ro_user1;
-GRANT USAGE, SELECT ON SEQUENCE lava_corpus.index_refresh_log_id_seq TO app_user1;
+GRANT SELECT, INSERT ON lava_corpus.index_refresh_log TO research_app;
+GRANT SELECT ON lava_corpus.index_refresh_log TO research_ro;
+GRANT USAGE, SELECT ON SEQUENCE lava_corpus.index_refresh_log_id_seq TO research_app;
 
-GRANT SELECT, INSERT ON lava_corpus.filing_status_audit TO app_user1;
-GRANT SELECT ON lava_corpus.filing_status_audit TO ro_user1;
-GRANT USAGE, SELECT ON SEQUENCE lava_corpus.filing_status_audit_id_seq TO app_user1;
+GRANT SELECT, INSERT ON lava_corpus.filing_status_audit TO research_app;
+GRANT SELECT ON lava_corpus.filing_status_audit TO research_ro;
+GRANT USAGE, SELECT ON SEQUENCE lava_corpus.filing_status_audit_id_seq TO research_app;
 
 COMMIT;

--- a/locard/operations/0037-cutover-dashboard-user-drop.sql
+++ b/locard/operations/0037-cutover-dashboard-user-drop.sql
@@ -1,0 +1,65 @@
+-- 0037-cutover-dashboard-user-drop.sql
+--
+-- Operator runs ONLY if pre-check determines dashboard_user1 exists AND has
+-- zero GRANTs AND zero non-rds_iam memberships (per spec §"dashboard_user1
+-- decision rule").
+--
+-- Defense-in-depth: re-validates all three conditions before dropping.
+-- If any check fails, RAISEs an EXCEPTION (HALT — operator investigates).
+--
+-- Usage: psql -h $RDS_ENDPOINT -U $MASTER_USER -d $DB -f 0037-cutover-dashboard-user-drop.sql
+
+DO $$
+DECLARE
+  v_grant_count int;
+  v_owned_count int;
+  v_noniam_member_count int;
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'dashboard_user1') THEN
+    RAISE NOTICE 'dashboard_user1 does not exist — no-op';
+    RETURN;
+  END IF;
+
+  -- Check 1: zero non-rds_iam memberships
+  SELECT count(*) INTO v_noniam_member_count
+  FROM pg_auth_members am
+  JOIN pg_roles r ON r.oid = am.member
+  JOIN pg_roles m ON m.oid = am.roleid
+  WHERE r.rolname = 'dashboard_user1' AND m.rolname <> 'rds_iam';
+
+  IF v_noniam_member_count > 0 THEN
+    RAISE EXCEPTION 'dashboard_user1 has % non-rds_iam memberships — HALT per spec',
+                    v_noniam_member_count;
+  END IF;
+
+  -- Check 2: zero object-privilege grants
+  SELECT count(*) INTO v_grant_count
+  FROM (
+    SELECT 1 FROM information_schema.table_privileges
+      WHERE grantee = 'dashboard_user1'
+    UNION ALL
+    SELECT 1 FROM information_schema.routine_privileges
+      WHERE grantee = 'dashboard_user1'
+    UNION ALL
+    SELECT 1 FROM information_schema.usage_privileges
+      WHERE grantee = 'dashboard_user1'
+  ) g;
+
+  IF v_grant_count > 0 THEN
+    RAISE EXCEPTION 'dashboard_user1 has % object-privilege grants — HALT per spec',
+                    v_grant_count;
+  END IF;
+
+  -- Check 3: zero objects owned by the role
+  SELECT count(*) INTO v_owned_count
+  FROM pg_class c JOIN pg_roles r ON c.relowner = r.oid
+  WHERE r.rolname = 'dashboard_user1';
+
+  IF v_owned_count > 0 THEN
+    RAISE EXCEPTION 'dashboard_user1 owns % objects — HALT', v_owned_count;
+  END IF;
+
+  -- All checks passed; safe to drop.
+  DROP ROLE dashboard_user1;
+  RAISE NOTICE 'dashboard_user1 dropped (was vestigial)';
+END $$;

--- a/locard/operations/0037-cutover-dashboard-user-drop.sql
+++ b/locard/operations/0037-cutover-dashboard-user-drop.sql
@@ -4,7 +4,7 @@
 -- zero GRANTs AND zero non-rds_iam memberships (per spec §"dashboard_user1
 -- decision rule").
 --
--- Defense-in-depth: re-validates all three conditions before dropping.
+-- Defense-in-depth: re-validates all four conditions before dropping.
 -- If any check fails, RAISEs an EXCEPTION (HALT — operator investigates).
 --
 -- Usage: psql -h $RDS_ENDPOINT -U $MASTER_USER -d $DB -f 0037-cutover-dashboard-user-drop.sql
@@ -12,6 +12,7 @@
 DO $$
 DECLARE
   v_grant_count int;
+  v_schema_grant_count int;
   v_owned_count int;
   v_noniam_member_count int;
 BEGIN
@@ -50,7 +51,19 @@ BEGIN
                     v_grant_count;
   END IF;
 
-  -- Check 3: zero objects owned by the role
+  -- Check 3: zero schema-level privileges (USAGE/CREATE on schemas)
+  -- information_schema.usage_privileges does NOT cover schemas.
+  SELECT count(*) INTO v_schema_grant_count
+  FROM pg_namespace n,
+       LATERAL unnest(n.nspacl) AS a(acl_entry)
+  WHERE a.acl_entry::text LIKE 'dashboard_user1=%';
+
+  IF v_schema_grant_count > 0 THEN
+    RAISE EXCEPTION 'dashboard_user1 has % schema-level privilege grants — HALT per spec',
+                    v_schema_grant_count;
+  END IF;
+
+  -- Check 4: zero objects owned by the role
   SELECT count(*) INTO v_owned_count
   FROM pg_class c JOIN pg_roles r ON c.relowner = r.oid
   WHERE r.rolname = 'dashboard_user1';

--- a/locard/operations/0037-cutover-rename.sql
+++ b/locard/operations/0037-cutover-rename.sql
@@ -8,24 +8,35 @@
 
 BEGIN;
 DO $$ BEGIN
+  -- HALT on mixed state: both source and target exist simultaneously
   IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'app_user1')
-     AND NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'research_app') THEN
+     AND EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'research_app') THEN
+    RAISE EXCEPTION 'MIXED STATE: both app_user1 and research_app exist — '
+                    'operator must investigate per spec §Rollback Decision Tree';
+  END IF;
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'ro_user1')
+     AND EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'research_ro') THEN
+    RAISE EXCEPTION 'MIXED STATE: both ro_user1 and research_ro exist — '
+                    'operator must investigate per spec §Rollback Decision Tree';
+  END IF;
+
+  -- Rename or no-op
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'app_user1') THEN
     ALTER ROLE app_user1 RENAME TO research_app;
     RAISE NOTICE 'Renamed app_user1 → research_app';
   ELSIF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'research_app') THEN
     RAISE NOTICE 'research_app already exists — no-op';
   ELSE
-    RAISE NOTICE 'app_user1 does not exist and research_app does not exist — nothing to rename';
+    RAISE NOTICE 'Neither app_user1 nor research_app exist — nothing to rename';
   END IF;
 
-  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'ro_user1')
-     AND NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'research_ro') THEN
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'ro_user1') THEN
     ALTER ROLE ro_user1 RENAME TO research_ro;
     RAISE NOTICE 'Renamed ro_user1 → research_ro';
   ELSIF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'research_ro') THEN
     RAISE NOTICE 'research_ro already exists — no-op';
   ELSE
-    RAISE NOTICE 'ro_user1 does not exist and research_ro does not exist — nothing to rename';
+    RAISE NOTICE 'Neither ro_user1 nor research_ro exist — nothing to rename';
   END IF;
 END $$;
 COMMIT;

--- a/locard/operations/0037-cutover-rename.sql
+++ b/locard/operations/0037-cutover-rename.sql
@@ -8,18 +8,24 @@
 
 BEGIN;
 DO $$ BEGIN
-  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'app_user1') THEN
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'app_user1')
+     AND NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'research_app') THEN
     ALTER ROLE app_user1 RENAME TO research_app;
     RAISE NOTICE 'Renamed app_user1 → research_app';
+  ELSIF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'research_app') THEN
+    RAISE NOTICE 'research_app already exists — no-op';
   ELSE
-    RAISE NOTICE 'app_user1 does not exist (already renamed or never created) — no-op';
+    RAISE NOTICE 'app_user1 does not exist and research_app does not exist — nothing to rename';
   END IF;
 
-  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'ro_user1') THEN
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'ro_user1')
+     AND NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'research_ro') THEN
     ALTER ROLE ro_user1 RENAME TO research_ro;
     RAISE NOTICE 'Renamed ro_user1 → research_ro';
+  ELSIF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'research_ro') THEN
+    RAISE NOTICE 'research_ro already exists — no-op';
   ELSE
-    RAISE NOTICE 'ro_user1 does not exist (already renamed or never created) — no-op';
+    RAISE NOTICE 'ro_user1 does not exist and research_ro does not exist — nothing to rename';
   END IF;
 END $$;
 COMMIT;

--- a/locard/operations/0037-cutover-rename.sql
+++ b/locard/operations/0037-cutover-rename.sql
@@ -1,0 +1,30 @@
+-- 0037-cutover-rename.sql — Transactional role rename with idempotency guards.
+--
+-- Renames: app_user1 → research_app, ro_user1 → research_ro
+-- Re-running after a successful rename is a no-op (not an error).
+-- Does NOT touch dashboard_user1 (see 0037-cutover-dashboard-user-drop.sql).
+--
+-- Usage: psql -h $RDS_ENDPOINT -U $MASTER_USER -d $DB -f 0037-cutover-rename.sql
+
+BEGIN;
+DO $$ BEGIN
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'app_user1') THEN
+    ALTER ROLE app_user1 RENAME TO research_app;
+    RAISE NOTICE 'Renamed app_user1 → research_app';
+  ELSE
+    RAISE NOTICE 'app_user1 does not exist (already renamed or never created) — no-op';
+  END IF;
+
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'ro_user1') THEN
+    ALTER ROLE ro_user1 RENAME TO research_ro;
+    RAISE NOTICE 'Renamed ro_user1 → research_ro';
+  ELSE
+    RAISE NOTICE 'ro_user1 does not exist (already renamed or never created) — no-op';
+  END IF;
+END $$;
+COMMIT;
+
+-- Verify
+SELECT rolname FROM pg_roles
+WHERE rolname IN ('app_user1', 'ro_user1', 'research_app', 'research_ro')
+ORDER BY rolname;

--- a/locard/operations/0037-cutover-rollback.sql
+++ b/locard/operations/0037-cutover-rollback.sql
@@ -1,0 +1,29 @@
+-- 0037-cutover-rollback.sql — Symmetric reverse rename with idempotency guards.
+--
+-- Renames: research_app → app_user1, research_ro → ro_user1
+-- Re-running after a successful rollback is a no-op (not an error).
+--
+-- Usage: psql -h $RDS_ENDPOINT -U $MASTER_USER -d $DB -f 0037-cutover-rollback.sql
+
+BEGIN;
+DO $$ BEGIN
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'research_app') THEN
+    ALTER ROLE research_app RENAME TO app_user1;
+    RAISE NOTICE 'Rolled back research_app → app_user1';
+  ELSE
+    RAISE NOTICE 'research_app does not exist (already rolled back or never renamed) — no-op';
+  END IF;
+
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'research_ro') THEN
+    ALTER ROLE research_ro RENAME TO ro_user1;
+    RAISE NOTICE 'Rolled back research_ro → ro_user1';
+  ELSE
+    RAISE NOTICE 'research_ro does not exist (already rolled back or never renamed) — no-op';
+  END IF;
+END $$;
+COMMIT;
+
+-- Verify
+SELECT rolname FROM pg_roles
+WHERE rolname IN ('app_user1', 'ro_user1', 'research_app', 'research_ro')
+ORDER BY rolname;

--- a/locard/operations/0037-cutover-rollback.sql
+++ b/locard/operations/0037-cutover-rollback.sql
@@ -7,18 +7,24 @@
 
 BEGIN;
 DO $$ BEGIN
-  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'research_app') THEN
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'research_app')
+     AND NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'app_user1') THEN
     ALTER ROLE research_app RENAME TO app_user1;
     RAISE NOTICE 'Rolled back research_app → app_user1';
+  ELSIF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'app_user1') THEN
+    RAISE NOTICE 'app_user1 already exists — no-op';
   ELSE
-    RAISE NOTICE 'research_app does not exist (already rolled back or never renamed) — no-op';
+    RAISE NOTICE 'research_app does not exist and app_user1 does not exist — nothing to roll back';
   END IF;
 
-  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'research_ro') THEN
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'research_ro')
+     AND NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'ro_user1') THEN
     ALTER ROLE research_ro RENAME TO ro_user1;
     RAISE NOTICE 'Rolled back research_ro → ro_user1';
+  ELSIF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'ro_user1') THEN
+    RAISE NOTICE 'ro_user1 already exists — no-op';
   ELSE
-    RAISE NOTICE 'research_ro does not exist (already rolled back or never renamed) — no-op';
+    RAISE NOTICE 'research_ro does not exist and ro_user1 does not exist — nothing to roll back';
   END IF;
 END $$;
 COMMIT;

--- a/locard/operations/0037-cutover-rollback.sql
+++ b/locard/operations/0037-cutover-rollback.sql
@@ -7,24 +7,35 @@
 
 BEGIN;
 DO $$ BEGIN
+  -- HALT on mixed state: both source and target exist simultaneously
   IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'research_app')
-     AND NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'app_user1') THEN
+     AND EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'app_user1') THEN
+    RAISE EXCEPTION 'MIXED STATE: both research_app and app_user1 exist — '
+                    'operator must investigate per spec §Rollback Decision Tree';
+  END IF;
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'research_ro')
+     AND EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'ro_user1') THEN
+    RAISE EXCEPTION 'MIXED STATE: both research_ro and ro_user1 exist — '
+                    'operator must investigate per spec §Rollback Decision Tree';
+  END IF;
+
+  -- Rollback or no-op
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'research_app') THEN
     ALTER ROLE research_app RENAME TO app_user1;
     RAISE NOTICE 'Rolled back research_app → app_user1';
   ELSIF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'app_user1') THEN
     RAISE NOTICE 'app_user1 already exists — no-op';
   ELSE
-    RAISE NOTICE 'research_app does not exist and app_user1 does not exist — nothing to roll back';
+    RAISE NOTICE 'Neither research_app nor app_user1 exist — nothing to roll back';
   END IF;
 
-  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'research_ro')
-     AND NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'ro_user1') THEN
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'research_ro') THEN
     ALTER ROLE research_ro RENAME TO ro_user1;
     RAISE NOTICE 'Rolled back research_ro → ro_user1';
   ELSIF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'ro_user1') THEN
     RAISE NOTICE 'ro_user1 already exists — no-op';
   ELSE
-    RAISE NOTICE 'research_ro does not exist and ro_user1 does not exist — nothing to roll back';
+    RAISE NOTICE 'Neither research_ro nor ro_user1 exist — nothing to roll back';
   END IF;
 END $$;
 COMMIT;

--- a/locard/operations/0037-iam-policy-final.json
+++ b/locard/operations/0037-iam-policy-final.json
@@ -1,0 +1,14 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "RDSIAMConnect",
+      "Effect": "Allow",
+      "Action": "rds-db:connect",
+      "Resource": [
+        "arn:aws:rds-db:us-east-1:ACCT:dbuser/DB-RES-ID/research_app",
+        "arn:aws:rds-db:us-east-1:ACCT:dbuser/DB-RES-ID/research_ro"
+      ]
+    }
+  ]
+}

--- a/locard/operations/0037-iam-policy-overlay.json
+++ b/locard/operations/0037-iam-policy-overlay.json
@@ -1,0 +1,16 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "RDSIAMConnectOverlay0037",
+      "Effect": "Allow",
+      "Action": "rds-db:connect",
+      "Resource": [
+        "arn:aws:rds-db:us-east-1:ACCT:dbuser/DB-RES-ID/app_user1",
+        "arn:aws:rds-db:us-east-1:ACCT:dbuser/DB-RES-ID/ro_user1",
+        "arn:aws:rds-db:us-east-1:ACCT:dbuser/DB-RES-ID/research_app",
+        "arn:aws:rds-db:us-east-1:ACCT:dbuser/DB-RES-ID/research_ro"
+      ]
+    }
+  ]
+}

--- a/locard/operations/0037-parity-diff.sh
+++ b/locard/operations/0037-parity-diff.sh
@@ -9,7 +9,7 @@
 # from before-snapshots before diffing (the DROP was intentional, not
 # a privilege regression).
 #
-# Implements spec AC #6 (privilege parity across all 4 dimensions / 7 files).
+# Implements spec AC #6 (privilege parity across all dimensions / 8 files).
 #
 # Usage: bash locard/operations/0037-parity-diff.sh [--dashboard-dropped]
 # Exit code: 0 if all pass, 1 if any diff is non-empty.
@@ -29,6 +29,7 @@ FILES=(
   grants_corpus
   grants_pipeline
   grants_dashboard
+  routine_privileges
   default_acl
   ownership_objects
   ownership_schemas

--- a/locard/operations/0037-parity-diff.sh
+++ b/locard/operations/0037-parity-diff.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# 0037-parity-diff.sh — Verify privilege parity across the rename.
+#
+# Reads /tmp/0037_*.before.txt and /tmp/0037_*.after.txt,
+# applies sed substitution (old→new role names) to the before files,
+# then diffs against after files. Zero diff = parity preserved.
+#
+# Implements spec AC #6 (privilege parity across all 4 dimensions / 7 files).
+#
+# Usage: bash locard/operations/0037-parity-diff.sh
+# Exit code: 0 if all pass, 1 if any diff is non-empty.
+
+set -uo pipefail
+
+PREFIX="/tmp/0037"
+FAIL=0
+
+FILES=(
+  grants_corpus
+  grants_pipeline
+  grants_dashboard
+  default_acl
+  ownership_objects
+  ownership_schemas
+  memberships
+)
+
+for f in "${FILES[@]}"; do
+  BEFORE="${PREFIX}_${f}.before.txt"
+  AFTER="${PREFIX}_${f}.after.txt"
+
+  if [[ ! -f "$BEFORE" ]]; then
+    echo "FAIL: $f — missing $BEFORE"
+    FAIL=1
+    continue
+  fi
+  if [[ ! -f "$AFTER" ]]; then
+    echo "FAIL: $f — missing $AFTER"
+    FAIL=1
+    continue
+  fi
+
+  DIFF_OUTPUT=$(sed 's/app_user1/research_app/g; s/ro_user1/research_ro/g' "$BEFORE" \
+    | diff -u - "$AFTER" || true)
+
+  if [[ -n "$DIFF_OUTPUT" ]]; then
+    echo "FAIL: $f"
+    echo "$DIFF_OUTPUT"
+    FAIL=1
+  else
+    echo "PASS: $f"
+  fi
+done
+
+exit "${FAIL}"

--- a/locard/operations/0037-parity-diff.sh
+++ b/locard/operations/0037-parity-diff.sh
@@ -5,12 +5,22 @@
 # applies sed substitution (old→new role names) to the before files,
 # then diffs against after files. Zero diff = parity preserved.
 #
+# If --dashboard-dropped is passed, dashboard_user1 rows are filtered
+# from before-snapshots before diffing (the DROP was intentional, not
+# a privilege regression).
+#
 # Implements spec AC #6 (privilege parity across all 4 dimensions / 7 files).
 #
-# Usage: bash locard/operations/0037-parity-diff.sh
+# Usage: bash locard/operations/0037-parity-diff.sh [--dashboard-dropped]
 # Exit code: 0 if all pass, 1 if any diff is non-empty.
 
 set -uo pipefail
+
+DASHBOARD_DROPPED=0
+if [[ "${1:-}" == "--dashboard-dropped" ]]; then
+  DASHBOARD_DROPPED=1
+  echo "NOTE: --dashboard-dropped flag set; filtering dashboard_user1 from before-snapshots"
+fi
 
 PREFIX="/tmp/0037"
 FAIL=0
@@ -40,7 +50,12 @@ for f in "${FILES[@]}"; do
     continue
   fi
 
-  DIFF_OUTPUT=$(sed 's/app_user1/research_app/g; s/ro_user1/research_ro/g' "$BEFORE" \
+  SED_CMD='s/app_user1/research_app/g; s/ro_user1/research_ro/g'
+  if [[ $DASHBOARD_DROPPED -eq 1 ]]; then
+    SED_CMD="${SED_CMD}; /dashboard_user1/d"
+  fi
+
+  DIFF_OUTPUT=$(sed "$SED_CMD" "$BEFORE" \
     | diff -u - "$AFTER" || true)
 
   if [[ -n "$DIFF_OUTPUT" ]]; then

--- a/locard/operations/0037-pre-rename-checks.sql
+++ b/locard/operations/0037-pre-rename-checks.sql
@@ -1,0 +1,80 @@
+-- 0037-pre-rename-checks.sql
+-- Run as RDS instance master role (postgres / rds_superuser) for full output.
+-- Steps 1, 3, 4a, 4d work with any IAM-tier role.
+-- Steps 2, 4b, 4c require master/rds_superuser (skip if unavailable).
+--
+-- Usage: psql -h $RDS_ENDPOINT -U $MASTER_USER -d $DB -f 0037-pre-rename-checks.sql
+
+-- Step 1: Determine the universe of roles to act on.
+-- Expected: app_user1, ro_user1. dashboard_user1 may or may not appear.
+\echo '=== Step 1: Role universe ==='
+SELECT rolname FROM pg_roles
+WHERE rolname IN ('app_user1', 'ro_user1', 'dashboard_user1')
+ORDER BY rolname;
+
+-- Step 2: (OPTIONAL — requires master/rds_superuser) Password encryption check.
+-- IAM auth does not use stored passwords; this is informational only.
+\echo '=== Step 2: Password encryption (requires master role) ==='
+SELECT rolname,
+       CASE
+         WHEN rolpassword IS NULL THEN '(no stored password — IAM-only)'
+         WHEN rolpassword LIKE 'SCRAM-%' THEN 'SCRAM (rename-safe)'
+         WHEN rolpassword LIKE 'md5%' THEN 'MD5 (rename invalidates password)'
+         ELSE 'unknown'
+       END AS password_status
+FROM pg_authid
+WHERE rolname IN ('app_user1', 'ro_user1', 'dashboard_user1');
+
+-- Step 3: Confirm rds_iam membership.
+\echo '=== Step 3: rds_iam membership ==='
+SELECT r.rolname, m.rolname AS member_of
+FROM pg_roles r
+JOIN pg_auth_members am ON r.oid = am.member
+JOIN pg_roles m ON am.roleid = m.oid
+WHERE r.rolname IN ('app_user1', 'ro_user1', 'dashboard_user1')
+  AND m.rolname = 'rds_iam'
+ORDER BY r.rolname;
+
+-- Step 4a: Object-privilege snapshot (GRANT statements).
+\echo '=== Step 4a: Object privileges — lava_corpus ==='
+\dp lava_corpus.*
+\echo '=== Step 4a: Object privileges — lava_pipeline ==='
+\dp lava_pipeline.*
+\echo '=== Step 4a: Object privileges — lava_dashboard ==='
+\dp lava_dashboard.*
+
+-- Step 4b: Default-ACL snapshot (ALTER DEFAULT PRIVILEGES).
+\echo '=== Step 4b: Default ACLs ==='
+SELECT n.nspname, r.rolname AS grantor, d.defaclobjtype, d.defaclacl
+FROM pg_default_acl d
+LEFT JOIN pg_namespace n ON d.defaclnamespace = n.oid
+JOIN pg_roles r ON d.defaclrole = r.oid
+WHERE n.nspname IN ('lava_corpus', 'lava_pipeline', 'lava_dashboard')
+   OR n.nspname IS NULL
+ORDER BY n.nspname, defaclobjtype;
+
+-- Step 4c: Ownership snapshot — objects.
+\echo '=== Step 4c: Ownership — objects ==='
+SELECT n.nspname, c.relname, c.relkind, r.rolname AS owner
+FROM pg_class c
+JOIN pg_namespace n ON c.relnamespace = n.oid
+JOIN pg_roles r ON c.relowner = r.oid
+WHERE n.nspname IN ('lava_corpus', 'lava_pipeline', 'lava_dashboard')
+ORDER BY n.nspname, c.relname;
+
+-- Step 4c: Ownership snapshot — schemas.
+\echo '=== Step 4c: Ownership — schemas ==='
+SELECT n.nspname, r.rolname AS owner
+FROM pg_namespace n
+JOIN pg_roles r ON n.nspowner = r.oid
+WHERE n.nspname IN ('lava_corpus', 'lava_pipeline', 'lava_dashboard')
+ORDER BY n.nspname;
+
+-- Step 4d: Membership snapshot.
+\echo '=== Step 4d: Memberships ==='
+SELECT r.rolname, m.rolname AS member_of
+FROM pg_roles r
+JOIN pg_auth_members am ON r.oid = am.member
+JOIN pg_roles m ON am.roleid = m.oid
+WHERE r.rolname IN ('app_user1', 'ro_user1', 'dashboard_user1')
+ORDER BY r.rolname, m.rolname;

--- a/locard/operations/0037-pre-rename-checks.sql
+++ b/locard/operations/0037-pre-rename-checks.sql
@@ -78,3 +78,29 @@ JOIN pg_auth_members am ON r.oid = am.member
 JOIN pg_roles m ON am.roleid = m.oid
 WHERE r.rolname IN ('app_user1', 'ro_user1', 'dashboard_user1')
 ORDER BY r.rolname, m.rolname;
+
+-- Step 4e: dashboard_user1 drop-guard pre-validation.
+-- These three queries mirror the checks in 0037-cutover-dashboard-user-drop.sql.
+-- If dashboard_user1 exists, these must ALL return 0 rows for the DROP branch
+-- to be safe. Any non-zero result means the HALT branch applies.
+-- Run BEFORE the maintenance window so HALT surfaces early, not mid-cutover.
+
+\echo '=== Step 4e: dashboard_user1 — function (EXECUTE) privileges ==='
+SELECT routine_schema, routine_name, grantee, privilege_type
+FROM information_schema.routine_privileges
+WHERE grantee = 'dashboard_user1'
+ORDER BY routine_schema, routine_name;
+
+\echo '=== Step 4e: dashboard_user1 — USAGE privileges ==='
+SELECT object_schema, object_name, object_type, grantee, privilege_type
+FROM information_schema.usage_privileges
+WHERE grantee = 'dashboard_user1'
+ORDER BY object_schema, object_name;
+
+\echo '=== Step 4e: dashboard_user1 — owned objects ==='
+SELECT n.nspname, c.relname, c.relkind
+FROM pg_class c
+JOIN pg_namespace n ON c.relnamespace = n.oid
+JOIN pg_roles r ON c.relowner = r.oid
+WHERE r.rolname = 'dashboard_user1'
+ORDER BY n.nspname, c.relname;

--- a/locard/operations/0037-pre-rename-checks.sql
+++ b/locard/operations/0037-pre-rename-checks.sql
@@ -80,7 +80,7 @@ WHERE r.rolname IN ('app_user1', 'ro_user1', 'dashboard_user1')
 ORDER BY r.rolname, m.rolname;
 
 -- Step 4e: dashboard_user1 drop-guard pre-validation.
--- These three queries mirror the checks in 0037-cutover-dashboard-user-drop.sql.
+-- These four queries mirror the checks in 0037-cutover-dashboard-user-drop.sql.
 -- If dashboard_user1 exists, these must ALL return 0 rows for the DROP branch
 -- to be safe. Any non-zero result means the HALT branch applies.
 -- Run BEFORE the maintenance window so HALT surfaces early, not mid-cutover.
@@ -91,11 +91,20 @@ FROM information_schema.routine_privileges
 WHERE grantee = 'dashboard_user1'
 ORDER BY routine_schema, routine_name;
 
-\echo '=== Step 4e: dashboard_user1 — USAGE privileges ==='
+\echo '=== Step 4e: dashboard_user1 — USAGE privileges (sequences, etc.) ==='
 SELECT object_schema, object_name, object_type, grantee, privilege_type
 FROM information_schema.usage_privileges
 WHERE grantee = 'dashboard_user1'
 ORDER BY object_schema, object_name;
+
+\echo '=== Step 4e: dashboard_user1 — schema-level privileges (USAGE/CREATE) ==='
+-- information_schema.usage_privileges does NOT cover schema USAGE/CREATE.
+-- Query pg_namespace.nspacl directly for any ACL entry naming dashboard_user1.
+SELECT n.nspname, a.acl_entry
+FROM pg_namespace n,
+     LATERAL unnest(n.nspacl) AS a(acl_entry)
+WHERE a.acl_entry::text LIKE 'dashboard_user1=%'
+ORDER BY n.nspname;
 
 \echo '=== Step 4e: dashboard_user1 — owned objects ==='
 SELECT n.nspname, c.relname, c.relkind

--- a/locard/operations/0037-role-rename-runbook.md
+++ b/locard/operations/0037-role-rename-runbook.md
@@ -106,9 +106,14 @@ SELECT rolname FROM pg_roles
 WHERE rolname IN ('app_user1', 'ro_user1', 'research_app', 'research_ro');
 ```
 
-- **Expected**: `app_user1`, `ro_user1` only.
-- If `research_app` present → jump to T+2 (rename already done).
-- If BOTH pairs present → **HALT** — mixed state requires manual investigation.
+Interpret the result:
+
+| Query returns | Meaning | Action |
+|---|---|---|
+| Only `app_user1`, `ro_user1` | Normal pre-rename state | Proceed to T+0 actions below |
+| Only `research_app`, `research_ro` | Rename already complete | Jump to T+2 (SSM update) |
+| All four roles present | Mixed state — collision | **HALT.** Investigate per spec §Rollback Decision Tree |
+| Any other mix (e.g., `research_app` + `ro_user1`) | Partial rename from a prior aborted run | Run T+1 anyway — the cutover SQL is idempotent and will complete the missing rename. Verify with the post-T+1 SELECT |
 
 ### Action
 

--- a/locard/operations/0037-role-rename-runbook.md
+++ b/locard/operations/0037-role-rename-runbook.md
@@ -4,7 +4,10 @@
 
 **Estimated outage**: 3–10 minutes (T+0 through T+5). Total elapsed including IAM warm-up and cleanup: hours, but only the cutover window is service-impacting.
 
-**Prerequisites**: Operator has master/`rds_superuser` access to the RDS instance and `aws` CLI configured with permissions to edit IAM policies and SSM parameters.
+**Prerequisites**:
+- Operator has master/`rds_superuser` access to the RDS instance and `aws` CLI configured with permissions to edit IAM policies and SSM parameters.
+- No other applications/repos connect to this shared RDS using the role names `app_user1`/`ro_user1` directly (all consumers go through SSM).
+- **Scheduled tasks**: Run `crontab -l` and `systemctl list-timers --all`. Confirm the cutover window does not overlap any scheduled job (e.g., `load_990_index` at 03:00 UTC). Disable affected cron entries or systemd timers for the duration of the cutover window. Re-enable after T+5 confirms success.
 
 ---
 

--- a/locard/operations/0037-role-rename-runbook.md
+++ b/locard/operations/0037-role-rename-runbook.md
@@ -297,7 +297,11 @@ During this time, run the post-rename snapshots and parity diff:
 
 ```bash
 bash locard/operations/0037-snapshot-post.sh
-bash locard/operations/0037-parity-diff.sh
+
+# If dashboard_user1 was DROPPED at T+1, use --dashboard-dropped to filter
+# its rows from the before-snapshot (intentional deletion, not a regression):
+bash locard/operations/0037-parity-diff.sh              # normal case
+bash locard/operations/0037-parity-diff.sh --dashboard-dropped  # if dashboard_user1 was dropped
 # Expected: PASS on all 7 dimensions
 ```
 

--- a/locard/operations/0037-role-rename-runbook.md
+++ b/locard/operations/0037-role-rename-runbook.md
@@ -46,8 +46,8 @@ Examine the Step 1 output from `0037-pre-rename-checks.sql`:
 | Step 1 returns | Action |
 |---|---|
 | Only `app_user1`, `ro_user1` | **Skip dashboard_user1 entirely.** Do not create, drop, or rename. This is the expected case. |
-| Includes `dashboard_user1` BUT it has zero GRANTs (Step 4a) and zero memberships beyond `rds_iam` (Step 3) | **Drop:** Run `psql -f locard/operations/0037-cutover-dashboard-user-drop.sql` at T+1 (after the rename). |
-| Includes `dashboard_user1` AND it has GRANTs OR non-`rds_iam` memberships | **HALT.** Do NOT proceed with the cutover. Record the finding and write a follow-up spec. |
+| Includes `dashboard_user1` BUT it has zero table GRANTs (Step 4a), zero function GRANTs (Step 4e), zero USAGE GRANTs (Step 4e), zero owned objects (Step 4e), and zero memberships beyond `rds_iam` (Step 3) | **Drop:** Run `psql -f locard/operations/0037-cutover-dashboard-user-drop.sql` at T+1 (after the rename). |
+| Includes `dashboard_user1` AND any of: table GRANTs (Step 4a), function GRANTs (Step 4e), USAGE GRANTs (Step 4e), owned objects (Step 4e), or non-`rds_iam` memberships (Step 3) | **HALT.** Do NOT proceed with the cutover. Record the finding and write a follow-up spec. |
 
 **Record which branch was taken:** ____________
 

--- a/locard/operations/0037-role-rename-runbook.md
+++ b/locard/operations/0037-role-rename-runbook.md
@@ -118,8 +118,9 @@ Interpret the result:
 ### Action
 
 ```bash
-# Stop the dashboard
+# Stop the dashboard and orchestrator
 systemctl stop lavandula-dashboard
+systemctl stop lavandula-orchestrator
 
 # Stop any running CLI processes (crawler, classifier, etc.)
 ps -ef | grep python3
@@ -223,13 +224,20 @@ fi
 ```
 
 ### Failure handling
-If `put-parameter` fails: retry up to 3 times. If still failing, revert via:
+If `put-parameter` fails: retry up to 3 times. If still failing, restore **both** SSM values to old names first (even if one already succeeded — idempotent), then revert the DB rename:
 ```bash
+# 1. Restore SSM to old values (prevents split-brain if one update succeeded)
+aws ssm put-parameter --name /cloud2.lavandulagroup.com/rds-app-user \
+    --type SecureString --value app_user1 --overwrite
+aws ssm put-parameter --name /cloud2.lavandulagroup.com/rds-ro-user \
+    --type SecureString --value ro_user1 --overwrite
+
+# 2. Revert DB rename
 PGPASSWORD="$MASTER_PW" psql -h "$RDS_ENDPOINT" -U "$MASTER_USER" -d "$DB" \
   --set=sslmode=require -v ON_ERROR_STOP=1 \
   -f locard/operations/0037-cutover-rollback.sql
 ```
-This reverts to old names so the system is consistent (old name everywhere).
+This ensures SSM and DB are consistent (old name everywhere) before restarting services.
 
 ---
 
@@ -265,11 +273,12 @@ PGPASSWORD="$TOK" psql -h "$RDS_ENDPOINT" -U research_ro -d "$DB" \
 **If `role does not exist`**: Rename didn't apply — go back to T+1.
 **If `permission denied for ...`**: Grants didn't follow OID — investigate. If unresolvable after 10 minutes, run full rollback.
 
-### Restart dashboard
+### Restart services
 
 ```bash
 systemctl start lavandula-dashboard
-journalctl -u lavandula-dashboard -f
+systemctl start lavandula-orchestrator
+journalctl -u lavandula-dashboard -u lavandula-orchestrator -f
 # Watch for 60 seconds. If auth error: likely IAM propagation lag — wait 5 min, retry start.
 ```
 

--- a/locard/operations/0037-role-rename-runbook.md
+++ b/locard/operations/0037-role-rename-runbook.md
@@ -1,0 +1,387 @@
+# Runbook: Spec 0037 — Rename RDS Roles
+
+**Purpose**: Rename `app_user1` → `research_app` and `ro_user1` → `research_ro` on the shared RDS instance.
+
+**Estimated outage**: 3–10 minutes (T+0 through T+5). Total elapsed including IAM warm-up and cleanup: hours, but only the cutover window is service-impacting.
+
+**Prerequisites**: Operator has master/`rds_superuser` access to the RDS instance and `aws` CLI configured with permissions to edit IAM policies and SSM parameters.
+
+---
+
+## Environment Variables
+
+Set these before starting. All scripts in `locard/operations/0037-*` read from these.
+
+```bash
+export RDS_ENDPOINT="<your-rds-endpoint>"
+export DB="<your-database-name>"
+export MASTER_USER="postgres"
+export MASTER_PW="<master-password-from-ssm>"
+export REGION="us-east-1"
+# Fill in your AWS account ID and DB resource ID for IAM policy edits:
+export ACCT="<aws-account-id>"
+export DB_RES_ID="<rds-db-resource-id>"
+```
+
+---
+
+## Pre-Rename Checks
+
+Run **before scheduling the maintenance window**. These checks are non-destructive.
+
+### Step P1: Run pre-rename checks
+
+```bash
+PGPASSWORD="$MASTER_PW" psql -h "$RDS_ENDPOINT" -U "$MASTER_USER" -d "$DB" \
+  --set=sslmode=require -f locard/operations/0037-pre-rename-checks.sql
+```
+
+### Step P2: `dashboard_user1` decision
+
+Examine the Step 1 output from `0037-pre-rename-checks.sql`:
+
+| Step 1 returns | Action |
+|---|---|
+| Only `app_user1`, `ro_user1` | **Skip dashboard_user1 entirely.** Do not create, drop, or rename. This is the expected case. |
+| Includes `dashboard_user1` BUT it has zero GRANTs (Step 4a) and zero memberships beyond `rds_iam` (Step 3) | **Drop:** Run `psql -f locard/operations/0037-cutover-dashboard-user-drop.sql` at T+1 (after the rename). |
+| Includes `dashboard_user1` AND it has GRANTs OR non-`rds_iam` memberships | **HALT.** Do NOT proceed with the cutover. Record the finding and write a follow-up spec. |
+
+**Record which branch was taken:** ____________
+
+### Step P3: Capture pre-rename snapshots
+
+```bash
+bash locard/operations/0037-snapshot-pre.sh
+```
+
+Verify all 7 files are produced:
+```bash
+ls -la /tmp/0037_*.before.txt
+# Expected: 7 files (grants_corpus, grants_pipeline, grants_dashboard,
+#   default_acl, ownership_objects, ownership_schemas, memberships)
+```
+
+---
+
+## T-1: IAM Additive Overlap (BEFORE the outage window)
+
+**Goal**: Allow both old and new role ARNs in the IAM policy so there is no IAM propagation race during cutover.
+
+### Action
+
+1. Edit the EC2 instance-profile policy (`cloud2_lavandulagroup`) to use the contents of `locard/operations/0037-iam-policy-overlay.json`. Replace `ACCT` with your AWS account ID and `DB-RES-ID` with the RDS database resource ID.
+
+2. Wait **≥5 minutes** for IAM propagation.
+
+3. Verify IAM allows the new ARN (the role doesn't exist yet, so we expect a specific Postgres error, NOT an IAM error):
+
+```bash
+TOK=$(aws rds generate-db-auth-token --hostname "$RDS_ENDPOINT" \
+      --port 5432 --username research_app --region us-east-1)
+PGPASSWORD="$TOK" psql -h "$RDS_ENDPOINT" -U research_app -d "$DB" \
+  --set=sslmode=require -c "SELECT 1" 2>&1 | tee /tmp/iam_warmup.log
+```
+
+**Expected output**: `FATAL: role "research_app" does not exist`
+- This proves IAM is allowing the `rds-db:connect` call through.
+
+**If output contains** `PAM authentication failed` or `permission denied to use this connection method`:
+- IAM has NOT propagated yet. Wait another 2 minutes and retry.
+- Do **NOT** proceed to T+0 until this check passes.
+
+### Failure handling
+This step is reversible at any time by removing the new ARNs from the IAM policy. No service impact — old ARNs still work.
+
+---
+
+## T+0: Stop Services and Drain Connections
+
+**Precondition**: Confirm rename has not already happened.
+
+```sql
+SELECT rolname FROM pg_roles
+WHERE rolname IN ('app_user1', 'ro_user1', 'research_app', 'research_ro');
+```
+
+- **Expected**: `app_user1`, `ro_user1` only.
+- If `research_app` present → jump to T+2 (rename already done).
+- If BOTH pairs present → **HALT** — mixed state requires manual investigation.
+
+### Action
+
+```bash
+# Stop the dashboard
+systemctl stop lavandula-dashboard
+
+# Stop any running CLI processes (crawler, classifier, etc.)
+ps -ef | grep python3
+af status
+# Kill any lavandula processes still running
+
+# Wait 30 seconds for connections to drain
+sleep 30
+
+# Forcibly terminate remaining sessions
+PGPASSWORD="$MASTER_PW" psql -h "$RDS_ENDPOINT" -U "$MASTER_USER" -d "$DB" \
+  --set=sslmode=require -c "
+SELECT pg_terminate_backend(pid)
+FROM pg_stat_activity
+WHERE usename IN ('app_user1', 'ro_user1')
+  AND pid <> pg_backend_pid();"
+
+# Confirm clean
+PGPASSWORD="$MASTER_PW" psql -h "$RDS_ENDPOINT" -U "$MASTER_USER" -d "$DB" \
+  --set=sslmode=require -c "
+SELECT pid, usename, state, query
+FROM pg_stat_activity
+WHERE usename IN ('app_user1', 'ro_user1');"
+# Expected: 0 rows
+```
+
+### Failure handling
+If services cannot stop or sessions won't terminate: diagnose the stuck process. Do NOT proceed to T+1 with active old-name connections. The rename works, but cached usernames cause silent issues post-restart. If unresolvable, abort cutover and reschedule.
+
+---
+
+## T+1: Execute Rename
+
+**Precondition**: `app_user1` and `ro_user1` still exist (confirmed at T+0). No active sessions using those roles.
+
+### Action
+
+```bash
+PGPASSWORD="$MASTER_PW" psql -h "$RDS_ENDPOINT" -U "$MASTER_USER" -d "$DB" \
+  --set=sslmode=require -v ON_ERROR_STOP=1 \
+  -f locard/operations/0037-cutover-rename.sql
+```
+
+**Expected output**:
+```
+NOTICE:  Renamed app_user1 → research_app
+NOTICE:  Renamed ro_user1 → research_ro
+ rolname
+--------------
+ research_app
+ research_ro
+(2 rows)
+```
+
+If pre-check Step P2 determined `dashboard_user1` should be DROPPED, also run:
+```bash
+PGPASSWORD="$MASTER_PW" psql -h "$RDS_ENDPOINT" -U "$MASTER_USER" -d "$DB" \
+  --set=sslmode=require -v ON_ERROR_STOP=1 \
+  -f locard/operations/0037-cutover-dashboard-user-drop.sql
+```
+
+### Failure handling
+
+| Error | Action |
+|---|---|
+| `role "app_user1" does not exist` | Rename already happened (idempotent). Check `pg_roles` for `research_app` — if present, proceed to T+2. |
+| `role is being used by other sessions` | Drain again (repeat T+0 termination), retry. |
+| `permission denied` | Abort. Escalate. No rollback needed (nothing was renamed). |
+| Transaction commit fails | Re-check `pg_roles`. PG renames are atomic within the transaction. If partial: manually converge with `ALTER ROLE`. |
+
+---
+
+## T+2: Update SSM Parameters
+
+**Precondition**: Read current SSM values. If already `research_*`, skip.
+
+```bash
+OLD_APP=$(aws ssm get-parameter --name /cloud2.lavandulagroup.com/rds-app-user \
+  --with-decryption --query Parameter.Value --output text)
+echo "Current rds-app-user: $OLD_APP"
+
+if [[ "$OLD_APP" != "research_app" ]]; then
+  aws ssm put-parameter --name /cloud2.lavandulagroup.com/rds-app-user \
+    --type SecureString --value research_app --overwrite
+  echo "Updated rds-app-user → research_app"
+else
+  echo "rds-app-user already set to research_app — no-op"
+fi
+
+OLD_RO=$(aws ssm get-parameter --name /cloud2.lavandulagroup.com/rds-ro-user \
+  --with-decryption --query Parameter.Value --output text)
+echo "Current rds-ro-user: $OLD_RO"
+
+if [[ "$OLD_RO" != "research_ro" ]]; then
+  aws ssm put-parameter --name /cloud2.lavandulagroup.com/rds-ro-user \
+    --type SecureString --value research_ro --overwrite
+  echo "Updated rds-ro-user → research_ro"
+else
+  echo "rds-ro-user already set to research_ro — no-op"
+fi
+```
+
+### Failure handling
+If `put-parameter` fails: retry up to 3 times. If still failing, revert via:
+```bash
+PGPASSWORD="$MASTER_PW" psql -h "$RDS_ENDPOINT" -U "$MASTER_USER" -d "$DB" \
+  --set=sslmode=require -v ON_ERROR_STOP=1 \
+  -f locard/operations/0037-cutover-rollback.sql
+```
+This reverts to old names so the system is consistent (old name everywhere).
+
+---
+
+## T+3: No Action
+
+Additive IAM overlap was applied at T-1. Old ARNs remain; they will be removed at T+6.
+
+---
+
+## T+4: Verify IAM Connect + Restart Dashboard
+
+**Precondition**: Actual IAM-authenticated psql connect as the new roles MUST succeed before starting the dashboard.
+
+### Verify both roles
+
+```bash
+# research_app
+TOK=$(aws rds generate-db-auth-token --hostname "$RDS_ENDPOINT" \
+      --port 5432 --username research_app --region us-east-1)
+PGPASSWORD="$TOK" psql -h "$RDS_ENDPOINT" -U research_app -d "$DB" \
+  --set=sslmode=require -c "SELECT current_user, 1 AS ok"
+# Expected: current_user = research_app, ok = 1
+
+# research_ro
+TOK=$(aws rds generate-db-auth-token --hostname "$RDS_ENDPOINT" \
+      --port 5432 --username research_ro --region us-east-1)
+PGPASSWORD="$TOK" psql -h "$RDS_ENDPOINT" -U research_ro -d "$DB" \
+  --set=sslmode=require -c "SELECT current_user, 1 AS ok"
+# Expected: current_user = research_ro, ok = 1
+```
+
+**If `PAM authentication failed`**: IAM propagation lag (despite T-1 warm-up). Wait 5 minutes, retry.
+**If `role does not exist`**: Rename didn't apply — go back to T+1.
+**If `permission denied for ...`**: Grants didn't follow OID — investigate. If unresolvable after 10 minutes, run full rollback.
+
+### Restart dashboard
+
+```bash
+systemctl start lavandula-dashboard
+journalctl -u lavandula-dashboard -f
+# Watch for 60 seconds. If auth error: likely IAM propagation lag — wait 5 min, retry start.
+```
+
+Hit a health endpoint to confirm DB connectivity.
+
+---
+
+## T+5: Smoke Tests
+
+```bash
+bash locard/operations/0037-smoke-test.sh
+```
+
+Additionally verify via browser:
+- Dashboard home page loads
+- Org list (`/orgs/`) loads
+- One write operation (create a noop Job, then cancel it)
+
+### Failure handling
+
+| Symptom | Likely cause | Action |
+|---|---|---|
+| Read query fails | IAM/grant issue | Compare pre/post snapshots (AC #6). If snapshots match: IAM propagation — wait 5 min, retry. If not: full rollback. |
+| Write query fails but read succeeds | Targeted GRANT regression | Investigate `\dp` on the affected table. Run full rollback if unresolvable. |
+
+---
+
+## Wait Period
+
+Wait **≥30 minutes** of stable operation before proceeding to T+6.
+
+During this time, run the post-rename snapshots and parity diff:
+
+```bash
+bash locard/operations/0037-snapshot-post.sh
+bash locard/operations/0037-parity-diff.sh
+# Expected: PASS on all 7 dimensions
+```
+
+If ANY dimension shows FAIL, investigate before removing old ARNs. A FAIL means privilege regression — potential grounds for full rollback.
+
+---
+
+## T+6: Remove Old IAM ARNs (Post-Cutover Cleanup)
+
+**Only after ≥30 minutes of stable operation and parity-diff PASSing all 7 dimensions.**
+
+### Action
+
+Replace the EC2 instance-profile policy with the contents of `locard/operations/0037-iam-policy-final.json`. Replace `ACCT` and `DB-RES-ID` with your values.
+
+### Verify
+
+```bash
+# Token generation is local and never fails — we need to test actual connect.
+TOK=$(aws rds generate-db-auth-token --hostname "$RDS_ENDPOINT" \
+      --port 5432 --username app_user1 --region us-east-1)
+PGPASSWORD="$TOK" psql -h "$RDS_ENDPOINT" -U app_user1 -d "$DB" \
+  --set=sslmode=require -c "SELECT 1" 2>&1 | tee /tmp/iam_cleanup_verify.log
+# Expected: "PAM authentication failed for user \"app_user1\""
+# This proves IAM no longer allows the old ARN.
+```
+
+---
+
+## Full Rollback Procedure
+
+Use if the rollback decision tree directs full rollback at any step.
+
+```bash
+# 1. Stop services
+systemctl stop lavandula-dashboard
+
+# 2. Drain leftover sessions
+PGPASSWORD="$MASTER_PW" psql -h "$RDS_ENDPOINT" -U "$MASTER_USER" -d "$DB" \
+  --set=sslmode=require -c "
+SELECT pg_terminate_backend(pid)
+FROM pg_stat_activity
+WHERE usename IN ('research_app', 'research_ro')
+  AND pid <> pg_backend_pid();"
+
+# 3. Reverse rename
+PGPASSWORD="$MASTER_PW" psql -h "$RDS_ENDPOINT" -U "$MASTER_USER" -d "$DB" \
+  --set=sslmode=require -v ON_ERROR_STOP=1 \
+  -f locard/operations/0037-cutover-rollback.sql
+
+# 4. Restore SSM values
+aws ssm put-parameter --name /cloud2.lavandulagroup.com/rds-app-user \
+    --type SecureString --value app_user1 --overwrite
+aws ssm put-parameter --name /cloud2.lavandulagroup.com/rds-ro-user \
+    --type SecureString --value ro_user1 --overwrite
+
+# 5. Restart (IAM policy stays in overlap — old ARNs still allowed)
+systemctl start lavandula-dashboard
+```
+
+**Total rollback time**: ~3 minutes from decision-to-rollback to dashboard-back-up.
+
+### Source-tree handling during rollback
+
+- **Short rollback (<4 hours, retry scheduled)**: Leave source-tree edits in place. Runtime reads from SSM; source-tree leading production is harmless during a brief window.
+- **Extended rollback (overnight or longer, no retry)**: `git revert` the source-tree PR. Prevents fresh-environment builds from diverging.
+
+---
+
+## Execution Log
+
+Record timestamps and decisions as you execute:
+
+| Step | Time | Result | Notes |
+|------|------|--------|-------|
+| P1 Pre-checks | | | |
+| P2 dashboard_user1 decision | | Branch taken: | |
+| P3 Snapshots | | 7 files: Y/N | |
+| T-1 IAM overlay | | Propagation confirmed: Y/N | |
+| T+0 Stop services | | Sessions drained: Y/N | |
+| T+1 Rename | | research_app + research_ro: Y/N | |
+| T+2 SSM update | | Both params updated: Y/N | |
+| T+4 IAM connect verify | | Both roles connect: Y/N | |
+| T+4 Dashboard restart | | Health OK: Y/N | |
+| T+5 Smoke tests | | All pass: Y/N | |
+| Parity diff | | All 7 PASS: Y/N | |
+| T+6 Remove old ARNs | | Old ARN denied: Y/N | |

--- a/locard/operations/0037-role-rename-runbook.md
+++ b/locard/operations/0037-role-rename-runbook.md
@@ -355,6 +355,7 @@ Use if the rollback decision tree directs full rollback at any step.
 ```bash
 # 1. Stop services
 systemctl stop lavandula-dashboard
+systemctl stop lavandula-orchestrator
 
 # 2. Drain leftover sessions
 PGPASSWORD="$MASTER_PW" psql -h "$RDS_ENDPOINT" -U "$MASTER_USER" -d "$DB" \
@@ -377,6 +378,7 @@ aws ssm put-parameter --name /cloud2.lavandulagroup.com/rds-ro-user \
 
 # 5. Restart (IAM policy stays in overlap — old ARNs still allowed)
 systemctl start lavandula-dashboard
+systemctl start lavandula-orchestrator
 ```
 
 **Total rollback time**: ~3 minutes from decision-to-rollback to dashboard-back-up.

--- a/locard/operations/0037-role-rename-runbook.md
+++ b/locard/operations/0037-role-rename-runbook.md
@@ -57,11 +57,11 @@ Examine the Step 1 output from `0037-pre-rename-checks.sql`:
 bash locard/operations/0037-snapshot-pre.sh
 ```
 
-Verify all 7 files are produced:
+Verify all 8 files are produced:
 ```bash
 ls -la /tmp/0037_*.before.txt
-# Expected: 7 files (grants_corpus, grants_pipeline, grants_dashboard,
-#   default_acl, ownership_objects, ownership_schemas, memberships)
+# Expected: 8 files (grants_corpus, grants_pipeline, grants_dashboard,
+#   routine_privileges, default_acl, ownership_objects, ownership_schemas, memberships)
 ```
 
 ---
@@ -305,7 +305,7 @@ bash locard/operations/0037-snapshot-post.sh
 # its rows from the before-snapshot (intentional deletion, not a regression):
 bash locard/operations/0037-parity-diff.sh              # normal case
 bash locard/operations/0037-parity-diff.sh --dashboard-dropped  # if dashboard_user1 was dropped
-# Expected: PASS on all 7 dimensions
+# Expected: PASS on all 8 dimensions
 ```
 
 If ANY dimension shows FAIL, investigate before removing old ARNs. A FAIL means privilege regression — potential grounds for full rollback.
@@ -314,7 +314,7 @@ If ANY dimension shows FAIL, investigate before removing old ARNs. A FAIL means 
 
 ## T+6: Remove Old IAM ARNs (Post-Cutover Cleanup)
 
-**Only after ≥30 minutes of stable operation and parity-diff PASSing all 7 dimensions.**
+**Only after ≥30 minutes of stable operation and parity-diff PASSing all 8 dimensions.**
 
 ### Action
 
@@ -382,7 +382,7 @@ Record timestamps and decisions as you execute:
 |------|------|--------|-------|
 | P1 Pre-checks | | | |
 | P2 dashboard_user1 decision | | Branch taken: | |
-| P3 Snapshots | | 7 files: Y/N | |
+| P3 Snapshots | | 8 files: Y/N | |
 | T-1 IAM overlay | | Propagation confirmed: Y/N | |
 | T+0 Stop services | | Sessions drained: Y/N | |
 | T+1 Rename | | research_app + research_ro: Y/N | |
@@ -390,5 +390,5 @@ Record timestamps and decisions as you execute:
 | T+4 IAM connect verify | | Both roles connect: Y/N | |
 | T+4 Dashboard restart | | Health OK: Y/N | |
 | T+5 Smoke tests | | All pass: Y/N | |
-| Parity diff | | All 7 PASS: Y/N | |
+| Parity diff | | All 8 PASS: Y/N | |
 | T+6 Remove old ARNs | | Old ARN denied: Y/N | |

--- a/locard/operations/0037-smoke-test.sh
+++ b/locard/operations/0037-smoke-test.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# 0037-smoke-test.sh — Post-cutover smoke tests for renamed roles.
+#
+# Tests IAM-authenticated psql connect, SELECT permission, and INSERT
+# permission (with ROLLBACK) for both research_app and research_ro.
+#
+# Required env vars: RDS_ENDPOINT, DB
+# Exit code: 0 if all pass, 1 on first failure.
+#
+# Usage:
+#   export RDS_ENDPOINT=... DB=...
+#   bash locard/operations/0037-smoke-test.sh
+
+set -euo pipefail
+
+: "${RDS_ENDPOINT:?Set RDS_ENDPOINT}" "${DB:?Set DB}"
+
+REGION="us-east-1"
+FAIL=0
+
+check() {
+  local desc="$1"
+  shift
+  if "$@"; then
+    echo "PASS: $desc"
+  else
+    echo "FAIL: $desc"
+    FAIL=1
+    return 1
+  fi
+}
+
+psql_as() {
+  local role="$1"
+  shift
+  local tok
+  tok=$(aws rds generate-db-auth-token \
+    --hostname "$RDS_ENDPOINT" --port 5432 \
+    --username "$role" --region "$REGION")
+  PGPASSWORD="$tok" psql -h "$RDS_ENDPOINT" -U "$role" -d "$DB" \
+    --set=sslmode=require -v ON_ERROR_STOP=1 "$@"
+}
+
+# --- research_ro checks ---
+echo "=== research_ro ==="
+
+check "research_ro: identity" \
+  psql_as research_ro -Atc "SELECT current_user" \
+  | grep -q "research_ro"
+
+check "research_ro: SELECT on lava_corpus.corpus" \
+  psql_as research_ro -Atc "SELECT count(*) FROM lava_corpus.corpus LIMIT 1"
+
+# --- research_app checks ---
+echo ""
+echo "=== research_app ==="
+
+check "research_app: identity" \
+  psql_as research_app -Atc "SELECT current_user" \
+  | grep -q "research_app"
+
+check "research_app: SELECT on lava_corpus.corpus" \
+  psql_as research_app -Atc "SELECT count(*) FROM lava_corpus.corpus LIMIT 1"
+
+# Write check: INSERT into lava_pipeline.org_provenance then ROLLBACK.
+echo "--- research_app: write check (INSERT + ROLLBACK) ---"
+psql_as research_app <<'EOSQL'
+BEGIN;
+INSERT INTO lava_pipeline.org_provenance (ein, seed_status, updated_at)
+  VALUES ('ZZ-SMOKETEST-37', 'completed', NOW())
+  ON CONFLICT (ein) DO NOTHING;
+ROLLBACK;
+EOSQL
+check "research_app: INSERT permission verified (rolled back)" test $? -eq 0
+
+# Verify the smoke row did NOT persist
+ROW_COUNT=$(psql_as research_app -Atc \
+  "SELECT count(*) FROM lava_pipeline.org_provenance WHERE ein = 'ZZ-SMOKETEST-37'")
+check "research_app: smoke row absent after ROLLBACK (count=$ROW_COUNT)" \
+  test "$ROW_COUNT" -eq 0
+
+echo ""
+if [[ $FAIL -eq 0 ]]; then
+  echo "All smoke tests passed."
+else
+  echo "SOME SMOKE TESTS FAILED — see above."
+fi
+exit $FAIL

--- a/locard/operations/0037-smoke-test.sh
+++ b/locard/operations/0037-smoke-test.sh
@@ -44,9 +44,9 @@ psql_as() {
 # --- research_ro checks ---
 echo "=== research_ro ==="
 
-check "research_ro: identity" \
-  psql_as research_ro -Atc "SELECT current_user" \
-  | grep -q "research_ro"
+RO_IDENTITY=$(psql_as research_ro -Atc "SELECT current_user")
+check "research_ro: identity (current_user=$RO_IDENTITY)" \
+  test "$RO_IDENTITY" = "research_ro"
 
 check "research_ro: SELECT on lava_corpus.corpus" \
   psql_as research_ro -Atc "SELECT count(*) FROM lava_corpus.corpus LIMIT 1"
@@ -55,9 +55,9 @@ check "research_ro: SELECT on lava_corpus.corpus" \
 echo ""
 echo "=== research_app ==="
 
-check "research_app: identity" \
-  psql_as research_app -Atc "SELECT current_user" \
-  | grep -q "research_app"
+APP_IDENTITY=$(psql_as research_app -Atc "SELECT current_user")
+check "research_app: identity (current_user=$APP_IDENTITY)" \
+  test "$APP_IDENTITY" = "research_app"
 
 check "research_app: SELECT on lava_corpus.corpus" \
   psql_as research_app -Atc "SELECT count(*) FROM lava_corpus.corpus LIMIT 1"

--- a/locard/operations/0037-smoke-test.sh
+++ b/locard/operations/0037-smoke-test.sh
@@ -62,6 +62,11 @@ check "research_app: identity" \
 check "research_app: SELECT on lava_corpus.corpus" \
   psql_as research_app -Atc "SELECT count(*) FROM lava_corpus.corpus LIMIT 1"
 
+# Function EXECUTE check: attribution_rank must be callable
+RANK_RESULT=$(psql_as research_app -Atc "SELECT lava_corpus.attribution_rank('own_domain')")
+check "research_app: EXECUTE on attribution_rank (result=$RANK_RESULT)" \
+  test "$RANK_RESULT" -ge 0
+
 # Write check: INSERT into lava_pipeline.org_provenance then ROLLBACK.
 echo "--- research_app: write check (INSERT + ROLLBACK) ---"
 psql_as research_app <<'EOSQL'

--- a/locard/operations/0037-snapshot-post.sh
+++ b/locard/operations/0037-snapshot-post.sh
@@ -5,7 +5,7 @@
 # Reason: pg_default_acl and pg_class.relowner require master/superuser access.
 #
 # Required env vars: RDS_ENDPOINT, DB, MASTER_USER, MASTER_PW
-# Output: /tmp/0037_*.after.txt (7 files, overwritten on each run)
+# Output: /tmp/0037_*.after.txt (8 files, overwritten on each run)
 #
 # Usage:
 #   export RDS_ENDPOINT=... DB=... MASTER_USER=postgres MASTER_PW=...
@@ -26,6 +26,7 @@ FILES=(
   grants_corpus
   grants_pipeline
   grants_dashboard
+  routine_privileges
   default_acl
   ownership_objects
   ownership_schemas
@@ -45,6 +46,16 @@ echo "Capturing post-rename snapshots..."
 psql "${PSQL_ARGS[@]}" -c "\dp lava_corpus.*" > "${PREFIX}_grants_corpus.${SUFFIX}.txt"
 psql "${PSQL_ARGS[@]}" -c "\dp lava_pipeline.*" > "${PREFIX}_grants_pipeline.${SUFFIX}.txt"
 psql "${PSQL_ARGS[@]}" -c "\dp lava_dashboard.*" > "${PREFIX}_grants_dashboard.${SUFFIX}.txt"
+
+# 4a+: Function (EXECUTE) privileges — \dp does not cover functions
+psql "${PSQL_ARGS[@]}" -c "
+SELECT routine_schema, routine_name, grantee, privilege_type
+FROM information_schema.routine_privileges
+WHERE grantee IN ('app_user1','ro_user1','dashboard_user1',
+                  'research_app','research_ro')
+  AND routine_schema IN ('lava_corpus','lava_pipeline','lava_dashboard')
+ORDER BY routine_schema, routine_name, grantee, privilege_type;
+" > "${PREFIX}_routine_privileges.${SUFFIX}.txt"
 
 # 4b: Default ACLs
 psql "${PSQL_ARGS[@]}" -c "

--- a/locard/operations/0037-snapshot-post.sh
+++ b/locard/operations/0037-snapshot-post.sh
@@ -16,7 +16,8 @@ set -euo pipefail
 : "${RDS_ENDPOINT:?Set RDS_ENDPOINT}" "${DB:?Set DB}"
 : "${MASTER_USER:?Set MASTER_USER}" "${MASTER_PW:?Set MASTER_PW}"
 
-PSQL="PGPASSWORD=$MASTER_PW psql -h $RDS_ENDPOINT -U $MASTER_USER -d $DB --set=sslmode=require -v ON_ERROR_STOP=1 -At"
+export PGPASSWORD="$MASTER_PW"
+PSQL_ARGS=(-h "$RDS_ENDPOINT" -U "$MASTER_USER" -d "$DB" --set=sslmode=require -v ON_ERROR_STOP=1 -At)
 
 SUFFIX="after"
 PREFIX="/tmp/0037"
@@ -41,12 +42,12 @@ done
 echo "Capturing post-rename snapshots..."
 
 # 4a: Object privileges per schema
-eval $PSQL -c "\\dp lava_corpus.*" > "${PREFIX}_grants_corpus.${SUFFIX}.txt"
-eval $PSQL -c "\\dp lava_pipeline.*" > "${PREFIX}_grants_pipeline.${SUFFIX}.txt"
-eval $PSQL -c "\\dp lava_dashboard.*" > "${PREFIX}_grants_dashboard.${SUFFIX}.txt"
+psql "${PSQL_ARGS[@]}" -c "\dp lava_corpus.*" > "${PREFIX}_grants_corpus.${SUFFIX}.txt"
+psql "${PSQL_ARGS[@]}" -c "\dp lava_pipeline.*" > "${PREFIX}_grants_pipeline.${SUFFIX}.txt"
+psql "${PSQL_ARGS[@]}" -c "\dp lava_dashboard.*" > "${PREFIX}_grants_dashboard.${SUFFIX}.txt"
 
 # 4b: Default ACLs
-eval $PSQL -c "
+psql "${PSQL_ARGS[@]}" -c "
 SELECT n.nspname, r.rolname AS grantor, d.defaclobjtype, d.defaclacl
 FROM pg_default_acl d
 LEFT JOIN pg_namespace n ON d.defaclnamespace = n.oid
@@ -57,7 +58,7 @@ ORDER BY n.nspname, defaclobjtype;
 " > "${PREFIX}_default_acl.${SUFFIX}.txt"
 
 # 4c: Ownership — objects
-eval $PSQL -c "
+psql "${PSQL_ARGS[@]}" -c "
 SELECT n.nspname, c.relname, c.relkind, r.rolname AS owner
 FROM pg_class c
 JOIN pg_namespace n ON c.relnamespace = n.oid
@@ -67,7 +68,7 @@ ORDER BY n.nspname, c.relname;
 " > "${PREFIX}_ownership_objects.${SUFFIX}.txt"
 
 # 4c: Ownership — schemas
-eval $PSQL -c "
+psql "${PSQL_ARGS[@]}" -c "
 SELECT n.nspname, r.rolname AS owner
 FROM pg_namespace n
 JOIN pg_roles r ON n.nspowner = r.oid
@@ -76,7 +77,7 @@ ORDER BY n.nspname;
 " > "${PREFIX}_ownership_schemas.${SUFFIX}.txt"
 
 # 4d: Memberships
-eval $PSQL -c "
+psql "${PSQL_ARGS[@]}" -c "
 SELECT r.rolname, m.rolname AS member_of
 FROM pg_roles r
 JOIN pg_auth_members am ON r.oid = am.member

--- a/locard/operations/0037-snapshot-post.sh
+++ b/locard/operations/0037-snapshot-post.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# 0037-snapshot-post.sh — Capture post-rename privilege/ownership snapshots.
+#
+# Must run as the RDS instance master role (NOT as research_app/research_ro).
+# Reason: pg_default_acl and pg_class.relowner require master/superuser access.
+#
+# Required env vars: RDS_ENDPOINT, DB, MASTER_USER, MASTER_PW
+# Output: /tmp/0037_*.after.txt (7 files, overwritten on each run)
+#
+# Usage:
+#   export RDS_ENDPOINT=... DB=... MASTER_USER=postgres MASTER_PW=...
+#   bash locard/operations/0037-snapshot-post.sh
+
+set -euo pipefail
+
+: "${RDS_ENDPOINT:?Set RDS_ENDPOINT}" "${DB:?Set DB}"
+: "${MASTER_USER:?Set MASTER_USER}" "${MASTER_PW:?Set MASTER_PW}"
+
+PSQL="PGPASSWORD=$MASTER_PW psql -h $RDS_ENDPOINT -U $MASTER_USER -d $DB --set=sslmode=require -v ON_ERROR_STOP=1 -At"
+
+SUFFIX="after"
+PREFIX="/tmp/0037"
+
+FILES=(
+  grants_corpus
+  grants_pipeline
+  grants_dashboard
+  default_acl
+  ownership_objects
+  ownership_schemas
+  memberships
+)
+
+for f in "${FILES[@]}"; do
+  OUT="${PREFIX}_${f}.${SUFFIX}.txt"
+  if [[ -f "$OUT" ]]; then
+    echo "WARNING: overwriting existing $OUT"
+  fi
+done
+
+echo "Capturing post-rename snapshots..."
+
+# 4a: Object privileges per schema
+eval $PSQL -c "\\dp lava_corpus.*" > "${PREFIX}_grants_corpus.${SUFFIX}.txt"
+eval $PSQL -c "\\dp lava_pipeline.*" > "${PREFIX}_grants_pipeline.${SUFFIX}.txt"
+eval $PSQL -c "\\dp lava_dashboard.*" > "${PREFIX}_grants_dashboard.${SUFFIX}.txt"
+
+# 4b: Default ACLs
+eval $PSQL -c "
+SELECT n.nspname, r.rolname AS grantor, d.defaclobjtype, d.defaclacl
+FROM pg_default_acl d
+LEFT JOIN pg_namespace n ON d.defaclnamespace = n.oid
+JOIN pg_roles r ON d.defaclrole = r.oid
+WHERE n.nspname IN ('lava_corpus','lava_pipeline','lava_dashboard')
+   OR n.nspname IS NULL
+ORDER BY n.nspname, defaclobjtype;
+" > "${PREFIX}_default_acl.${SUFFIX}.txt"
+
+# 4c: Ownership — objects
+eval $PSQL -c "
+SELECT n.nspname, c.relname, c.relkind, r.rolname AS owner
+FROM pg_class c
+JOIN pg_namespace n ON c.relnamespace = n.oid
+JOIN pg_roles r ON c.relowner = r.oid
+WHERE n.nspname IN ('lava_corpus','lava_pipeline','lava_dashboard')
+ORDER BY n.nspname, c.relname;
+" > "${PREFIX}_ownership_objects.${SUFFIX}.txt"
+
+# 4c: Ownership — schemas
+eval $PSQL -c "
+SELECT n.nspname, r.rolname AS owner
+FROM pg_namespace n
+JOIN pg_roles r ON n.nspowner = r.oid
+WHERE n.nspname IN ('lava_corpus','lava_pipeline','lava_dashboard')
+ORDER BY n.nspname;
+" > "${PREFIX}_ownership_schemas.${SUFFIX}.txt"
+
+# 4d: Memberships
+eval $PSQL -c "
+SELECT r.rolname, m.rolname AS member_of
+FROM pg_roles r
+JOIN pg_auth_members am ON r.oid = am.member
+JOIN pg_roles m ON am.roleid = m.oid
+WHERE r.rolname IN ('app_user1','ro_user1','dashboard_user1',
+                    'research_app','research_ro')
+ORDER BY r.rolname, m.rolname;
+" > "${PREFIX}_memberships.${SUFFIX}.txt"
+
+echo "Post-rename snapshots written:"
+for f in "${FILES[@]}"; do
+  OUT="${PREFIX}_${f}.${SUFFIX}.txt"
+  echo "  $OUT ($(wc -l < "$OUT") lines)"
+done
+echo "Done."

--- a/locard/operations/0037-snapshot-pre.sh
+++ b/locard/operations/0037-snapshot-pre.sh
@@ -16,7 +16,8 @@ set -euo pipefail
 : "${RDS_ENDPOINT:?Set RDS_ENDPOINT}" "${DB:?Set DB}"
 : "${MASTER_USER:?Set MASTER_USER}" "${MASTER_PW:?Set MASTER_PW}"
 
-PSQL="PGPASSWORD=$MASTER_PW psql -h $RDS_ENDPOINT -U $MASTER_USER -d $DB --set=sslmode=require -v ON_ERROR_STOP=1 -At"
+export PGPASSWORD="$MASTER_PW"
+PSQL_ARGS=(-h "$RDS_ENDPOINT" -U "$MASTER_USER" -d "$DB" --set=sslmode=require -v ON_ERROR_STOP=1 -At)
 
 SUFFIX="before"
 PREFIX="/tmp/0037"
@@ -41,12 +42,12 @@ done
 echo "Capturing pre-rename snapshots..."
 
 # 4a: Object privileges per schema
-eval $PSQL -c "\\dp lava_corpus.*" > "${PREFIX}_grants_corpus.${SUFFIX}.txt"
-eval $PSQL -c "\\dp lava_pipeline.*" > "${PREFIX}_grants_pipeline.${SUFFIX}.txt"
-eval $PSQL -c "\\dp lava_dashboard.*" > "${PREFIX}_grants_dashboard.${SUFFIX}.txt"
+psql "${PSQL_ARGS[@]}" -c "\dp lava_corpus.*" > "${PREFIX}_grants_corpus.${SUFFIX}.txt"
+psql "${PSQL_ARGS[@]}" -c "\dp lava_pipeline.*" > "${PREFIX}_grants_pipeline.${SUFFIX}.txt"
+psql "${PSQL_ARGS[@]}" -c "\dp lava_dashboard.*" > "${PREFIX}_grants_dashboard.${SUFFIX}.txt"
 
 # 4b: Default ACLs
-eval $PSQL -c "
+psql "${PSQL_ARGS[@]}" -c "
 SELECT n.nspname, r.rolname AS grantor, d.defaclobjtype, d.defaclacl
 FROM pg_default_acl d
 LEFT JOIN pg_namespace n ON d.defaclnamespace = n.oid
@@ -57,7 +58,7 @@ ORDER BY n.nspname, defaclobjtype;
 " > "${PREFIX}_default_acl.${SUFFIX}.txt"
 
 # 4c: Ownership — objects
-eval $PSQL -c "
+psql "${PSQL_ARGS[@]}" -c "
 SELECT n.nspname, c.relname, c.relkind, r.rolname AS owner
 FROM pg_class c
 JOIN pg_namespace n ON c.relnamespace = n.oid
@@ -67,7 +68,7 @@ ORDER BY n.nspname, c.relname;
 " > "${PREFIX}_ownership_objects.${SUFFIX}.txt"
 
 # 4c: Ownership — schemas
-eval $PSQL -c "
+psql "${PSQL_ARGS[@]}" -c "
 SELECT n.nspname, r.rolname AS owner
 FROM pg_namespace n
 JOIN pg_roles r ON n.nspowner = r.oid
@@ -76,7 +77,7 @@ ORDER BY n.nspname;
 " > "${PREFIX}_ownership_schemas.${SUFFIX}.txt"
 
 # 4d: Memberships
-eval $PSQL -c "
+psql "${PSQL_ARGS[@]}" -c "
 SELECT r.rolname, m.rolname AS member_of
 FROM pg_roles r
 JOIN pg_auth_members am ON r.oid = am.member

--- a/locard/operations/0037-snapshot-pre.sh
+++ b/locard/operations/0037-snapshot-pre.sh
@@ -5,7 +5,7 @@
 # Reason: pg_default_acl and pg_class.relowner require master/superuser access.
 #
 # Required env vars: RDS_ENDPOINT, DB, MASTER_USER, MASTER_PW
-# Output: /tmp/0037_*.before.txt (7 files, overwritten on each run)
+# Output: /tmp/0037_*.before.txt (8 files, overwritten on each run)
 #
 # Usage:
 #   export RDS_ENDPOINT=... DB=... MASTER_USER=postgres MASTER_PW=...
@@ -26,6 +26,7 @@ FILES=(
   grants_corpus
   grants_pipeline
   grants_dashboard
+  routine_privileges
   default_acl
   ownership_objects
   ownership_schemas
@@ -45,6 +46,16 @@ echo "Capturing pre-rename snapshots..."
 psql "${PSQL_ARGS[@]}" -c "\dp lava_corpus.*" > "${PREFIX}_grants_corpus.${SUFFIX}.txt"
 psql "${PSQL_ARGS[@]}" -c "\dp lava_pipeline.*" > "${PREFIX}_grants_pipeline.${SUFFIX}.txt"
 psql "${PSQL_ARGS[@]}" -c "\dp lava_dashboard.*" > "${PREFIX}_grants_dashboard.${SUFFIX}.txt"
+
+# 4a+: Function (EXECUTE) privileges — \dp does not cover functions
+psql "${PSQL_ARGS[@]}" -c "
+SELECT routine_schema, routine_name, grantee, privilege_type
+FROM information_schema.routine_privileges
+WHERE grantee IN ('app_user1','ro_user1','dashboard_user1',
+                  'research_app','research_ro')
+  AND routine_schema IN ('lava_corpus','lava_pipeline','lava_dashboard')
+ORDER BY routine_schema, routine_name, grantee, privilege_type;
+" > "${PREFIX}_routine_privileges.${SUFFIX}.txt"
 
 # 4b: Default ACLs
 psql "${PSQL_ARGS[@]}" -c "

--- a/locard/operations/0037-snapshot-pre.sh
+++ b/locard/operations/0037-snapshot-pre.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# 0037-snapshot-pre.sh — Capture pre-rename privilege/ownership snapshots.
+#
+# Must run as the RDS instance master role (NOT as research_app/research_ro).
+# Reason: pg_default_acl and pg_class.relowner require master/superuser access.
+#
+# Required env vars: RDS_ENDPOINT, DB, MASTER_USER, MASTER_PW
+# Output: /tmp/0037_*.before.txt (7 files, overwritten on each run)
+#
+# Usage:
+#   export RDS_ENDPOINT=... DB=... MASTER_USER=postgres MASTER_PW=...
+#   bash locard/operations/0037-snapshot-pre.sh
+
+set -euo pipefail
+
+: "${RDS_ENDPOINT:?Set RDS_ENDPOINT}" "${DB:?Set DB}"
+: "${MASTER_USER:?Set MASTER_USER}" "${MASTER_PW:?Set MASTER_PW}"
+
+PSQL="PGPASSWORD=$MASTER_PW psql -h $RDS_ENDPOINT -U $MASTER_USER -d $DB --set=sslmode=require -v ON_ERROR_STOP=1 -At"
+
+SUFFIX="before"
+PREFIX="/tmp/0037"
+
+FILES=(
+  grants_corpus
+  grants_pipeline
+  grants_dashboard
+  default_acl
+  ownership_objects
+  ownership_schemas
+  memberships
+)
+
+for f in "${FILES[@]}"; do
+  OUT="${PREFIX}_${f}.${SUFFIX}.txt"
+  if [[ -f "$OUT" ]]; then
+    echo "WARNING: overwriting existing $OUT"
+  fi
+done
+
+echo "Capturing pre-rename snapshots..."
+
+# 4a: Object privileges per schema
+eval $PSQL -c "\\dp lava_corpus.*" > "${PREFIX}_grants_corpus.${SUFFIX}.txt"
+eval $PSQL -c "\\dp lava_pipeline.*" > "${PREFIX}_grants_pipeline.${SUFFIX}.txt"
+eval $PSQL -c "\\dp lava_dashboard.*" > "${PREFIX}_grants_dashboard.${SUFFIX}.txt"
+
+# 4b: Default ACLs
+eval $PSQL -c "
+SELECT n.nspname, r.rolname AS grantor, d.defaclobjtype, d.defaclacl
+FROM pg_default_acl d
+LEFT JOIN pg_namespace n ON d.defaclnamespace = n.oid
+JOIN pg_roles r ON d.defaclrole = r.oid
+WHERE n.nspname IN ('lava_corpus','lava_pipeline','lava_dashboard')
+   OR n.nspname IS NULL
+ORDER BY n.nspname, defaclobjtype;
+" > "${PREFIX}_default_acl.${SUFFIX}.txt"
+
+# 4c: Ownership — objects
+eval $PSQL -c "
+SELECT n.nspname, c.relname, c.relkind, r.rolname AS owner
+FROM pg_class c
+JOIN pg_namespace n ON c.relnamespace = n.oid
+JOIN pg_roles r ON c.relowner = r.oid
+WHERE n.nspname IN ('lava_corpus','lava_pipeline','lava_dashboard')
+ORDER BY n.nspname, c.relname;
+" > "${PREFIX}_ownership_objects.${SUFFIX}.txt"
+
+# 4c: Ownership — schemas
+eval $PSQL -c "
+SELECT n.nspname, r.rolname AS owner
+FROM pg_namespace n
+JOIN pg_roles r ON n.nspowner = r.oid
+WHERE n.nspname IN ('lava_corpus','lava_pipeline','lava_dashboard')
+ORDER BY n.nspname;
+" > "${PREFIX}_ownership_schemas.${SUFFIX}.txt"
+
+# 4d: Memberships
+eval $PSQL -c "
+SELECT r.rolname, m.rolname AS member_of
+FROM pg_roles r
+JOIN pg_auth_members am ON r.oid = am.member
+JOIN pg_roles m ON am.roleid = m.oid
+WHERE r.rolname IN ('app_user1','ro_user1','dashboard_user1',
+                    'research_app','research_ro')
+ORDER BY r.rolname, m.rolname;
+" > "${PREFIX}_memberships.${SUFFIX}.txt"
+
+echo "Pre-rename snapshots written:"
+for f in "${FILES[@]}"; do
+  OUT="${PREFIX}_${f}.${SUFFIX}.txt"
+  echo "  $OUT ($(wc -l < "$OUT") lines)"
+done
+echo "Done."

--- a/locard/plans/0037-rds-role-rename.md
+++ b/locard/plans/0037-rds-role-rename.md
@@ -44,11 +44,10 @@ The builder's job is to (1) update 6 files where old role names are hardcoded, (
    - `app_user1` → `research_app`
    - `ro_user1` → `research_ro`
 
-2. **Verify zero remaining references** in source tree:
+2. **Verify zero remaining references** in source tree (matches Phase 1 acceptance and spec AC #7):
    ```bash
-   grep -rn -E "app_user1|ro_user1" \
-     lavandula/migrations/ lavandula/common/tests/
-   # Expected: zero matches
+   grep -rn -E "app_user1|ro_user1" lavandula/
+   # Expected: zero matches across the entire lavandula/ tree
    ```
 
 3. **Verify SSM-indirection files are NOT edited** (regression check):
@@ -95,24 +94,31 @@ The builder's job is to (1) update 6 files where old role names are hardcoded, (
 
 ### Implementation Steps
 
-1. **Write the runbook** as a numbered T-1..T+6 sequence. Each step includes:
+1. **Write the runbook** as a numbered T-1..T+6 sequence. **The runbook must be self-contained: an operator can execute it without reading the spec.** Each step includes:
    - **Precondition**: SQL or shell command + expected output
    - **Action**: exact command(s) to run
    - **Verification**: SQL or shell command + expected output
-   - **Failure branch**: pointer to spec §"Rollback Plan §Decision tree by failure point"
+   - **Failure branch**: the failure-mode decision tree from spec §"Rollback Plan §Decision tree by failure point" is copied INTO the runbook at the relevant step (not referenced — copied). Each step's failure section names the exact next action.
 
-   The runbook copies content from spec §"Cutover sequence" verbatim, then expands placeholders to concrete values. The operator will fill in `$RDS_ENDPOINT`, `$DB`, `ACCT`, and `DB-RES-ID` as environment variables before running.
+   Concrete branches that MUST be fully resolved in the runbook (not pointers):
+   - **`dashboard_user1` decision**: the runbook contains the exact `psql` invocation to query state, the literal three-row decision table, and the next-action for each row.
+   - **Privileged pre-check execution**: the runbook explicitly states which connection (master role) to use for steps 2/4b/4c, and which connection (master OR IAM-tier) to use for steps 1/3/4a/4d. The operator does not have to figure this out.
+   - **Smoke-test write path**: the exact INSERT into `lava_pipeline.org_provenance` with EIN `ZZ-SMOKETEST-37` (per step 10 below) is in the runbook verbatim — the operator does not improvise the write target.
+
+   The runbook copies content from spec §"Cutover sequence" verbatim, then expands placeholders to concrete values. The operator fills in `$RDS_ENDPOINT`, `$DB`, `ACCT`, and `DB-RES-ID` as environment variables before running.
 
 2. **Write `0037-pre-rename-checks.sql`** with the four queries from spec §"Pre-rename checks" (steps 1, 2, 3, and 4a-4d). Each query has a header comment explaining its purpose and expected output. The file is operator-runnable via `psql -f`.
 
-3. **Write `0037-snapshot-pre.sh`**:
-   - Reads `RDS_ENDPOINT`, `DB`, `IAM_USER` from env vars
-   - Calls `aws rds generate-db-auth-token` to mint a token for the IAM_USER
-   - Runs each snapshot query with `psql -At` (tab-aligned, no headers) and writes output to `/tmp/0037_<dimension>.before.txt`
-   - Files produced: `grants_corpus.before.txt`, `grants_pipeline.before.txt`, `grants_dashboard.before.txt`, `default_acl.before.txt`, `ownership_objects.before.txt`, `ownership_schemas.before.txt`, `memberships.before.txt`
-   - Exits non-zero if any query fails
+3. **Write `0037-snapshot-pre.sh`** — must run as the **RDS instance master role** (the bootstrap superuser), not as `research_app` or `research_ro`. Reason: snapshots 4b (`pg_default_acl`) and 4c (`pg_class.relowner`) read columns that require ownership-or-superuser access. Running as the IAM-tier role would silently return empty rows and mask privilege regressions.
 
-4. **Write `0037-snapshot-post.sh`**: identical to `pre.sh` but writes `.after.txt` files. (Could be a single script with a CLI flag — builder's call.)
+   - Reads env vars: `RDS_ENDPOINT`, `DB`, `MASTER_USER` (the master role name), `MASTER_PW` (master password from SSM).
+   - Connects via password auth (NOT IAM) — the master role uses password auth: `PGPASSWORD="$MASTER_PW" psql -h $RDS_ENDPOINT -U $MASTER_USER -d $DB --set=sslmode=require -v ON_ERROR_STOP=1`.
+   - Runs each of the 7 snapshot queries with `psql -At` (tab-aligned, no headers). Overwrites pre-existing output files (idempotent).
+   - Files produced (overwritten on each run): `grants_corpus.before.txt`, `grants_pipeline.before.txt`, `grants_dashboard.before.txt`, `default_acl.before.txt`, `ownership_objects.before.txt`, `ownership_schemas.before.txt`, `memberships.before.txt`.
+   - Print one-line warning if previous output files existed and were overwritten.
+   - Exits non-zero if any query fails.
+
+4. **Write `0037-snapshot-post.sh`**: identical to `pre.sh` but writes `.after.txt` files. (Could be a single script with a `--mode pre|post` flag — builder's call.)
 
 5. **Write `0037-parity-diff.sh`** — must cover ALL 7 produced files (4 dimensions, but ownership splits into objects+schemas and object-privileges splits across 3 schemas). The script iterates this exact list:
 
@@ -157,23 +163,65 @@ The builder's job is to (1) update 6 files where old role names are hardcoded, (
    ```
    The `dashboard_user1` HALT branch is enforced in the runbook (operator stops if pre-check finds it with grants); this SQL file does NOT touch dashboard_user1. The DROP path lives in a separate file (step 8b below) so the operator runs it explicitly only when pre-check directs.
 
-8b. **Write `0037-cutover-dashboard-user-drop.sql`** — operator runs ONLY if pre-check determines `dashboard_user1` exists AND has zero GRANTs AND zero non-`rds_iam` memberships:
+8b. **Write `0037-cutover-dashboard-user-drop.sql`** — operator runs ONLY if pre-check determines `dashboard_user1` exists AND has zero GRANTs AND zero non-`rds_iam` memberships. The SQL re-validates BOTH conditions before dropping (defense-in-depth — operator could misinterpret pre-check):
    ```sql
-   DO $$ BEGIN
-     IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'dashboard_user1') THEN
-       -- Defense-in-depth re-check: confirm zero non-rds_iam memberships
-       -- before dropping. If any exist, raise — operator must HALT.
-       IF EXISTS (
-         SELECT 1 FROM pg_auth_members am
-         JOIN pg_roles r ON r.oid = am.member
-         JOIN pg_roles m ON m.oid = am.roleid
-         WHERE r.rolname = 'dashboard_user1' AND m.rolname <> 'rds_iam'
-       ) THEN
-         RAISE EXCEPTION 'dashboard_user1 has non-rds_iam memberships — '
-                         'HALT per spec §"dashboard_user1 decision rule"';
-       END IF;
-       DROP ROLE dashboard_user1;
+   DO $$
+   DECLARE
+     v_grant_count int;
+     v_owned_count int;
+     v_nonimg_member_count int;
+   BEGIN
+     IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'dashboard_user1') THEN
+       RAISE NOTICE 'dashboard_user1 does not exist — no-op';
+       RETURN;
      END IF;
+
+     -- Check 1: zero non-rds_iam memberships
+     SELECT count(*) INTO v_nonimg_member_count
+     FROM pg_auth_members am
+     JOIN pg_roles r ON r.oid = am.member
+     JOIN pg_roles m ON m.oid = am.roleid
+     WHERE r.rolname = 'dashboard_user1' AND m.rolname <> 'rds_iam';
+
+     IF v_nonimg_member_count > 0 THEN
+       RAISE EXCEPTION 'dashboard_user1 has % non-rds_iam memberships — '
+                       'HALT per spec §"dashboard_user1 decision rule"',
+                       v_nonimg_member_count;
+     END IF;
+
+     -- Check 2: zero object-privilege grants on the role across all schemas
+     -- (covers tables, sequences, functions, schemas).
+     SELECT count(*) INTO v_grant_count
+     FROM (
+       SELECT 1 FROM information_schema.table_privileges
+         WHERE grantee = 'dashboard_user1'
+       UNION ALL
+       SELECT 1 FROM information_schema.routine_privileges
+         WHERE grantee = 'dashboard_user1'
+       UNION ALL
+       SELECT 1 FROM information_schema.usage_privileges
+         WHERE grantee = 'dashboard_user1'
+     ) g;
+
+     IF v_grant_count > 0 THEN
+       RAISE EXCEPTION 'dashboard_user1 has % object-privilege grants — '
+                       'HALT per spec §"dashboard_user1 decision rule"',
+                       v_grant_count;
+     END IF;
+
+     -- Check 3: zero objects owned by the role (defense-in-depth — DROP ROLE
+     -- on an owner would fail anyway, but raise a clearer message).
+     SELECT count(*) INTO v_owned_count
+     FROM pg_class c JOIN pg_roles r ON c.relowner = r.oid
+     WHERE r.rolname = 'dashboard_user1';
+
+     IF v_owned_count > 0 THEN
+       RAISE EXCEPTION 'dashboard_user1 owns % objects — HALT', v_owned_count;
+     END IF;
+
+     -- All three defense-in-depth checks passed; safe to drop.
+     DROP ROLE dashboard_user1;
+     RAISE NOTICE 'dashboard_user1 dropped (was vestigial)';
    END $$;
    ```
 
@@ -192,13 +240,31 @@ The builder's job is to (1) update 6 files where old role names are hardcoded, (
    ```
    Run only if rollback decision tree directs full rollback (per spec §"Rollback Plan §Decision tree").
 
-10. **Write `0037-smoke-test.sh`**:
-    - Generates IAM tokens for `research_app` and `research_ro`
-    - Connects with each via `psql` and runs `SELECT current_user, 1 AS ok`
-    - Asserts the returned `current_user` matches the expected role
-    - Runs read query (`SELECT 1 FROM lava_corpus.corpus LIMIT 1`) as `research_ro`
-    - Runs write query (`INSERT into a no-op table; ROLLBACK`) as `research_app`
-    - Exits 0 only if all four checks pass
+10. **Write `0037-smoke-test.sh`** with concrete, named queries (no operator improvisation):
+
+    For each `(role, role_purpose)` in `[(research_ro, "read-only SELECT"), (research_app, "CRUD")]`:
+    - Generate IAM token: `aws rds generate-db-auth-token --hostname $RDS_ENDPOINT --port 5432 --username $role --region us-east-1`
+    - Connect: `PGPASSWORD=$tok psql -h $RDS_ENDPOINT -U $role -d $DB --set=sslmode=require -v ON_ERROR_STOP=1`
+    - Identity check: `SELECT current_user, 1 AS ok` — expect a single row with `current_user = $role`.
+    - Read check (both roles): `SELECT count(*) FROM lava_corpus.corpus LIMIT 1` — expect a row with a non-negative integer (does NOT need rows to exist; just proves SELECT permission).
+
+    For `research_app` only, ALSO run a write check using a transactional INSERT that is GUARANTEED to roll back regardless of operator error:
+    ```sql
+    BEGIN;
+    INSERT INTO lava_pipeline.org_provenance (ein, seed_status, updated_at)
+      VALUES ('ZZ-SMOKETEST-37', 'completed', NOW())
+      ON CONFLICT (ein) DO NOTHING;
+    -- Force rollback unconditionally with a deliberate error:
+    ROLLBACK;
+    ```
+    Then verify (in a new connection): `SELECT count(*) FROM lava_pipeline.org_provenance WHERE ein = 'ZZ-SMOKETEST-37'` — expect `0`. This proves:
+    (a) `research_app` has INSERT permission on `lava_pipeline.org_provenance` (otherwise the INSERT would fail).
+    (b) The ROLLBACK was honored (no smoke-test row leaked into production data).
+    (c) The session is connected as the right role with the right grants.
+
+    The script exits 0 ONLY if all checks pass. Any failure → exit non-zero with a one-line description of which check failed.
+
+    **Why `lava_pipeline.org_provenance` and EIN `ZZ-SMOKETEST-37`?** It's a real production table (so we test real grants), it has INSERT permission for `research_app` per `migration_011_990_index_automation.sql`, and the EIN format `ZZ-...` is invalid (real EINs are 9 digits) — even if the rollback somehow fails, downstream code that filters by valid EIN format will ignore the smoke row.
 
 ### Phase 2 Acceptance
 
@@ -247,13 +313,28 @@ The builder's job is to (1) update 6 files where old role names are hardcoded, (
    ```
    All 14 migrations must apply successfully. If a migration requires `rds_iam` (an AWS-RDS-only role that doesn't exist on plain Postgres), the builder records this as a bootstrap-script gap in the PR and adds `CREATE ROLE rds_iam;` to the scratch setup. Do not silently pre-grant — surface the issue.
 
-3. **Document results** in the PR description: paste the test summary lines and the migration loop's "all OK" output. The reviewer should be able to read the PR description and see all checks passed without re-running them.
+3. **Exercise helper scripts end-to-end against scratch DB**. Syntax-checking is not enough; the scripts must actually run against a real Postgres instance. Specifically:
+   - Run `0037-snapshot-pre.sh` against the scratch DB (with the renamed roles created) — verify all 7 `.before.txt` files are produced with expected content.
+   - Run `0037-cutover-rename.sql` TWICE against the scratch DB (first time renames; second time is a no-op due to idempotency guards). Confirm second run produces no error.
+   - Run `0037-snapshot-post.sh` against the scratch DB — verify all 7 `.after.txt` files are produced.
+   - Run `0037-parity-diff.sh` — expect PASS on all 7 dimensions (renames preserve grants, default ACLs, ownership, memberships).
+   - Run `0037-cutover-rollback.sql` — verify it reverses the rename. Run a SECOND time — verify it's a no-op.
+   - Run `0037-cutover-dashboard-user-drop.sql` against scratch DB where `dashboard_user1` doesn't exist — verify it raises NOTICE and exits 0 (no-op branch).
+   - (Optional but recommended) Create a fake `dashboard_user1` in scratch DB with grants, run drop SQL — verify it RAISEs EXCEPTION (HALT branch).
+
+4. **Document results** in the PR description: paste the test summary lines, the migration loop's "all OK" output, and the helper-script exercise output. The reviewer should be able to read the PR description and see all checks passed without re-running them.
 
 ### Phase 3 Acceptance
 
 - `pytest` exit code 0 for both test invocations.
 - Scratch-DB migration loop applies all 14 migrations to completion (exit 0 from the for-loop).
-- PR description contains the test output summary and migration validation output.
+- All 6 helper-script exercises pass against scratch DB:
+  - snapshot-pre/snapshot-post produce all 7 expected files
+  - cutover-rename idempotent (second run no-op)
+  - parity-diff PASSes all 7 dimensions
+  - cutover-rollback reverses cleanly and is itself idempotent
+  - dashboard-user-drop is a no-op when role absent; RAISEs when role has grants/memberships
+- PR description contains the test output summary, migration validation output, and helper-script exercise output.
 
 ---
 

--- a/locard/plans/0037-rds-role-rename.md
+++ b/locard/plans/0037-rds-role-rename.md
@@ -1,0 +1,265 @@
+# Plan 0037: Rename RDS Roles to Project-Prefixed Names
+
+**Spec**: `locard/specs/0037-rds-role-rename.md`
+**Status**: Draft
+**Phases**: 5 (B = builder, O = operator, M = mixed)
+**Prefix**: `research` (operator-confirmed 2026-05-10)
+
+## Context for the Builder
+
+This work renames two Postgres roles on the shared RDS instance so a second project can coexist without role-name collisions. The clean part: the codebase already abstracts usernames behind SSM keys (`rds-app-user`, `rds-ro-user`) — only the SSM **values** change, not the keys. This means **zero changes to `lavandula/common/db.py` or `lavandula/dashboard/dashboard/settings.py`**.
+
+The builder's job is to (1) update 6 files where old role names are hardcoded, (2) write the operator runbook + helper scripts that drive the live cutover, and (3) prove correctness against a scratch database. The builder **does NOT execute the live cutover** — that is operator-only work documented in the runbook.
+
+**Key codebase context**:
+- Username flow: `lavandula/common/db.py:162-181` (`_engine_from_ssm`), `lavandula/dashboard/dashboard/settings.py:72` (`_APP_USER`)
+- SSM secrets reader: `lavandula/common/secrets.py` — `get_secret(short_name)` with `lru_cache(maxsize=64)` and `_PARAM_PREFIX = "/cloud2.lavandulagroup.com/"`
+- Test fixtures: `lavandula/common/tests/conftest.py` (role-presence assertions), `lavandula/common/tests/unit/test_db_adapter_0013.py` (11 hardcoded references)
+- Migration runner: migrations are applied manually via `psql -f` (not Alembic/Django migrations); no migration framework metadata to update
+- IAM policy: attached to EC2 instance profile `cloud2_lavandulagroup`; resource ARNs are `arn:aws:rds-db:us-east-1:ACCT:dbuser/DB-RES-ID/<rolename>`
+
+**Important constraints**:
+- The builder's PR must NOT be merged until after the live cutover succeeds (so source tree never describes a state that diverges from production for more than the cutover window).
+- All SQL files use `app_user1` and `ro_user1` literally — no parameterization, so mechanical find/replace is correct.
+- Scratch-DB validation requires Docker + Postgres locally, OR an ephemeral RDS scratch instance — the builder picks based on what's available.
+- Helper scripts go under `locard/operations/0037-*` (a new directory) — they are operational artifacts, not application code.
+
+---
+
+## Phase 1: Source-tree Edits (B)
+
+**Goal**: Replace every hardcoded `app_user1`/`ro_user1` reference in the 6 files identified in the spec inventory. Verify grep returns zero before moving on.
+
+**Files**:
+- `lavandula/migrations/rds/001_initial_schema.sql`
+- `lavandula/migrations/rds/002_attribution_helper.sql`
+- `lavandula/migrations/rds/010_990_people_filing_index.sql`
+- `lavandula/migrations/rds/migration_011_990_index_automation.sql`
+- `lavandula/common/tests/conftest.py`
+- `lavandula/common/tests/unit/test_db_adapter_0013.py`
+
+### Implementation Steps
+
+1. **Mechanical replacement** in each of the 6 files:
+   - `app_user1` → `research_app`
+   - `ro_user1` → `research_ro`
+
+2. **Verify zero remaining references** in source tree:
+   ```bash
+   grep -rn -E "app_user1|ro_user1" \
+     lavandula/migrations/ lavandula/common/tests/
+   # Expected: zero matches
+   ```
+
+3. **Verify SSM-indirection files are NOT edited** (regression check):
+   ```bash
+   git diff --name-only HEAD lavandula/common/db.py \
+     lavandula/dashboard/dashboard/settings.py
+   # Expected: zero output (these files must remain unchanged)
+   ```
+
+4. **Optional narrative-prose footnote edits** (low priority, defer if time-constrained): add a one-line footnote to `locard/specs/0013-rds-postgres-migration.md`, `0017-retire-sqlite.md`, `locard/plans/0013-phase2-backfill.md`, `0017-retire-sqlite.md` saying "Roles renamed to `research_app`/`research_ro` per Spec 0037 (2026-05-10)." Do not rewrite the historical narrative.
+
+### Phase 1 Acceptance
+
+- 6 files modified; diff shows ONLY `app_user1 → research_app` and `ro_user1 → research_ro` substitutions (no incidental changes).
+- `grep -rn -E "app_user1|ro_user1"` against `lavandula/` returns zero hits.
+- `lavandula/common/db.py` and `lavandula/dashboard/dashboard/settings.py` are byte-identical to `master`.
+
+---
+
+## Phase 2: Operator Runbook + Helper Scripts (B)
+
+**Goal**: Produce a self-contained operator runbook that an operator can execute without re-reading the spec, plus the SQL/shell scripts the runbook invokes.
+
+**Files (new)**:
+- `locard/operations/0037-role-rename-runbook.md` — step-by-step T-1..T+6 procedure with exact commands, expected outputs, and decision points
+- `locard/operations/0037-pre-rename-checks.sql` — the four pre-check queries from spec §"Pre-rename checks"
+- `locard/operations/0037-snapshot-pre.sh` — bash script that runs the 4 snapshot queries and writes outputs to `/tmp/0037_*.before.txt`
+- `locard/operations/0037-snapshot-post.sh` — same queries against post-rename DB; writes to `/tmp/0037_*.after.txt`
+- `locard/operations/0037-parity-diff.sh` — applies `sed 's/app_user1/research_app/g; s/ro_user1/research_ro/g'` to each `before` file and `diff`s against `after`; non-zero exit if any diff is non-empty
+- `locard/operations/0037-iam-policy-overlay.json` — the additive-overlap policy JSON for the EC2 instance profile (operator copies this into the AWS console at T-1)
+- `locard/operations/0037-iam-policy-final.json` — the post-cleanup policy with only the new ARNs (operator applies at T+6)
+- `locard/operations/0037-cutover-rename.sql` — the transactional rename
+- `locard/operations/0037-cutover-rollback.sql` — the symmetric reverse rename
+- `locard/operations/0037-smoke-test.sh` — runs the IAM-authenticated psql connect tests for both roles (T+4 and T+5)
+
+### Implementation Steps
+
+1. **Write the runbook** as a numbered T-1..T+6 sequence. Each step includes:
+   - **Precondition**: SQL or shell command + expected output
+   - **Action**: exact command(s) to run
+   - **Verification**: SQL or shell command + expected output
+   - **Failure branch**: pointer to spec §"Rollback Plan §Decision tree by failure point"
+
+   The runbook copies content from spec §"Cutover sequence" verbatim, then expands placeholders to concrete values. The operator will fill in `$RDS_ENDPOINT`, `$DB`, `ACCT`, and `DB-RES-ID` as environment variables before running.
+
+2. **Write `0037-pre-rename-checks.sql`** with the four queries from spec §"Pre-rename checks" (steps 1, 2, 3, and 4a-4d). Each query has a header comment explaining its purpose and expected output. The file is operator-runnable via `psql -f`.
+
+3. **Write `0037-snapshot-pre.sh`**:
+   - Reads `RDS_ENDPOINT`, `DB`, `IAM_USER` from env vars
+   - Calls `aws rds generate-db-auth-token` to mint a token for the IAM_USER
+   - Runs each snapshot query with `psql -At` (tab-aligned, no headers) and writes output to `/tmp/0037_<dimension>.before.txt`
+   - Files produced: `grants_corpus.before.txt`, `grants_pipeline.before.txt`, `grants_dashboard.before.txt`, `default_acl.before.txt`, `ownership_objects.before.txt`, `ownership_schemas.before.txt`, `memberships.before.txt`
+   - Exits non-zero if any query fails
+
+4. **Write `0037-snapshot-post.sh`**: identical to `pre.sh` but writes `.after.txt` files. (Could be a single script with a CLI flag — builder's call.)
+
+5. **Write `0037-parity-diff.sh`**:
+   - For each of the 4 snapshot dimensions, apply `sed 's/app_user1/research_app/g; s/ro_user1/research_ro/g'` to the `.before.txt` file and `diff -u` against the `.after.txt` file
+   - Print PASS/FAIL per dimension
+   - Exit non-zero if ANY dimension diff is non-empty
+   - This script implements AC #6 from the spec (privilege parity, 4 dimensions)
+
+6. **Write `0037-iam-policy-overlay.json`**: a JSON IAM policy document with `Statement` containing `Action: rds-db:connect` and `Resource` listing all FOUR ARNs (old × 2 + new × 2). Operator applies this at T-1.
+
+7. **Write `0037-iam-policy-final.json`**: the post-cleanup version listing only the two new ARNs. Operator applies at T+6.
+
+8. **Write `0037-cutover-rename.sql`**:
+   ```sql
+   BEGIN;
+   ALTER ROLE app_user1 RENAME TO research_app;
+   ALTER ROLE ro_user1  RENAME TO research_ro;
+   -- dashboard_user1 branch: only if pre-check directs DROP. If RENAME branch
+   -- triggered, runbook HALTs — see spec §"dashboard_user1 decision rule".
+   COMMIT;
+   ```
+
+9. **Write `0037-cutover-rollback.sql`**: the symmetric reverse, run only if rollback decision tree directs full rollback.
+
+10. **Write `0037-smoke-test.sh`**:
+    - Generates IAM tokens for `research_app` and `research_ro`
+    - Connects with each via `psql` and runs `SELECT current_user, 1 AS ok`
+    - Asserts the returned `current_user` matches the expected role
+    - Runs read query (`SELECT 1 FROM lava_corpus.corpus LIMIT 1`) as `research_ro`
+    - Runs write query (`INSERT into a no-op table; ROLLBACK`) as `research_app`
+    - Exits 0 only if all four checks pass
+
+### Phase 2 Acceptance
+
+- All 9 files created under `locard/operations/0037-*`.
+- `bash -n locard/operations/*.sh` (syntax check) passes for each shell script.
+- `psql -f locard/operations/0037-pre-rename-checks.sql --set ON_ERROR_STOP=1` runs cleanly against any Postgres ≥14 (does not need RDS).
+- The runbook references each helper script by relative path; no orphan or broken references.
+- IAM policy JSONs validate against the AWS IAM policy schema (use `aws iam validate-policy-document` if available, otherwise manual review).
+
+---
+
+## Phase 3: Targeted Test Validation (B)
+
+**Goal**: Prove the source-tree edits do not break the test suite and that fresh-rebuild correctness holds.
+
+### Implementation Steps
+
+1. **Run targeted unit tests** (per spec AC #8):
+   ```bash
+   cd /home/ubuntu/research
+   pytest lavandula/common/tests/unit/test_db_adapter_0013.py -v
+   pytest lavandula/common/tests/ -v -k "not slow"
+   ```
+   All tests must pass. If a test references the old names via parameterization that the grep-based search missed, it surfaces here.
+
+2. **Run scratch-DB migration validation** (per spec AC #8):
+   ```bash
+   # Use a local Docker Postgres or ephemeral RDS scratch instance
+   docker run -d --rm --name pg37 -e POSTGRES_PASSWORD=test \
+     -p 5499:5432 postgres:16
+   sleep 5
+   psql "host=localhost port=5499 user=postgres dbname=postgres" \
+     -c "CREATE DATABASE lava_test;"
+   psql "host=localhost port=5499 user=postgres dbname=lava_test" \
+     -c "CREATE ROLE research_app; CREATE ROLE research_ro; CREATE ROLE rds_iam;
+         GRANT rds_iam TO research_app; GRANT rds_iam TO research_ro;"
+   for f in lavandula/migrations/rds/{001,002,003,004,005,006,007,008,009,010,011,012,013,014}_*.sql; do
+     psql "host=localhost port=5499 user=postgres dbname=lava_test" \
+       -v ON_ERROR_STOP=1 -f "$f" \
+       || { echo "FAIL: $f"; exit 1; }
+   done
+   docker stop pg37
+   ```
+   All 14 migrations must apply successfully.
+
+3. **Document results** in the PR description: paste the test summary lines and the migration loop's "all OK" output. The reviewer should be able to read the PR description and see all checks passed without re-running them.
+
+### Phase 3 Acceptance
+
+- `pytest` exit code 0 for both test invocations.
+- Scratch-DB migration loop applies all 14 migrations to completion (exit 0 from the for-loop).
+- PR description contains the test output summary and migration validation output.
+
+---
+
+## Phase 4: Live Cutover (O — operator-only)
+
+**Goal**: Execute the runbook against the live RDS instance. Builder is NOT involved in this phase except as documentation reference.
+
+### Operator Steps (driven by runbook)
+
+1. Schedule a maintenance window (3–10 min outage).
+2. Run `0037-pre-rename-checks.sql` and capture the result. Decide branch for `dashboard_user1` per spec §"dashboard_user1 decision rule".
+3. Run `0037-snapshot-pre.sh` to capture all 4 dimensions of pre-rename state.
+4. **T-1**: Apply `0037-iam-policy-overlay.json` to `cloud2_lavandulagroup` instance profile. Wait ≥5 min. Verify additive overlap with the warm-up psql connect (expected: "role does not exist" — proves IAM allows the rds-db:connect through).
+5. **T+0**: `systemctl stop lavandula-dashboard`; `ps -ef` audit; `pg_terminate_backend` for any leftover sessions.
+6. **T+1**: Run `0037-cutover-rename.sql` (transactional).
+7. **T+2**: Update SSM values for `rds-app-user` and `rds-ro-user`.
+8. **T+3**: No action (additive overlap already in place).
+9. **T+4**: Run smoke psql connect tests as `research_app` and `research_ro`. Both must succeed. Then `systemctl start lavandula-dashboard`.
+10. **T+5**: Run `0037-smoke-test.sh`. Hit dashboard endpoints (`/orgs/`, `/jobs/`, write a noop Job).
+11. Wait ≥30 minutes of stable operation.
+12. Run `0037-snapshot-post.sh` and `0037-parity-diff.sh`. AC #6 must pass (zero diff across all 4 dimensions).
+13. **T+6**: Apply `0037-iam-policy-final.json` (removes old ARNs).
+14. Verify with the warm-up psql connect against the OLD role name — expected: "PAM authentication failed" (proves IAM no longer allows the old ARN).
+
+### Failure Handling
+
+If any step fails, consult spec §"Rollback Plan §Decision tree by failure point". Do NOT proceed past a failure without the spec's guidance for that specific failure point.
+
+### Phase 4 Acceptance
+
+- All AC items 1-6 from spec §"Acceptance Criteria" hold.
+- Operator records execution log in `locard/operations/0037-cutover-log-YYYY-MM-DD.md` (timestamps, decisions taken at each branch point, any deviations from the runbook).
+
+---
+
+## Phase 5: PR Merge + Documentation (M)
+
+**Goal**: Merge the source-tree PR after live cutover succeeds. Capture lessons learned.
+
+### Steps
+
+1. **Builder merges PR** after operator confirms Phase 4 acceptance. Ordering matters: live cutover MUST happen first, source-tree edits MUST be merged within the same maintenance window. If cutover succeeds but PR merge is delayed, source tree is correct but historical inconsistency persists — flag and merge ASAP.
+
+2. **Builder writes lessons-learned entry** in `locard/resources/lessons-learned.md` if any deviations from the runbook occurred during cutover. Examples worth recording:
+   - IAM propagation took longer/shorter than expected
+   - Connection drain required `pg_terminate_backend` (sessions didn't close cleanly)
+   - Privilege-parity diff revealed unexpected differences (and how they were resolved)
+   - `dashboard_user1` branch hit any state other than "absent"
+
+3. **Builder writes review document** at `locard/reviews/0037-rds-role-rename.md` summarizing:
+   - Outage duration (actual vs estimated 3-10 min)
+   - All 6 AC items from spec verified
+   - Any changes made during execution (deviations from plan)
+   - Sign-off: builder + operator
+
+4. **Operator updates project status** in `locard/projectlist.md` from `planned` → `implementing` → `implemented` → `committed` → `integrated` as the work progresses.
+
+### Phase 5 Acceptance
+
+- PR merged to master.
+- `locard/reviews/0037-rds-role-rename.md` exists and is signed off.
+- `locard/projectlist.md` shows status `integrated` for project 0037.
+- (If applicable) `locard/resources/lessons-learned.md` has new entry.
+
+---
+
+## Open Items / Decisions
+
+1. **Maintenance window scheduling**: out of scope for the plan; operator picks based on operational calendar. Plan assumes the operator coordinates this independently.
+
+2. **Scratch-DB choice (Phase 3 step 2)**: Docker is faster but builder may prefer ephemeral RDS for closer fidelity. Either is acceptable as long as Phase 3 acceptance is met.
+
+3. **Narrative-prose footnotes (Phase 1 step 4)**: optional. Skip if time-constrained; can be a follow-up TICK.
+
+## Risks Inherited from Spec
+
+This plan does not introduce new risks beyond those documented in spec §"Risks & Mitigations". The plan's primary risk is **plan-execution divergence**: an operator deviating from the runbook without consulting the spec's decision tree. Mitigation: each step of the runbook explicitly cross-references the spec's failure-point decision tree.

--- a/locard/plans/0037-rds-role-rename.md
+++ b/locard/plans/0037-rds-role-rename.md
@@ -422,14 +422,52 @@ This plan does not introduce new risks beyond those documented in spec §"Risks 
 
 ## Consultation Log
 
-- **Codex (plan-review)**: REQUEST_CHANGES — 6 findings: (1) idempotency required only in prose runbook, not in helper SQL/scripts — added DO/IF EXISTS guards to every state-mutating SQL; (2) `dashboard_user1` HALT branch had only a comment in cutover-rename.sql — moved to its own file `0037-cutover-dashboard-user-drop.sql`; (3) parity-diff iterated vague "4 dimensions" — expanded to enumerate all 7 produced files (3 grants + 1 default ACL + 2 ownership + 1 memberships); (4) Phase 3 scratch DB pre-granted `rds_iam` not in spec AC #8 — removed; if a migration depends on `rds_iam`, surface it as a real bootstrap-script gap; (5) Phase 2 acceptance for pre-rename-checks.sql said "any Postgres ≥14 runs cleanly" but step 2 needs `rds_superuser` — distinguished privileged vs non-privileged execution context; (6) Phase 5 missing the spec's short-vs-extended source-tree rollback policy — added
-- **Gemini (plan-review)**: Rate-limited (API quota exhausted)
+### First Consultation (After Initial Draft)
+**Date**: 2026-05-10
+**Models Consulted**: Codex ✅ (Gemini unavailable — quota exhausted)
+**Commands**:
+```
+consult --model codex --type plan-review plan 0037
+consult --model gemini --type plan-review plan 0037   # 429
+```
 
-All findings addressed in revision 2.
+**Verdict**: REQUEST_CHANGES (Codex) — all findings addressed in v2
 
-- **Codex (red-team-plan)**: REQUEST_CHANGES — 5 findings: (1) HIGH: `0037-cutover-dashboard-user-drop.sql` checked memberships but not GRANTs — expanded to 3 defense-in-depth checks (zero non-`rds_iam` memberships, zero object-privilege grants across `information_schema.table_privileges`/`routine_privileges`/`usage_privileges`, zero owned objects); each RAISEs EXCEPTION with count if fails; (2) HIGH: smoke-test write path underspecified — named exact INSERT into `lava_pipeline.org_provenance` with EIN `ZZ-SMOKETEST-37` (invalid format so downstream code rejects even if rollback fails); (3) MEDIUM: snapshot scripts used single IAM_USER but `pg_default_acl` and `pg_class.relowner` require master/superuser — clarified scripts must connect as RDS master via password auth, not IAM; (4) MEDIUM: Phase 1 grep scope mismatched between step 2 (`migrations/+tests/`) and acceptance (`lavandula/` tree-wide) — aligned both; (5) MEDIUM: runbook self-containment — required `dashboard_user1` decision table, privileged-execution role choice, and smoke-test write path to be COPIED into the runbook, not pointers to spec
-- **Gemini (red-team-plan)**: Rate-limited (API quota exhausted)
+| Model  | Verdict          | Key Issues |
+|--------|------------------|------------|
+| Codex  | REQUEST_CHANGES  | Idempotency required only in prose runbook, not in helper SQL/scripts; `dashboard_user1` HALT branch only commented in cutover-rename.sql; parity-diff iterated vague "4 dimensions" rather than enumerating 7 produced files; Phase 3 scratch DB pre-granted `rds_iam` not in spec AC #8; Phase 2 acceptance for pre-rename-checks.sql claimed "any Postgres ≥14 runs cleanly" but step 2 needs `rds_superuser`; Phase 5 missing the spec's short-vs-extended source-tree rollback policy |
+| Gemini | (unavailable)    | API quota exhausted |
 
-Plan also added end-to-end helper-script exercise to Phase 3 (not just `bash -n` syntax checks) including double-run idempotency proof.
+### Red Team Security Review (MANDATORY)
+**Date**: 2026-05-10
+**Models Consulted**: Codex ✅ (Gemini unavailable — quota exhausted)
+**Commands**:
+```
+consult --model codex --type red-team-plan plan 0037
+consult --model gemini --type red-team-plan plan 0037  # 429
+```
 
-All findings addressed in revision 3.
+**Verdict**: REQUEST_CHANGES (Codex) — all findings addressed in v3
+
+| Model  | Verdict          | Key Issues |
+|--------|------------------|------------|
+| Codex  | REQUEST_CHANGES  | HIGH: `0037-cutover-dashboard-user-drop.sql` checked memberships but not GRANTs; HIGH: smoke-test write path underspecified (operator would improvise); MEDIUM: snapshot scripts used IAM_USER but `pg_default_acl` and `pg_class.relowner` require master/superuser; MEDIUM: Phase 1 grep scope mismatched between step 2 and acceptance; MEDIUM: runbook self-containment — too much referenced back to spec |
+| Gemini | (unavailable)    | API quota exhausted |
+
+### Changes in v2 (post plan-review)
+
+1. **Idempotency made explicit per script**: SQL uses `DO`/`IF EXISTS` guards; shell scripts overwrite snapshots cleanly; smoke test rolls back side effects.
+2. **`dashboard_user1` DROP path moved** from inline comment to its own file `0037-cutover-dashboard-user-drop.sql` with defense-in-depth re-check.
+3. **Parity-diff script now lists all 7 produced files explicitly** (4 dimensions split into: 3 grants + 1 default ACL + 2 ownership + 1 memberships).
+4. **Phase 3 scratch-DB validation**: removed `rds_iam` pre-grant. If a migration depends on `rds_iam`, surface that as a real bootstrap-script gap.
+5. **Phase 2 acceptance for pre-rename-checks.sql**: distinguished plain vs privileged execution context; no longer claims "any Postgres ≥14" runs all 4 query tiers cleanly.
+6. **Phase 5**: added explicit short-vs-extended rollback policy per spec §"Rollback Plan §Source-tree handling during rollback".
+
+### Changes in v3 (post red-team)
+
+1. **`0037-cutover-dashboard-user-drop.sql` now defends 3 conditions** before `DROP`: zero non-`rds_iam` memberships, zero object-privilege grants (table/routine/usage), zero owned objects. RAISEs with count if any check fails.
+2. **Smoke-test write path made concrete**: `BEGIN/INSERT/ROLLBACK` against `lava_pipeline.org_provenance` with EIN `ZZ-SMOKETEST-37` (invalid format, ignored by downstream code if rollback ever fails).
+3. **Snapshot scripts** (pre/post) now explicitly require master/super-user role, NOT IAM-tier roles. Reason: `pg_default_acl` and `pg_class.relowner` are masked for non-superuser; reading as `research_*` would silently miss privilege regressions.
+4. **Phase 1 grep scope** aligned with Phase 1 acceptance: `lavandula/` tree-wide, not just `migrations/`+`tests/`.
+5. **Runbook self-containment** requirement strengthened: `dashboard_user1` decision table, privileged-execution role choice, and smoke-test write path must be COPIED into the runbook (not pointers to spec).
+6. **Phase 3 adds end-to-end helper-script exercise** (not just `bash -n` syntax checks) including double-run idempotency proof.

--- a/locard/plans/0037-rds-role-rename.md
+++ b/locard/plans/0037-rds-role-rename.md
@@ -75,14 +75,23 @@ The builder's job is to (1) update 6 files where old role names are hardcoded, (
 **Files (new)**:
 - `locard/operations/0037-role-rename-runbook.md` — step-by-step T-1..T+6 procedure with exact commands, expected outputs, and decision points
 - `locard/operations/0037-pre-rename-checks.sql` — the four pre-check queries from spec §"Pre-rename checks"
-- `locard/operations/0037-snapshot-pre.sh` — bash script that runs the 4 snapshot queries and writes outputs to `/tmp/0037_*.before.txt`
+- `locard/operations/0037-snapshot-pre.sh` — bash script that runs the snapshot queries and writes outputs to `/tmp/0037_*.before.txt`
 - `locard/operations/0037-snapshot-post.sh` — same queries against post-rename DB; writes to `/tmp/0037_*.after.txt`
 - `locard/operations/0037-parity-diff.sh` — applies `sed 's/app_user1/research_app/g; s/ro_user1/research_ro/g'` to each `before` file and `diff`s against `after`; non-zero exit if any diff is non-empty
 - `locard/operations/0037-iam-policy-overlay.json` — the additive-overlap policy JSON for the EC2 instance profile (operator copies this into the AWS console at T-1)
 - `locard/operations/0037-iam-policy-final.json` — the post-cleanup policy with only the new ARNs (operator applies at T+6)
 - `locard/operations/0037-cutover-rename.sql` — the transactional rename
 - `locard/operations/0037-cutover-rollback.sql` — the symmetric reverse rename
+- `locard/operations/0037-cutover-dashboard-user-drop.sql` — conditional `DROP ROLE dashboard_user1;` for the vestigial branch (operator runs ONLY if pre-check directs DROP per spec §"dashboard_user1 decision rule")
 - `locard/operations/0037-smoke-test.sh` — runs the IAM-authenticated psql connect tests for both roles (T+4 and T+5)
+
+**Idempotency requirement for ALL scripts in this phase**: every script must be safe to re-run. Specifically:
+- Snapshot scripts: overwrite (don't append) any pre-existing `/tmp/0037_*.{before,after}.txt` so a re-run produces a clean snapshot. Print a one-line warning if previous output is overwritten.
+- Cutover SQL: each `ALTER ROLE` is wrapped in `DO $$ BEGIN IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'app_user1') THEN ALTER ROLE app_user1 RENAME TO research_app; END IF; END $$;` — re-running after a successful rename is a no-op, not an error.
+- Rollback SQL: symmetric — uses `IF EXISTS (... rolname = 'research_app')` guard.
+- DROP-dashboard-user SQL: `DO $$ BEGIN IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'dashboard_user1') THEN DROP ROLE dashboard_user1; END IF; END $$;`.
+- Smoke test: connect tests are inherently idempotent; just ensure they don't accumulate side-effects (write test creates and rolls back).
+- Parity diff: re-runnable; reads existing snapshots and reports.
 
 ### Implementation Steps
 
@@ -105,27 +114,83 @@ The builder's job is to (1) update 6 files where old role names are hardcoded, (
 
 4. **Write `0037-snapshot-post.sh`**: identical to `pre.sh` but writes `.after.txt` files. (Could be a single script with a CLI flag — builder's call.)
 
-5. **Write `0037-parity-diff.sh`**:
-   - For each of the 4 snapshot dimensions, apply `sed 's/app_user1/research_app/g; s/ro_user1/research_ro/g'` to the `.before.txt` file and `diff -u` against the `.after.txt` file
-   - Print PASS/FAIL per dimension
-   - Exit non-zero if ANY dimension diff is non-empty
-   - This script implements AC #6 from the spec (privilege parity, 4 dimensions)
+5. **Write `0037-parity-diff.sh`** — must cover ALL 7 produced files (4 dimensions, but ownership splits into objects+schemas and object-privileges splits across 3 schemas). The script iterates this exact list:
+
+   ```bash
+   FILES=(
+     grants_corpus           # dim 4a: object privileges, lava_corpus
+     grants_pipeline         # dim 4a: object privileges, lava_pipeline
+     grants_dashboard        # dim 4a: object privileges, lava_dashboard
+     default_acl             # dim 4b: pg_default_acl
+     ownership_objects       # dim 4c: pg_class
+     ownership_schemas       # dim 4c: pg_namespace
+     memberships             # dim 4d: pg_auth_members
+   )
+   for f in "${FILES[@]}"; do
+     sed 's/app_user1/research_app/g; s/ro_user1/research_ro/g' \
+       "/tmp/0037_${f}.before.txt" \
+       | diff -u - "/tmp/0037_${f}.after.txt"
+     if [[ $? -ne 0 ]]; then echo "FAIL: $f"; FAIL=1; fi
+   done
+   exit ${FAIL:-0}
+   ```
+   - Print `PASS: <name>` or `FAIL: <name>` per file.
+   - Exit non-zero if ANY file diff is non-empty.
+   - This script implements AC #6 from the spec (privilege parity across all 7 outputs).
 
 6. **Write `0037-iam-policy-overlay.json`**: a JSON IAM policy document with `Statement` containing `Action: rds-db:connect` and `Resource` listing all FOUR ARNs (old × 2 + new × 2). Operator applies this at T-1.
 
 7. **Write `0037-iam-policy-final.json`**: the post-cleanup version listing only the two new ARNs. Operator applies at T+6.
 
-8. **Write `0037-cutover-rename.sql`**:
+8. **Write `0037-cutover-rename.sql`** with idempotency guards:
    ```sql
    BEGIN;
-   ALTER ROLE app_user1 RENAME TO research_app;
-   ALTER ROLE ro_user1  RENAME TO research_ro;
-   -- dashboard_user1 branch: only if pre-check directs DROP. If RENAME branch
-   -- triggered, runbook HALTs — see spec §"dashboard_user1 decision rule".
+   DO $$ BEGIN
+     IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'app_user1') THEN
+       ALTER ROLE app_user1 RENAME TO research_app;
+     END IF;
+     IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'ro_user1') THEN
+       ALTER ROLE ro_user1 RENAME TO research_ro;
+     END IF;
+   END $$;
    COMMIT;
    ```
+   The `dashboard_user1` HALT branch is enforced in the runbook (operator stops if pre-check finds it with grants); this SQL file does NOT touch dashboard_user1. The DROP path lives in a separate file (step 8b below) so the operator runs it explicitly only when pre-check directs.
 
-9. **Write `0037-cutover-rollback.sql`**: the symmetric reverse, run only if rollback decision tree directs full rollback.
+8b. **Write `0037-cutover-dashboard-user-drop.sql`** — operator runs ONLY if pre-check determines `dashboard_user1` exists AND has zero GRANTs AND zero non-`rds_iam` memberships:
+   ```sql
+   DO $$ BEGIN
+     IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'dashboard_user1') THEN
+       -- Defense-in-depth re-check: confirm zero non-rds_iam memberships
+       -- before dropping. If any exist, raise — operator must HALT.
+       IF EXISTS (
+         SELECT 1 FROM pg_auth_members am
+         JOIN pg_roles r ON r.oid = am.member
+         JOIN pg_roles m ON m.oid = am.roleid
+         WHERE r.rolname = 'dashboard_user1' AND m.rolname <> 'rds_iam'
+       ) THEN
+         RAISE EXCEPTION 'dashboard_user1 has non-rds_iam memberships — '
+                         'HALT per spec §"dashboard_user1 decision rule"';
+       END IF;
+       DROP ROLE dashboard_user1;
+     END IF;
+   END $$;
+   ```
+
+9. **Write `0037-cutover-rollback.sql`** — symmetric reverse with idempotency guards:
+   ```sql
+   BEGIN;
+   DO $$ BEGIN
+     IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'research_app') THEN
+       ALTER ROLE research_app RENAME TO app_user1;
+     END IF;
+     IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'research_ro') THEN
+       ALTER ROLE research_ro RENAME TO ro_user1;
+     END IF;
+   END $$;
+   COMMIT;
+   ```
+   Run only if rollback decision tree directs full rollback (per spec §"Rollback Plan §Decision tree").
 
 10. **Write `0037-smoke-test.sh`**:
     - Generates IAM tokens for `research_app` and `research_ro`
@@ -137,11 +202,12 @@ The builder's job is to (1) update 6 files where old role names are hardcoded, (
 
 ### Phase 2 Acceptance
 
-- All 9 files created under `locard/operations/0037-*`.
+- All 10 files created under `locard/operations/0037-*` (the 9 originally listed plus `0037-cutover-dashboard-user-drop.sql`).
 - `bash -n locard/operations/*.sh` (syntax check) passes for each shell script.
-- `psql -f locard/operations/0037-pre-rename-checks.sql --set ON_ERROR_STOP=1` runs cleanly against any Postgres ≥14 (does not need RDS).
+- **Pre-rename-checks SQL caveat**: the file contains queries with two privilege tiers. Steps 1, 3, 4a, 4d run as any role (validate against plain Postgres ≥14). Steps 2, 4b, 4c require master/`rds_superuser` access; on plain Postgres they require running as the bootstrap superuser. Acceptance: `psql -v ON_ERROR_STOP=1 -f locard/operations/0037-pre-rename-checks.sql` against a fresh local Postgres run as `postgres` superuser must complete without error. (RDS execution at cutover time has the same effective privilege level.)
 - The runbook references each helper script by relative path; no orphan or broken references.
 - IAM policy JSONs validate against the AWS IAM policy schema (use `aws iam validate-policy-document` if available, otherwise manual review).
+- All 5 SQL/shell scripts that mutate state are demonstrably idempotent: re-running each one twice in succession against the same DB produces no error and no second-effect (verified in scratch DB).
 
 ---
 
@@ -167,9 +233,11 @@ The builder's job is to (1) update 6 files where old role names are hardcoded, (
    sleep 5
    psql "host=localhost port=5499 user=postgres dbname=postgres" \
      -c "CREATE DATABASE lava_test;"
+   # Spec AC #8 requires only CREATE ROLE — no rds_iam grant. If any
+   # migration depends on rds_iam membership, the migration fails here
+   # and that's a real bootstrap-script gap to surface.
    psql "host=localhost port=5499 user=postgres dbname=lava_test" \
-     -c "CREATE ROLE research_app; CREATE ROLE research_ro; CREATE ROLE rds_iam;
-         GRANT rds_iam TO research_app; GRANT rds_iam TO research_ro;"
+     -c "CREATE ROLE research_app; CREATE ROLE research_ro;"
    for f in lavandula/migrations/rds/{001,002,003,004,005,006,007,008,009,010,011,012,013,014}_*.sql; do
      psql "host=localhost port=5499 user=postgres dbname=lava_test" \
        -v ON_ERROR_STOP=1 -f "$f" \
@@ -177,7 +245,7 @@ The builder's job is to (1) update 6 files where old role names are hardcoded, (
    done
    docker stop pg37
    ```
-   All 14 migrations must apply successfully.
+   All 14 migrations must apply successfully. If a migration requires `rds_iam` (an AWS-RDS-only role that doesn't exist on plain Postgres), the builder records this as a bootstrap-script gap in the PR and adds `CREATE ROLE rds_iam;` to the scratch setup. Do not silently pre-grant — surface the issue.
 
 3. **Document results** in the PR description: paste the test summary lines and the migration loop's "all OK" output. The reviewer should be able to read the PR description and see all checks passed without re-running them.
 
@@ -227,21 +295,28 @@ If any step fails, consult spec §"Rollback Plan §Decision tree by failure poin
 
 ### Steps
 
-1. **Builder merges PR** after operator confirms Phase 4 acceptance. Ordering matters: live cutover MUST happen first, source-tree edits MUST be merged within the same maintenance window. If cutover succeeds but PR merge is delayed, source tree is correct but historical inconsistency persists — flag and merge ASAP.
+1. **Builder merges PR** after operator confirms Phase 4 acceptance. Ordering matters: live cutover MUST happen first, source-tree edits MUST be merged within the same maintenance window.
 
-2. **Builder writes lessons-learned entry** in `locard/resources/lessons-learned.md` if any deviations from the runbook occurred during cutover. Examples worth recording:
+2. **Source-tree handling on rollback** (per spec §"Rollback Plan §Source-tree handling during rollback"). If Phase 4 triggers full rollback, the builder applies one of two policies based on rollback duration:
+   - **Short rollback (<4 hours, retry scheduled in same maintenance window)**: leave PR/edits in place if already merged; merge if not yet merged. Runtime reads from SSM, so source-tree leading production is harmless during a brief window.
+   - **Extended rollback (overnight or longer, no retry scheduled)**: `git revert` the merged PR. Reason: a fresh-environment build (new dev EC2, new scratch DB) would create the new role names while production runs old names — silent divergence. Revert restores source-tree truth to match production.
+
+   The builder records which policy was applied and why in the cutover log.
+
+3. **Builder writes lessons-learned entry** in `locard/resources/lessons-learned.md` if any deviations from the runbook occurred during cutover. Examples worth recording:
    - IAM propagation took longer/shorter than expected
    - Connection drain required `pg_terminate_backend` (sessions didn't close cleanly)
    - Privilege-parity diff revealed unexpected differences (and how they were resolved)
    - `dashboard_user1` branch hit any state other than "absent"
+   - Scratch-DB migration validation surfaced a missing `rds_iam` dependency
 
-3. **Builder writes review document** at `locard/reviews/0037-rds-role-rename.md` summarizing:
+4. **Builder writes review document** at `locard/reviews/0037-rds-role-rename.md` summarizing:
    - Outage duration (actual vs estimated 3-10 min)
    - All 6 AC items from spec verified
    - Any changes made during execution (deviations from plan)
    - Sign-off: builder + operator
 
-4. **Operator updates project status** in `locard/projectlist.md` from `planned` → `implementing` → `implemented` → `committed` → `integrated` as the work progresses.
+5. **Operator updates project status** in `locard/projectlist.md` from `planned` → `implementing` → `implemented` → `committed` → `integrated` as the work progresses.
 
 ### Phase 5 Acceptance
 

--- a/locard/plans/0037-rds-role-rename.md
+++ b/locard/plans/0037-rds-role-rename.md
@@ -419,3 +419,17 @@ If any step fails, consult spec §"Rollback Plan §Decision tree by failure poin
 ## Risks Inherited from Spec
 
 This plan does not introduce new risks beyond those documented in spec §"Risks & Mitigations". The plan's primary risk is **plan-execution divergence**: an operator deviating from the runbook without consulting the spec's decision tree. Mitigation: each step of the runbook explicitly cross-references the spec's failure-point decision tree.
+
+## Consultation Log
+
+- **Codex (plan-review)**: REQUEST_CHANGES — 6 findings: (1) idempotency required only in prose runbook, not in helper SQL/scripts — added DO/IF EXISTS guards to every state-mutating SQL; (2) `dashboard_user1` HALT branch had only a comment in cutover-rename.sql — moved to its own file `0037-cutover-dashboard-user-drop.sql`; (3) parity-diff iterated vague "4 dimensions" — expanded to enumerate all 7 produced files (3 grants + 1 default ACL + 2 ownership + 1 memberships); (4) Phase 3 scratch DB pre-granted `rds_iam` not in spec AC #8 — removed; if a migration depends on `rds_iam`, surface it as a real bootstrap-script gap; (5) Phase 2 acceptance for pre-rename-checks.sql said "any Postgres ≥14 runs cleanly" but step 2 needs `rds_superuser` — distinguished privileged vs non-privileged execution context; (6) Phase 5 missing the spec's short-vs-extended source-tree rollback policy — added
+- **Gemini (plan-review)**: Rate-limited (API quota exhausted)
+
+All findings addressed in revision 2.
+
+- **Codex (red-team-plan)**: REQUEST_CHANGES — 5 findings: (1) HIGH: `0037-cutover-dashboard-user-drop.sql` checked memberships but not GRANTs — expanded to 3 defense-in-depth checks (zero non-`rds_iam` memberships, zero object-privilege grants across `information_schema.table_privileges`/`routine_privileges`/`usage_privileges`, zero owned objects); each RAISEs EXCEPTION with count if fails; (2) HIGH: smoke-test write path underspecified — named exact INSERT into `lava_pipeline.org_provenance` with EIN `ZZ-SMOKETEST-37` (invalid format so downstream code rejects even if rollback fails); (3) MEDIUM: snapshot scripts used single IAM_USER but `pg_default_acl` and `pg_class.relowner` require master/superuser — clarified scripts must connect as RDS master via password auth, not IAM; (4) MEDIUM: Phase 1 grep scope mismatched between step 2 (`migrations/+tests/`) and acceptance (`lavandula/` tree-wide) — aligned both; (5) MEDIUM: runbook self-containment — required `dashboard_user1` decision table, privileged-execution role choice, and smoke-test write path to be COPIED into the runbook, not pointers to spec
+- **Gemini (red-team-plan)**: Rate-limited (API quota exhausted)
+
+Plan also added end-to-end helper-script exercise to Phase 3 (not just `bash -n` syntax checks) including double-run idempotency proof.
+
+All findings addressed in revision 3.

--- a/locard/projectlist.md
+++ b/locard/projectlist.md
@@ -581,15 +581,15 @@ projects:
   - id: "0037"
     title: "Rename RDS Roles to Project-Prefixed Names"
     summary: "Rename app_user1/ro_user1 to research_app/research_ro on shared RDS so a second project can coexist without role-name collisions. SSM keys (rds-app-user, rds-ro-user) stay stable; only values change."
-    status: conceived
+    status: implementing
     priority: medium
     files:
       spec: locard/specs/0037-rds-role-rename.md
-      plan: null
+      plan: locard/plans/0037-rds-role-rename.md
       review: null
     dependencies: []
     tags: [rds, iam, multi-tenant, ops]
-    notes: "Motivated by adding a second project to the shared RDS instance. Prefix decision: research (operator-confirmed 2026-05-10). Schemas keep lava_* names (already namespaced). 6 source files require edits (4 SQL migrations + 2 test files). Code uses SSM indirection for usernames, so settings.py and db.py are untouched. Requires coordinated dashboard/workers restart and IAM policy update for rds-db:connect resource ARNs."
+    notes: "Motivated by adding a second project to the shared RDS instance. Prefix decision: research (operator-confirmed 2026-05-10). Spec + plan approved 2026-05-11. Builder spawned to handle Phases 1-3 (source-tree edits, runbook+helper scripts, scratch-DB validation). Phase 4 (live cutover) is operator-only. Schemas keep lava_* names (already namespaced)."
 
 ## Next Available Number
 

--- a/locard/projectlist.md
+++ b/locard/projectlist.md
@@ -580,7 +580,7 @@ projects:
 
   - id: "0037"
     title: "Rename RDS Roles to Project-Prefixed Names"
-    summary: "Rename app_user1/ro_user1 to lavandula_app/lavandula_ro on shared RDS so a second project can coexist without role-name collisions. SSM keys (rds-app-user, rds-ro-user) stay stable; only values change."
+    summary: "Rename app_user1/ro_user1 to research_app/research_ro on shared RDS so a second project can coexist without role-name collisions. SSM keys (rds-app-user, rds-ro-user) stay stable; only values change."
     status: conceived
     priority: medium
     files:
@@ -589,7 +589,7 @@ projects:
       review: null
     dependencies: []
     tags: [rds, iam, multi-tenant, ops]
-    notes: "Motivated by adding a second project to the shared RDS instance. Schemas keep lava_* names (already namespaced). 6 source files require edits (4 SQL migrations + 2 test files). Code uses SSM indirection for usernames, so settings.py and db.py are untouched. Requires coordinated dashboard/workers restart and IAM policy update for rds-db:connect resource ARNs."
+    notes: "Motivated by adding a second project to the shared RDS instance. Prefix decision: research (operator-confirmed 2026-05-10). Schemas keep lava_* names (already namespaced). 6 source files require edits (4 SQL migrations + 2 test files). Code uses SSM indirection for usernames, so settings.py and db.py are untouched. Requires coordinated dashboard/workers restart and IAM policy update for rds-db:connect resource ARNs."
 
 ## Next Available Number
 

--- a/locard/projectlist.md
+++ b/locard/projectlist.md
@@ -578,9 +578,22 @@ projects:
     tags: [reliability, crawler, pipeline, observability, ses-notification]
     notes: "Motivated by 2026-05-08/09 deadlock incidents: VA crawler stalled 2h at 38/2935, WA crawler stalled 5h at 699/2137. PR #31 merged 2026-05-09. 47 tests, +2618/-131. Includes SES email alerts, dashboard Job updates, pre_abort cleanup hooks. Set WATCHDOG_NOTIFY_EMAIL env var to enable email alerts."
 
+  - id: "0037"
+    title: "Rename RDS Roles to Project-Prefixed Names"
+    summary: "Rename app_user1/ro_user1 to lavandula_app/lavandula_ro on shared RDS so a second project can coexist without role-name collisions. SSM keys (rds-app-user, rds-ro-user) stay stable; only values change."
+    status: conceived
+    priority: medium
+    files:
+      spec: locard/specs/0037-rds-role-rename.md
+      plan: null
+      review: null
+    dependencies: []
+    tags: [rds, iam, multi-tenant, ops]
+    notes: "Motivated by adding a second project to the shared RDS instance. Schemas keep lava_* names (already namespaced). 6 source files require edits (4 SQL migrations + 2 test files). Code uses SSM indirection for usernames, so settings.py and db.py are untouched. Requires coordinated dashboard/workers restart and IAM policy update for rds-db:connect resource ARNs."
+
 ## Next Available Number
 
-**0037** - Reserve this number for your next project
+**0038** - Reserve this number for your next project
 
 ---
 

--- a/locard/specs/0037-rds-role-rename.md
+++ b/locard/specs/0037-rds-role-rename.md
@@ -107,14 +107,17 @@ The numeric `1` suffix is dropped — it implied a sequence (`app_user2`?) that 
 
 ### Pre-rename checks (operator runs before any change)
 
+**Operator privilege assumption.** Steps 1, 3, 4 below run as any role with `rds_iam` access. Step 2 reads `pg_authid` and requires the RDS instance master role (the one created at instance provisioning) or a member of `rds_superuser`. If the operator does not have that access, **skip step 2** — IAM auth does not use stored passwords, so password algorithm is informational only. Mark the skip in the runbook log.
+
 ```sql
--- 1. Confirm no dashboard_user1 exists. If it does, decide whether to drop it
---    (likely vestigial) or rename it consistent with the others.
+-- 1. Determine the universe of roles to act on. dashboard_user1 may or may
+--    not exist; behavior branches below based on what this query returns.
 SELECT rolname FROM pg_roles WHERE rolname IN ('app_user1','ro_user1','dashboard_user1');
 
--- 2. Confirm SCRAM password encryption (rename invalidates MD5-hashed passwords
---    because MD5 includes the username; SCRAM is unaffected). IAM auth doesn't
---    use stored passwords, but if any fallback password ever was set this matters.
+-- 2. (OPTIONAL — requires master/rds_superuser) Confirm SCRAM password
+--    encryption. Rename invalidates MD5-hashed passwords (MD5 includes the
+--    username); SCRAM is unaffected. IAM auth doesn't use stored passwords,
+--    so this check is purely informational.
 SELECT rolname,
        CASE
          WHEN rolpassword IS NULL THEN '(no stored password — IAM-only)'
@@ -123,61 +126,133 @@ SELECT rolname,
          ELSE 'unknown'
        END AS password_status
 FROM pg_authid
-WHERE rolname IN ('app_user1','ro_user1');
+WHERE rolname IN ('app_user1','ro_user1','dashboard_user1');
 
 -- 3. Confirm rds_iam membership (must follow the rename automatically).
 SELECT r.rolname, m.rolname AS member_of
 FROM pg_roles r JOIN pg_auth_members am ON r.oid = am.member
 JOIN pg_roles m ON am.roleid = m.oid
-WHERE r.rolname IN ('app_user1','ro_user1') AND m.rolname = 'rds_iam';
+WHERE r.rolname IN ('app_user1','ro_user1','dashboard_user1') AND m.rolname = 'rds_iam';
 
--- 4. Snapshot grants (for post-rename verification).
-\dp lava_corpus.*
-\dp lava_pipeline.*
-\dp lava_dashboard.*
+-- 4. Snapshot grants AND memberships (for post-rename verification).
+--    Save the output of each to a file; compare post-rename diffs must show
+--    only role-name substitutions, never added/removed privileges.
+\dp lava_corpus.*           > /tmp/grants_corpus.before.txt
+\dp lava_pipeline.*         > /tmp/grants_pipeline.before.txt
+\dp lava_dashboard.*        > /tmp/grants_dashboard.before.txt
+SELECT r.rolname, m.rolname AS member_of
+FROM pg_roles r JOIN pg_auth_members am ON r.oid = am.member
+JOIN pg_roles m ON am.roleid = m.oid
+WHERE r.rolname IN ('app_user1','ro_user1','dashboard_user1')
+ORDER BY r.rolname, m.rolname; -- > /tmp/memberships.before.txt
 ```
 
-### Cutover sequence (operator-coordinated)
+### `dashboard_user1` decision rule (concrete, executed at pre-check time)
+
+The query in step 1 returns one of three states. The runbook acts on the result without further deliberation:
+
+| Step 1 returns | Action |
+|---|---|
+| Only `app_user1, ro_user1` | **Skip dashboard_user1 entirely.** Do not create, drop, or rename. Confirms the inventory finding. |
+| Includes `dashboard_user1` AND it has GRANTs in step 4 snapshots | **Rename:** `ALTER ROLE dashboard_user1 RENAME TO lavandula_dashboard;` Add to SSM as `rds-dashboard-user` (new key) and update IAM resource ARN. **This expands scope** — operator must explicitly approve this branch before proceeding. |
+| Includes `dashboard_user1` BUT it has zero GRANTs and zero memberships beyond `rds_iam` | **Drop:** `DROP ROLE dashboard_user1;` (vestigial — confirmed unused in code inventory). |
+
+The runbook records which branch was taken in its execution log.
+
+### Cutover sequence (operator-coordinated, idempotent)
+
+Each step has an explicit precondition check. If the precondition shows the step is already done, the step is a no-op. If it shows mixed state, the runbook halts with a clear diagnostic — the operator must investigate, not auto-proceed.
 
 ```
-T+0   Stop: dashboard (systemctl stop lavandula-dashboard)
+T-1   IAM ADDITIVE OVERLAP (do this BEFORE the outage window).
+      Edit the EC2 instance-profile policy to ALLOW BOTH old and new ARNs:
+        arn:aws:rds-db:us-east-1:ACCT:dbuser/DB-RES-ID/app_user1
+        arn:aws:rds-db:us-east-1:ACCT:dbuser/DB-RES-ID/ro_user1
+        arn:aws:rds-db:us-east-1:ACCT:dbuser/DB-RES-ID/lavandula_app   ← new
+        arn:aws:rds-db:us-east-1:ACCT:dbuser/DB-RES-ID/lavandula_ro    ← new
+      Wait ≥5 minutes for IAM propagation.
+      Verify: aws sts get-caller-identity (confirm role)
+              aws iam simulate-principal-policy ...
+              (or generate-db-auth-token --db-user lavandula_app and confirm
+               token is issued — this only checks IAM, not the role exists yet)
+      This step is reversible at any time by removing the new ARNs again.
+
+T+0   PRECONDITION: confirm rename has not already happened.
+        SELECT rolname FROM pg_roles
+        WHERE rolname IN ('app_user1','ro_user1','lavandula_app','lavandula_ro');
+      Expected: ('app_user1','ro_user1') only. If 'lavandula_app' present,
+      jump to T+2 (rename already done). If both pairs present, HALT — mixed
+      state requires manual investigation.
+
+      Stop: dashboard (systemctl stop lavandula-dashboard)
       Stop: any running CLI processes (crawler, classifier, etc.) — confirm
             via `ps -ef | grep python3` and `af status`.
-      Confirm no active connections held by app_user1/ro_user1:
-            SELECT pid, usename, state FROM pg_stat_activity
-            WHERE usename IN ('app_user1','ro_user1');
+      Wait 30 seconds for connections to drain naturally.
+      Forcibly terminate any sessions still owned by the old roles:
+        SELECT pg_terminate_backend(pid)
+        FROM pg_stat_activity
+        WHERE usename IN ('app_user1','ro_user1')
+          AND pid <> pg_backend_pid();
+      Re-check pg_stat_activity is clean before proceeding.
 
-T+1   ALTER ROLE app_user1 RENAME TO lavandula_app;
-      ALTER ROLE ro_user1  RENAME TO lavandula_ro;
+T+1   PRECONDITION: app_user1 and ro_user1 still exist (from T+0 query).
+      Execute rename in a single transaction:
+        BEGIN;
+        ALTER ROLE app_user1 RENAME TO lavandula_app;
+        ALTER ROLE ro_user1  RENAME TO lavandula_ro;
+        -- (conditional, if dashboard_user1 branch chosen at pre-check)
+        -- ALTER ROLE dashboard_user1 RENAME TO lavandula_dashboard;
+        -- OR
+        -- DROP ROLE dashboard_user1;
+        COMMIT;
+      Verify:
+        SELECT rolname FROM pg_roles WHERE rolname LIKE 'lavandula\_%' ESCAPE '\';
 
-T+2   Update SSM values:
-        aws ssm put-parameter --name /cloud2.lavandulagroup.com/rds-app-user \
+T+2   PRECONDITION: read SSM current values; if already lavandula_*, skip.
+        OLD_APP=$(aws ssm get-parameter --name /cloud2.lavandulagroup.com/rds-app-user --with-decryption --query Parameter.Value --output text)
+        if [[ "$OLD_APP" != "lavandula_app" ]]; then
+          aws ssm put-parameter --name /cloud2.lavandulagroup.com/rds-app-user \
             --type SecureString --value lavandula_app --overwrite
-        aws ssm put-parameter --name /cloud2.lavandulagroup.com/rds-ro-user \
-            --type SecureString --value lavandula_ro  --overwrite
+        fi
+      Same for rds-ro-user.
 
-T+3   Update IAM policy on EC2 instance profile (cloud2_lavandulagroup):
-        Replace resource ARN suffixes:
-          arn:aws:rds-db:us-east-1:ACCT:dbuser/DB-RES-ID/app_user1
-          arn:aws:rds-db:us-east-1:ACCT:dbuser/DB-RES-ID/ro_user1
-        with:
-          arn:aws:rds-db:us-east-1:ACCT:dbuser/DB-RES-ID/lavandula_app
-          arn:aws:rds-db:us-east-1:ACCT:dbuser/DB-RES-ID/lavandula_ro
-      IAM propagation is typically <1min but can be up to ~5min.
+T+3   No action — additive overlap was applied at T-1.
+      (Old ARNs remain; they will be removed at T+6.)
 
-T+4   Start: dashboard (systemctl start lavandula-dashboard)
-      Watch journalctl -u lavandula-dashboard -f for connect errors.
-      Hit /healthz (or equivalent) to confirm DB connectivity.
+T+4   PRECONDITION: psql connect test as the new roles works (see T+5 below).
+      Start: dashboard (systemctl start lavandula-dashboard)
+      Watch: journalctl -u lavandula-dashboard -f
+      Wait up to 60s; if first connection fails with auth error, this is most
+      likely IAM propagation lag — see Rollback Plan §"Decision tree".
+      Hit a health endpoint to confirm DB connectivity.
 
-T+5   Smoke tests:
+T+5   Smoke tests (each must pass before T+6):
         - Dashboard home page loads
         - One read query (org list)
-        - One write query (e.g., create a noop Job, then cancel it)
-        - psql as lavandula_ro: SELECT 1 FROM lava_corpus.corpus LIMIT 1
-        - psql as lavandula_app: same query
+        - One write query (create a noop Job, then cancel it)
+        - psql via IAM token as lavandula_ro: SELECT 1 FROM lava_corpus.corpus LIMIT 1
+        - psql via IAM token as lavandula_app: same query
+
+T+6   POST-CUTOVER CLEANUP (do this AFTER ≥30 minutes of stable operation).
+      Remove old ARNs from the IAM policy:
+        DELETE arn:aws:rds-db:...:dbuser/DB-RES-ID/app_user1
+        DELETE arn:aws:rds-db:...:dbuser/DB-RES-ID/ro_user1
+      Verify: an attempt to generate an IAM token for app_user1 should still
+      succeed (token generation is local), but actual rds-db:connect with
+      the old ARN must be denied.
+      Source-tree edits committed; PR merged.
 ```
 
-Estimated outage: 3–10 minutes including verification.
+Estimated outage window (T+0 through T+5): **3–10 minutes**.
+Total elapsed including IAM warm-up (T-1) and cleanup (T+6): hours, but only the cutover window is service-impacting.
+
+### Why additive IAM overlap
+
+An at-once swap of IAM resource ARNs creates a window where:
+- The role is renamed (T+1) but the IAM policy still allows only the OLD name → all new connections fail until T+3 propagates.
+- IAM propagation is non-deterministic (typically <1min, occasionally up to several minutes).
+
+Additive overlap eliminates the IAM-propagation race entirely: at T-1 the policy allows BOTH names, and IAM is given as much time as the operator wants to settle. The actual cutover window only depends on PG (instant) and SSM (instant). At T+6, the now-orphan old ARNs are removed cleanly.
 
 ### Source-tree edits (committed in same PR as the runbook)
 
@@ -231,22 +306,50 @@ The work is complete when ALL of the following hold:
 
 1. `\du` on RDS shows `lavandula_app` and `lavandula_ro`; no role named `app_user1` or `ro_user1` exists.
 2. SSM parameter `/cloud2.lavandulagroup.com/rds-app-user` returns `lavandula_app`; `rds-ro-user` returns `lavandula_ro`.
-3. EC2 instance profile IAM policy `rds-db:connect` resource ARNs reference `lavandula_app` and `lavandula_ro` (no references to `app_user1` or `ro_user1` remain).
+3. EC2 instance profile IAM policy `rds-db:connect` resource ARNs reference `lavandula_app` and `lavandula_ro`. Old ARNs (`.../app_user1`, `.../ro_user1`) have been removed at T+6 (no overlap remains in steady state).
 4. Dashboard is running and serving requests; `/orgs/`, `/jobs/`, and at least one write endpoint succeed.
 5. Direct psql connect as `lavandula_ro` and `lavandula_app` (via IAM token) both succeed.
-6. Each grant snapshot taken pre-rename matches the post-rename grant snapshot, with only the role name differing. (i.e., no privilege regression.)
+6. **Privilege parity (no regression).** The pre-rename grant snapshots (§"Pre-rename checks" step 4) compared against post-rename snapshots show ONLY role-name substitutions — no added, removed, or modified privileges, and no added or removed role memberships. A `diff` of the two snapshot sets, after sed-substituting the old names for the new, must be empty.
 7. The 6 source files in §"Code Changes" have zero remaining `app_user1` or `ro_user1` references (verified by `grep -rn`).
-8. Full test suite passes in the PR (no hidden references).
-9. Runbook `locard/operations/0037-role-rename-runbook.md` is committed.
+8. **Targeted test verification** (NOT full suite — narrowed per-Codex feedback). The following must pass:
+   - `pytest lavandula/common/tests/unit/test_db_adapter_0013.py` (touched fixtures + assertions).
+   - `pytest lavandula/common/tests/conftest.py`-using tests in `lavandula/common/tests/` (fixture validity).
+   - **Bootstrap + migration validation:** Against a scratch Postgres (local or ephemeral RDS), manually `CREATE ROLE lavandula_app; CREATE ROLE lavandula_ro;` then run all 14 migrations in order to completion. Confirms the SQL files reference the new names consistently.
+9. Runbook `locard/operations/0037-role-rename-runbook.md` is committed alongside the source-tree PR.
 10. Lessons-learned added to `locard/resources/lessons-learned.md` if anything unexpected was hit during cutover.
 
 ## Rollback Plan
 
-If at any step T+1 through T+5 something fails, rollback is symmetric:
+### Decision tree by failure point
+
+The right action depends on WHERE the failure happened. Rollback is symmetric but is not always the best first move — sometimes waiting or retrying is correct.
+
+| Failure point | First action | If first action fails |
+|---|---|---|
+| **T-1** IAM additive overlap fails to apply | Investigate IAM permission. The old policy is unchanged; no service impact. No rollback needed. | Abort cutover; reschedule. |
+| **T+0** Cannot stop services or terminate sessions cleanly | Diagnose stuck process; do not proceed to T+1 with active old-name connections. The rename works but cached usernames cause silent issues post-restart. | Abort cutover; reschedule. |
+| **T+1** `ALTER ROLE` fails (lock, permission, role-not-found) | Read the error. If "role does not exist" — rename already happened (idempotent re-run). If "is being used" — drain again, retry. If permission denied — abort, escalate. No rollback needed at this point because nothing was renamed. | Abort. No rollback needed. |
+| **T+1** Both renames succeed but transaction commit fails (extremely rare) | Re-check `pg_roles`. PG renames are atomic within the transaction. | If renames partially applied, manually `ALTER ROLE … RENAME TO …` to converge. |
+| **T+2** SSM `put-parameter` fails | Retry up to 3 times. If still failing, revert via `ALTER ROLE … RENAME TO app_user1` etc. so the system is consistent (old name everywhere). | Full rollback (rename back, no SSM change since none succeeded). |
+| **T+4** Dashboard fails to start with auth error | Check journalctl for specifics. Most common cause: IAM propagation lag (despite T-1 warm-up, edge case). **Wait 5 minutes, retry start.** If still failing after 10 minutes, run a manual `aws rds generate-db-auth-token --db-user lavandula_app` + `psql` to isolate. | If isolated to IAM/role: full rollback. If isolated to dashboard config: investigate code; revert role rename only if dashboard issue cannot be diagnosed quickly. |
+| **T+5** Smoke test fails on read query | Likely IAM/grant issue. Compare pre/post grant snapshots (AC #6). If snapshots match, IAM propagation issue — wait 5min and retry. | Full rollback. |
+| **T+5** Smoke test fails on write query but read succeeds | Targeted GRANT regression — investigate `\dp` on the affected table. Should not happen if AC #6 passes. | Full rollback. |
+
+### Full-rollback procedure
 
 ```sql
+-- Stop services first (same as T+0)
+systemctl stop lavandula-dashboard
+-- Drain leftover sessions
+SELECT pg_terminate_backend(pid)
+FROM pg_stat_activity
+WHERE usename IN ('lavandula_app','lavandula_ro')
+  AND pid <> pg_backend_pid();
+-- Reverse rename
+BEGIN;
 ALTER ROLE lavandula_app RENAME TO app_user1;
 ALTER ROLE lavandula_ro  RENAME TO ro_user1;
+COMMIT;
 ```
 
 ```bash
@@ -254,19 +357,20 @@ aws ssm put-parameter --name /cloud2.lavandulagroup.com/rds-app-user \
     --type SecureString --value app_user1 --overwrite
 aws ssm put-parameter --name /cloud2.lavandulagroup.com/rds-ro-user \
     --type SecureString --value ro_user1  --overwrite
+systemctl start lavandula-dashboard
 ```
 
-IAM policy: revert the resource ARN edit (keep the prior version cached locally before the change).
+IAM policy stays in additive-overlap state during rollback (both old and new ARNs allowed) — no IAM action needed for rollback. Old ARNs continue to authorize, which is what we want.
 
-Restart dashboard. Total rollback time: ~3 minutes.
+Source-tree edits: leave in (they're forward-only and don't break the live system) OR `git revert` if the PR has merged. Prefer leaving them — they document the intent and a future re-attempt only needs the cutover, not new edits.
 
-The source-tree edits can stay in (they are forward-only and don't break anything operationally) or be reverted via `git revert` of the PR — whichever is cleaner given where the rollback was triggered.
+Total rollback time: ~3 minutes from decision-to-rollback to dashboard-back-up.
 
 ## Open Questions / Decisions
 
-1. **Prefix value.** Recommended: `lavandula`. Alternative: `lava` (matches schema prefix exactly). Operator decides at spec approval. *(Affects all 6 source-file edits and the SSM values.)*
+1. **Prefix value (BLOCKING — must be resolved before approval).** Recommended: `lavandula`. Alternative: `lava` (matches schema prefix exactly). Operator decides at spec approval. This affects every source-file edit, every SSM value, every IAM ARN, and the runbook. **No builder work begins until the operator picks one.** Throughout this spec, `lavandula_*` is used as the placeholder; if the operator picks `lava_*`, the spec is updated globally before plan-writing begins.
 
-2. **Vestigial `dashboard_user1`.** If `\du` shows it exists, decide: drop it (`DROP ROLE`) or rename it for symmetry (`lavandula_dashboard`)? Recommend **drop** if it has no GRANTs and no `pg_authid.rolconfig` entries. *(Pre-rename check answers this.)*
+2. **Vestigial `dashboard_user1` — RESOLVED.** Decision rule is now concrete (§"`dashboard_user1` decision rule"). The pre-check answers it deterministically: if absent, no-op; if present without grants, drop; if present with grants, rename and expand scope (operator approval required for that branch).
 
 3. **Source-tree edits in same PR or separate?** Recommend **same PR** so the source tree never disagrees with the live database for more than the cutover window. The PR merges *after* the live cutover (so reviewers can see the runbook executed cleanly).
 

--- a/locard/specs/0037-rds-role-rename.md
+++ b/locard/specs/0037-rds-role-rename.md
@@ -101,7 +101,7 @@ The `lava_*` prefix already namespaces the schemas. The collision risk is on rol
 
 The numeric `1` suffix is dropped — it implied a sequence (`app_user2`?) that never existed.
 
-**Decision pending:** Operator confirms `lavandula` as the prefix at spec-approval time. Alternative: `lava` (matches the schemas exactly but loses the package-name match). Recommendation: `lavandula`.
+**Prefix decision:** `lavandula` (final — see Open Questions §1). Operator can veto at spec approval and trigger a global rename of the spec.
 
 ## Migration Strategy
 
@@ -134,12 +134,39 @@ FROM pg_roles r JOIN pg_auth_members am ON r.oid = am.member
 JOIN pg_roles m ON am.roleid = m.oid
 WHERE r.rolname IN ('app_user1','ro_user1','dashboard_user1') AND m.rolname = 'rds_iam';
 
--- 4. Snapshot grants AND memberships (for post-rename verification).
---    Save the output of each to a file; compare post-rename diffs must show
---    only role-name substitutions, never added/removed privileges.
+-- 4a. Object-privilege snapshot (covers GRANT statements, not default ACLs).
+--     Save each output; compare post-rename diffs must show only role-name
+--     substitutions, never added/removed privileges.
 \dp lava_corpus.*           > /tmp/grants_corpus.before.txt
 \dp lava_pipeline.*         > /tmp/grants_pipeline.before.txt
 \dp lava_dashboard.*        > /tmp/grants_dashboard.before.txt
+
+-- 4b. Default-ACL snapshot (covers ALTER DEFAULT PRIVILEGES — these
+--     determine what GRANTs are auto-applied to FUTURE objects). \dp does
+--     NOT show default ACLs; they live in pg_default_acl.
+SELECT n.nspname, r.rolname AS grantor, d.defaclobjtype, d.defaclacl
+FROM pg_default_acl d
+LEFT JOIN pg_namespace n ON d.defaclnamespace = n.oid
+JOIN pg_roles r ON d.defaclrole = r.oid
+WHERE n.nspname IN ('lava_corpus','lava_pipeline','lava_dashboard')
+   OR n.nspname IS NULL
+ORDER BY n.nspname, defaclobjtype; -- > /tmp/default_acl.before.txt
+
+-- 4c. Ownership snapshot (tables, views, sequences, schemas).
+--     ALTER ROLE … RENAME TO … should preserve ownership by OID, but verify.
+SELECT n.nspname, c.relname, c.relkind, r.rolname AS owner
+FROM pg_class c
+JOIN pg_namespace n ON c.relnamespace = n.oid
+JOIN pg_roles r ON c.relowner = r.oid
+WHERE n.nspname IN ('lava_corpus','lava_pipeline','lava_dashboard')
+ORDER BY n.nspname, c.relname; -- > /tmp/ownership_objects.before.txt
+
+SELECT n.nspname, r.rolname AS owner
+FROM pg_namespace n JOIN pg_roles r ON n.nspowner = r.oid
+WHERE n.nspname IN ('lava_corpus','lava_pipeline','lava_dashboard')
+ORDER BY n.nspname; -- > /tmp/ownership_schemas.before.txt
+
+-- 4d. Membership snapshot.
 SELECT r.rolname, m.rolname AS member_of
 FROM pg_roles r JOIN pg_auth_members am ON r.oid = am.member
 JOIN pg_roles m ON am.roleid = m.oid
@@ -153,9 +180,9 @@ The query in step 1 returns one of three states. The runbook acts on the result 
 
 | Step 1 returns | Action |
 |---|---|
-| Only `app_user1, ro_user1` | **Skip dashboard_user1 entirely.** Do not create, drop, or rename. Confirms the inventory finding. |
-| Includes `dashboard_user1` AND it has GRANTs in step 4 snapshots | **Rename:** `ALTER ROLE dashboard_user1 RENAME TO lavandula_dashboard;` Add to SSM as `rds-dashboard-user` (new key) and update IAM resource ARN. **This expands scope** — operator must explicitly approve this branch before proceeding. |
-| Includes `dashboard_user1` BUT it has zero GRANTs and zero memberships beyond `rds_iam` | **Drop:** `DROP ROLE dashboard_user1;` (vestigial — confirmed unused in code inventory). |
+| Only `app_user1, ro_user1` | **Skip dashboard_user1 entirely.** Do not create, drop, or rename. Confirms the inventory finding. This is the expected case. |
+| Includes `dashboard_user1` BUT it has zero GRANTs (per pre-check step 4) and zero memberships beyond `rds_iam` (per pre-check step 3) | **Drop:** `DROP ROLE dashboard_user1;` (vestigial — confirmed unused in code inventory). |
+| Includes `dashboard_user1` AND it has GRANTs OR non-`rds_iam` memberships | **HALT.** This is out of scope for Spec 0037 — the rename branch would require introducing a new SSM key (`rds-dashboard-user`) and a new consumer in code, which contradicts the "zero production-code change" goal. The operator records the finding and writes a follow-up spec (Spec 0038+) to address it. The Spec 0037 cutover does NOT proceed in this state. |
 
 The runbook records which branch was taken in its execution log.
 
@@ -171,10 +198,19 @@ T-1   IAM ADDITIVE OVERLAP (do this BEFORE the outage window).
         arn:aws:rds-db:us-east-1:ACCT:dbuser/DB-RES-ID/lavandula_app   ← new
         arn:aws:rds-db:us-east-1:ACCT:dbuser/DB-RES-ID/lavandula_ro    ← new
       Wait ≥5 minutes for IAM propagation.
-      Verify: aws sts get-caller-identity (confirm role)
-              aws iam simulate-principal-policy ...
-              (or generate-db-auth-token --db-user lavandula_app and confirm
-               token is issued — this only checks IAM, not the role exists yet)
+      Verify by ATTEMPTING ACTUAL CONNECT (not just token generation):
+        # The new role doesn't exist yet, so the connect should fail with
+        # "role lavandula_app does not exist" — this is the desired result.
+        # It proves IAM is allowing the rds-db:connect call through (otherwise
+        # we'd see "PAM authentication failed for user lavandula_app").
+        TOK=$(aws rds generate-db-auth-token --hostname $RDS_ENDPOINT \
+              --port 5432 --username lavandula_app --region us-east-1)
+        PGPASSWORD="$TOK" psql -h $RDS_ENDPOINT -U lavandula_app -d $DB \
+          --set=sslmode=require -c "SELECT 1" 2>&1 | tee /tmp/iam_warmup.log
+        # Expected output contains "role \"lavandula_app\" does not exist".
+        # If output contains "PAM authentication failed" or "permission denied
+        # to use this connection method", IAM has not propagated yet — wait
+        # another 2 min and retry. Do NOT proceed to T+0 until this confirms.
       This step is reversible at any time by removing the new ARNs again.
 
 T+0   PRECONDITION: confirm rename has not already happened.
@@ -219,7 +255,20 @@ T+2   PRECONDITION: read SSM current values; if already lavandula_*, skip.
 T+3   No action — additive overlap was applied at T-1.
       (Old ARNs remain; they will be removed at T+6.)
 
-T+4   PRECONDITION: psql connect test as the new roles works (see T+5 below).
+T+4   PRECONDITION: actual IAM-authenticated psql connect as the new role
+      MUST succeed before starting the dashboard. This is the definitive
+      authorization check — token generation is local and never fails;
+      rds-db:connect is what we actually need.
+        TOK=$(aws rds generate-db-auth-token --hostname $RDS_ENDPOINT \
+              --port 5432 --username lavandula_app --region us-east-1)
+        PGPASSWORD="$TOK" psql -h $RDS_ENDPOINT -U lavandula_app -d $DB \
+          --set=sslmode=require -c "SELECT current_user, 1 AS ok"
+        # Expected: a row returned with current_user='lavandula_app'.
+        # If "PAM authentication failed": IAM not propagated → wait, retry.
+        # If "role \"lavandula_app\" does not exist": rename didn't apply.
+        # If "permission denied for ...": grants didn't follow OID — investigate.
+      Repeat for lavandula_ro before continuing.
+
       Start: dashboard (systemctl start lavandula-dashboard)
       Watch: journalctl -u lavandula-dashboard -f
       Wait up to 60s; if first connection fails with auth error, this is most
@@ -309,12 +358,27 @@ The work is complete when ALL of the following hold:
 3. EC2 instance profile IAM policy `rds-db:connect` resource ARNs reference `lavandula_app` and `lavandula_ro`. Old ARNs (`.../app_user1`, `.../ro_user1`) have been removed at T+6 (no overlap remains in steady state).
 4. Dashboard is running and serving requests; `/orgs/`, `/jobs/`, and at least one write endpoint succeed.
 5. Direct psql connect as `lavandula_ro` and `lavandula_app` (via IAM token) both succeed.
-6. **Privilege parity (no regression).** The pre-rename grant snapshots (§"Pre-rename checks" step 4) compared against post-rename snapshots show ONLY role-name substitutions — no added, removed, or modified privileges, and no added or removed role memberships. A `diff` of the two snapshot sets, after sed-substituting the old names for the new, must be empty.
+6. **Privilege parity (no regression) — covers four dimensions.** The four pre-rename snapshots (§"Pre-rename checks" steps 4a-4d) re-collected post-rename, sed-substituted (`s/app_user1/lavandula_app/g; s/ro_user1/lavandula_ro/g`), and `diff`'d against the originals must produce **zero output for each of**:
+   - **4a Object privileges** (`\dp` of `lava_corpus.*`, `lava_pipeline.*`, `lava_dashboard.*`)
+   - **4b Default ACLs** (`pg_default_acl` for the same schemas)
+   - **4c Ownership** of tables/views/sequences (`pg_class`) and schemas (`pg_namespace`)
+   - **4d Memberships** (`pg_auth_members`)
+
+   If ANY of these four diffs are non-empty, AC #6 fails and the rollback procedure is triggered.
 7. The 6 source files in §"Code Changes" have zero remaining `app_user1` or `ro_user1` references (verified by `grep -rn`).
-8. **Targeted test verification** (NOT full suite — narrowed per-Codex feedback). The following must pass:
-   - `pytest lavandula/common/tests/unit/test_db_adapter_0013.py` (touched fixtures + assertions).
-   - `pytest lavandula/common/tests/conftest.py`-using tests in `lavandula/common/tests/` (fixture validity).
-   - **Bootstrap + migration validation:** Against a scratch Postgres (local or ephemeral RDS), manually `CREATE ROLE lavandula_app; CREATE ROLE lavandula_ro;` then run all 14 migrations in order to completion. Confirms the SQL files reference the new names consistently.
+8. **Targeted test verification** (NOT full suite — narrowed per-Codex feedback). The following exact commands must pass:
+   - `pytest lavandula/common/tests/unit/test_db_adapter_0013.py -v` (touched fixtures + assertions; the file with 11 hardcoded `app_user1`/`ro_user1` references).
+   - `pytest lavandula/common/tests/ -v -k "not slow"` (catches any indirect references via the shared `conftest.py` fixture; `-k "not slow"` excludes any tests that require live RDS).
+   - **Bootstrap + migration validation** against a scratch Postgres:
+     ```bash
+     # In a local Docker container or ephemeral RDS scratch instance:
+     createdb lava_test
+     psql lava_test -c "CREATE ROLE lavandula_app; CREATE ROLE lavandula_ro;"
+     for f in lavandula/migrations/rds/{001,002,003,004,005,006,007,008,009,010,011,012,013,014}_*.sql; do
+       psql lava_test -v ON_ERROR_STOP=1 -f "$f" || { echo "FAIL: $f"; exit 1; }
+     done
+     ```
+     All 14 migrations must run to completion without error. Confirms the SQL files reference the new names consistently.
 9. Runbook `locard/operations/0037-role-rename-runbook.md` is committed alongside the source-tree PR.
 10. Lessons-learned added to `locard/resources/lessons-learned.md` if anything unexpected was hit during cutover.
 
@@ -362,13 +426,19 @@ systemctl start lavandula-dashboard
 
 IAM policy stays in additive-overlap state during rollback (both old and new ARNs allowed) — no IAM action needed for rollback. Old ARNs continue to authorize, which is what we want.
 
-Source-tree edits: leave in (they're forward-only and don't break the live system) OR `git revert` if the PR has merged. Prefer leaving them — they document the intent and a future re-attempt only needs the cutover, not new edits.
+### Source-tree handling during rollback (explicit policy)
+
+If the live RDS rollback is **short (under ~4 hours)** and the cutover will be retried in the same maintenance window: **leave the source-tree edits in place** (already merged or not). The runtime reads usernames from SSM, so source-tree consistency does not affect the live system; bootstrap SQL describing the new names is harmless on a system that's only renamed back temporarily.
+
+If the live RDS rollback is **extended (overnight or longer)** without a retry scheduled: **`git revert` the PR**. Reason: a fresh-environment build (new dev EC2, new scratch DB) would create the new role names while production runs old names, which silently diverges. A revert restores source-tree truth to match production.
+
+The runbook records which policy was applied in its execution log.
 
 Total rollback time: ~3 minutes from decision-to-rollback to dashboard-back-up.
 
 ## Open Questions / Decisions
 
-1. **Prefix value (BLOCKING — must be resolved before approval).** Recommended: `lavandula`. Alternative: `lava` (matches schema prefix exactly). Operator decides at spec approval. This affects every source-file edit, every SSM value, every IAM ARN, and the runbook. **No builder work begins until the operator picks one.** Throughout this spec, `lavandula_*` is used as the placeholder; if the operator picks `lava_*`, the spec is updated globally before plan-writing begins.
+1. **Prefix value — RESOLVED (pending operator veto at approval).** **Final decision: `lavandula`.** This matches the package directory (`lavandula/`) and is the natural choice given `lava_*` already prefixes the schemas. Alternatives considered: `lava` (rejected — package name is `lavandula`, not `lava`; schema abbreviation is incidental). The operator can veto at spec-approval review and trigger a global rename of the spec, but the spec is now consistent end-to-end on `lavandula_*` and is ready for plan phase as-is.
 
 2. **Vestigial `dashboard_user1` — RESOLVED.** Decision rule is now concrete (§"`dashboard_user1` decision rule"). The pre-check answers it deterministically: if absent, no-op; if present without grants, drop; if present with grants, rename and expand scope (operator approval required for that branch).
 

--- a/locard/specs/0037-rds-role-rename.md
+++ b/locard/specs/0037-rds-role-rename.md
@@ -448,12 +448,59 @@ Total rollback time: ~3 minutes from decision-to-rollback to dashboard-back-up.
 
 ## Consultation Log
 
-- **Codex (spec-review)**: REQUEST_CHANGES — 10 findings: (1) blocking prefix decision unresolved; (2) AC #8 "full test suite" too broad; (3) idempotent runbook underspecified — `ALTER ROLE` fails if already renamed, no expected-reality checks; (4) IAM policy update treated as atomic swap, no additive overlap for outage reduction; (5) `pg_authid` requires privileges not stated; (6) rollback decision tree missing for timing-sensitive failures; (7) connection-pool drain weak — `pg_stat_activity` check alone is not enough; (8) least-privilege validation incomplete — grants checked but not memberships; (9) fresh-environment story inconsistent; (10) `dashboard_user1` treatment too open
-- **Gemini (spec-review)**: Rate-limited (API quota exhausted across 3 attempts)
+### First Consultation (After Initial Draft)
+**Date**: 2026-05-10
+**Models Consulted**: Codex ✅ (Gemini unavailable — quota exhausted across 3 retry attempts)
+**Commands**:
+```
+consult --model codex --type spec-review spec 0037
+consult --model gemini --type spec-review spec 0037   # all attempts 429
+```
 
-All findings addressed in revision 2.
+**Verdict**: REQUEST_CHANGES (Codex) — all findings addressed in v2
 
-- **Codex (red-team-spec)**: REQUEST_CHANGES — 6 findings: (1) HIGH: `dashboard_user1` rename branch had no consumer for new SSM key — contradicts "zero production-code change"; reduced to drop-if-vestigial or HALT; (2) HIGH: privilege-parity verification incomplete — `\dp` covers object privs but not default ACLs or ownership; expanded to 4 dimensions (object, default ACL, ownership, memberships); (3) MEDIUM: AC #8 not operationally precise — provided exact pytest commands and exact bootstrap+migration loop; (4) MEDIUM: prefix decision still blocking — promoted from placeholder to final (operator-confirmed `research` later); (5) MEDIUM: source-tree rollback policy ambiguous — added short-vs-extended rollback policy; (6) LOW: IAM verification relied on token generation — switched to actual `psql` IAM-authenticated connect tests with explicit expected output for each failure mode
-- **Gemini (red-team-spec)**: Rate-limited (API quota exhausted)
+| Model  | Verdict          | Key Issues |
+|--------|------------------|------------|
+| Codex  | REQUEST_CHANGES  | Prefix decision blocking; AC #8 "full test suite" too broad; runbook not idempotent (`ALTER ROLE` fails on re-run); IAM ARN swap not additive; `pg_authid` privilege not stated; rollback decision tree missing for timing-sensitive failures; connection drain weak; least-privilege validation grants-only; fresh-environment story inconsistent; `dashboard_user1` treatment open |
+| Gemini | (unavailable)    | API quota exhausted — 10 attempts each, all 429 |
 
-All findings addressed in revision 3. Prefix decision resolved by operator to `research` (revision 4).
+### Red Team Security Review (MANDATORY)
+**Date**: 2026-05-10
+**Models Consulted**: Codex ✅ (Gemini unavailable — quota exhausted)
+**Commands**:
+```
+consult --model codex --type red-team-spec spec 0037
+consult --model gemini --type red-team-spec spec 0037  # 429
+```
+
+**Verdict**: REQUEST_CHANGES (Codex) — all findings addressed in v3
+
+| Model  | Verdict          | Key Issues |
+|--------|------------------|------------|
+| Codex  | REQUEST_CHANGES  | HIGH: `dashboard_user1` rename branch had no consumer for new SSM key — contradicted "zero production-code change"; HIGH: privilege-parity check covered only `\dp` (object privs), missed default ACLs and ownership; MEDIUM: AC #8 not operationally precise; MEDIUM: prefix decision still blocking; MEDIUM: source-tree rollback policy ambiguous; LOW: IAM verification relied on token generation, not actual connect |
+| Gemini | (unavailable)    | API quota exhausted |
+
+### Changes in v2 (post spec-review)
+
+1. **Operator-privilege assumption stated** for `pg_authid` pre-check (master / `rds_superuser` required; otherwise skip — IAM doesn't use stored passwords).
+2. **`dashboard_user1` decision rule made concrete**: three explicit branches in a table, runbook acts without deliberation.
+3. **Cutover sequence restructured as idempotent T-1..T+6** with explicit precondition checks per step; halt-on-mixed-state behavior.
+4. **IAM additive-overlap strategy added** (T-1 warm-up, T+6 cleanup) to eliminate the IAM-propagation race during cutover.
+5. **Session drain via `pg_terminate_backend`** after service stop.
+6. **Rollback decision tree by failure point** (replaces flat rollback).
+7. **AC #8 narrowed** from "full test suite" to targeted unit tests + scratch-DB migration validation.
+8. **AC #6 strengthened**: empty diff after name substitution — no privilege regression.
+9. **Prefix decision (Open Question 1)** marked as BLOCKING approval.
+
+### Changes in v3 (post red-team)
+
+1. **`dashboard_user1` rename branch removed** (no consumer exists; would contradict zero-code-change goal). Branch is now: drop if vestigial, HALT if non-vestigial (defer to follow-up spec).
+2. **Privilege parity verification expanded** from `\dp` alone to four dimensions: object privileges (`\dp`), default ACLs (`pg_default_acl`), ownership (`pg_class` + `pg_namespace`), memberships (`pg_auth_members`). AC #6 now requires zero-diff on ALL four.
+3. **AC #8 made operationally precise**: exact pytest commands and exact bootstrap+migration loop with `-v ON_ERROR_STOP=1`.
+4. **Prefix decision promoted from placeholder to final**: `lavandula` (later changed to `research` by operator in v4).
+5. **Source-tree rollback policy made explicit**: leave-in for short rollback (<4hr), `git revert` for extended rollback.
+6. **IAM verification at T-1 and T+4 changed** from token-generation only (which never fails locally) to actual IAM-authenticated `psql` connect with explicit expected output for each failure mode.
+
+### Changes in v4 (post operator review)
+
+1. **Prefix value confirmed by operator**: `research` (matches the repo root name) — all 39 `lavandula_*` references in the spec replaced with `research_*` (plus the projectlist entry).

--- a/locard/specs/0037-rds-role-rename.md
+++ b/locard/specs/0037-rds-role-rename.md
@@ -445,3 +445,15 @@ Total rollback time: ~3 minutes from decision-to-rollback to dashboard-back-up.
 3. **Source-tree edits in same PR or separate?** Recommend **same PR** so the source tree never disagrees with the live database for more than the cutover window. The PR merges *after* the live cutover (so reviewers can see the runbook executed cleanly).
 
 4. **Should this work create a `015_role_rename_documentation.sql` migration?** No. Migrations write to `lava_corpus.schema_version` to track schema evolution, but role renames are not schema events. Document the rename in the runbook + git log; do not pollute the migration sequence.
+
+## Consultation Log
+
+- **Codex (spec-review)**: REQUEST_CHANGES — 10 findings: (1) blocking prefix decision unresolved; (2) AC #8 "full test suite" too broad; (3) idempotent runbook underspecified — `ALTER ROLE` fails if already renamed, no expected-reality checks; (4) IAM policy update treated as atomic swap, no additive overlap for outage reduction; (5) `pg_authid` requires privileges not stated; (6) rollback decision tree missing for timing-sensitive failures; (7) connection-pool drain weak — `pg_stat_activity` check alone is not enough; (8) least-privilege validation incomplete — grants checked but not memberships; (9) fresh-environment story inconsistent; (10) `dashboard_user1` treatment too open
+- **Gemini (spec-review)**: Rate-limited (API quota exhausted across 3 attempts)
+
+All findings addressed in revision 2.
+
+- **Codex (red-team-spec)**: REQUEST_CHANGES — 6 findings: (1) HIGH: `dashboard_user1` rename branch had no consumer for new SSM key — contradicts "zero production-code change"; reduced to drop-if-vestigial or HALT; (2) HIGH: privilege-parity verification incomplete — `\dp` covers object privs but not default ACLs or ownership; expanded to 4 dimensions (object, default ACL, ownership, memberships); (3) MEDIUM: AC #8 not operationally precise — provided exact pytest commands and exact bootstrap+migration loop; (4) MEDIUM: prefix decision still blocking — promoted from placeholder to final (operator-confirmed `research` later); (5) MEDIUM: source-tree rollback policy ambiguous — added short-vs-extended rollback policy; (6) LOW: IAM verification relied on token generation — switched to actual `psql` IAM-authenticated connect tests with explicit expected output for each failure mode
+- **Gemini (red-team-spec)**: Rate-limited (API quota exhausted)
+
+All findings addressed in revision 3. Prefix decision resolved by operator to `research` (revision 4).

--- a/locard/specs/0037-rds-role-rename.md
+++ b/locard/specs/0037-rds-role-rename.md
@@ -1,0 +1,273 @@
+# Spec 0037: Rename RDS Roles to Project-Prefixed Names
+
+## Problem Statement
+
+A second project will share the existing RDS Postgres instance. Current Lavandula roles use generic names — `app_user1` (CRUD) and `ro_user1` (read-only) — that conflict with any sensible role naming the new project would choose for its own CRUD/RO pair. We need to namespace Lavandula's roles so each project owns a clearly-scoped role-pair under a recognizable prefix, and the new project can stand up its own role-pair without collision.
+
+Schemas already carry a project prefix (`lava_corpus`, `lava_dashboard`, `lava_pipeline`) so they need no rename — Postgres schemas already provide the namespace they were designed for. **Only the role names need fixing.**
+
+## Goals
+
+### Must Have
+
+1. **Project-prefixed role names.** `app_user1` → `lavandula_app`, `ro_user1` → `lavandula_ro`. The new project will independently create `<newproj>_app`, `<newproj>_ro` under its own SSM path; this spec does not provision or touch the new project's roles.
+
+2. **Zero production-code change in the abstraction layer.** Usernames already flow through SSM keys (`rds-app-user`, `rds-ro-user`). The KEYS stay the same; only the VALUES change. This means `lavandula/common/db.py` and `lavandula/dashboard/dashboard/settings.py` are NOT edited.
+
+3. **All grants, ownerships, and default-privilege rules survive the rename.** Postgres ties these to role OIDs, not names — `ALTER ROLE … RENAME TO …` preserves them automatically. Spec validates this in the acceptance criteria; no manual re-granting required.
+
+4. **IAM authentication continues to work post-rename.** RDS IAM auth requires (a) the role has `rds_iam` membership and (b) the calling principal has `rds-db:connect` on a resource ARN that contains the username. The `rds_iam` membership follows the rename automatically; the IAM resource ARN does not. The IAM policy attached to the EC2 instance profile must be updated as part of this work.
+
+5. **Coordinated cutover with brief outage.** The dashboard and any long-running CLI processes hold username strings in-memory (via `lru_cache` on `get_secret`). They must be restarted after SSM is updated. The rename window is a small operator-coordinated outage (minutes), not a long migration.
+
+6. **Source-tree consistency.** The 6 source files that hardcode the old role names (4 SQL migrations + 2 test files) are updated so that fresh database rebuilds, new migration runs, and the test suite all reference the renamed roles.
+
+### Should Have
+
+7. **Idempotent runbook.** Each step in the runbook can be re-run without harm. If the operator is interrupted partway, restarting the runbook from the top either no-ops past the completed steps or fails fast with a clear diagnostic.
+
+8. **Verified rollback path.** If anything fails, the operator can `ALTER ROLE … RENAME TO …` back to the old name and restore the previous SSM values within minutes.
+
+### Out of Scope
+
+- **Schema rename.** The `lava_*` schemas already carry a project prefix and are out of scope. See Spec 0037 background analysis (this document, §"Why not rename schemas").
+- **Provisioning the new project's roles.** The new project gets its own role-pair under its own SSM path. That work belongs to that project's own spec.
+- **Password rotation.** IAM auth is in use; no password to rotate. (See §"Pre-rename checks" for the password-encryption verification step that confirms this.)
+- **Cross-project access patterns.** Whether the new project's roles can read Lavandula tables (or vice-versa) is a separate policy decision and is explicitly NOT addressed here. After this rename, both projects' roles remain isolated as today.
+- **A schema-name abstraction layer.** Adding `_SCHEMA = get_secret("rds-schema")` indirection across ~170 SQL strings is a separate refactor (Option C in the inventory analysis) and is NOT part of this work.
+
+## Background / Current State
+
+### Current roles
+
+```
+app_user1   -- CRUD on lava_corpus, lava_pipeline, lava_dashboard; member of rds_iam
+ro_user1    -- SELECT on lava_corpus tables; member of rds_iam
+postgres    -- AWS-managed superuser (untouched by this work)
+```
+
+There is no separate `dashboard_user1` despite that name appearing colloquially — the dashboard reuses `app_user1`. Confirmed by inventory: zero references to `dashboard_user1` in code or migrations.
+
+### How usernames flow today
+
+```
+SSM (/cloud2.lavandulagroup.com/rds-app-user = "app_user1")
+   ↓
+get_secret("rds-app-user") → "app_user1"   [lru_cache'd, per-process]
+   ↓
+make_app_engine() / Django settings.py → SQLAlchemy/psycopg2 connect
+   ↓
+IAMTokenManager.token() with DBUsername="app_user1" → 15-min auth token
+   ↓
+Connect to RDS as app_user1
+```
+
+The username is read at process start, cached in `lru_cache` for the process lifetime, and used for both the connection string AND the IAM token's `DBUsername` field. Changing the SSM value alone is not sufficient — running processes will keep using the cached old value until restart.
+
+### Inventory of source-tree references
+
+Files that hardcode `app_user1` or `ro_user1` (must be edited as part of this work):
+
+| File | References | Reason |
+|---|---|---|
+| `lavandula/migrations/rds/001_initial_schema.sql` | 8 | GRANT + default-privilege statements |
+| `lavandula/migrations/rds/002_attribution_helper.sql` | 1 | GRANT EXECUTE |
+| `lavandula/migrations/rds/010_990_people_filing_index.sql` | 5 | GRANT statements |
+| `lavandula/migrations/rds/migration_011_990_index_automation.sql` | 7 | GRANT statements |
+| `lavandula/common/tests/conftest.py` | 2 | Fixture role-presence assertion |
+| `lavandula/common/tests/unit/test_db_adapter_0013.py` | 11 | Hardcoded test strings |
+
+Files that mention old names in narrative prose (lower priority; update for historical accuracy or leave with a note):
+
+| File | Treatment |
+|---|---|
+| `locard/specs/0013-rds-postgres-migration.md` | Add a footnote: "Roles renamed to `lavandula_app`/`lavandula_ro` per Spec 0037 (2026-05-XX)." Do not rewrite history. |
+| `locard/specs/0017-retire-sqlite.md` | Same. |
+| `locard/plans/0013-phase2-backfill.md` | Same. |
+| `locard/plans/0017-retire-sqlite.md` | Same. |
+
+### Why not rename schemas
+
+170 references to `lava_corpus` exist across 30+ source files. Schema names are NOT abstracted: they appear inline in SQL string literals (`"FROM lava_corpus.corpus"`), as module-level constants (`_SCHEMA = "lava_corpus"`), and as Django Meta `db_table` attributes. There IS an `rds-schema` SSM key, but it only controls `SET search_path` — it does not drive query construction. A schema rename would require ~170 file edits with high risk of missed references (SQL strings are not type-checked).
+
+The `lava_*` prefix already namespaces the schemas. The collision risk is on role names alone. Schemas are explicitly out of scope.
+
+## Proposed Naming
+
+| Old | New | Justification |
+|---|---|---|
+| `app_user1` | `lavandula_app` | Matches the package directory (`lavandula/`) and conceptually aligns with the `lava_*` schema prefix. |
+| `ro_user1` | `lavandula_ro` | Same. The `_ro` suffix is standard PG convention for read-only roles. |
+
+The numeric `1` suffix is dropped — it implied a sequence (`app_user2`?) that never existed.
+
+**Decision pending:** Operator confirms `lavandula` as the prefix at spec-approval time. Alternative: `lava` (matches the schemas exactly but loses the package-name match). Recommendation: `lavandula`.
+
+## Migration Strategy
+
+### Pre-rename checks (operator runs before any change)
+
+```sql
+-- 1. Confirm no dashboard_user1 exists. If it does, decide whether to drop it
+--    (likely vestigial) or rename it consistent with the others.
+SELECT rolname FROM pg_roles WHERE rolname IN ('app_user1','ro_user1','dashboard_user1');
+
+-- 2. Confirm SCRAM password encryption (rename invalidates MD5-hashed passwords
+--    because MD5 includes the username; SCRAM is unaffected). IAM auth doesn't
+--    use stored passwords, but if any fallback password ever was set this matters.
+SELECT rolname,
+       CASE
+         WHEN rolpassword IS NULL THEN '(no stored password — IAM-only)'
+         WHEN rolpassword LIKE 'SCRAM-%' THEN 'SCRAM (rename-safe)'
+         WHEN rolpassword LIKE 'md5%' THEN 'MD5 (rename invalidates password)'
+         ELSE 'unknown'
+       END AS password_status
+FROM pg_authid
+WHERE rolname IN ('app_user1','ro_user1');
+
+-- 3. Confirm rds_iam membership (must follow the rename automatically).
+SELECT r.rolname, m.rolname AS member_of
+FROM pg_roles r JOIN pg_auth_members am ON r.oid = am.member
+JOIN pg_roles m ON am.roleid = m.oid
+WHERE r.rolname IN ('app_user1','ro_user1') AND m.rolname = 'rds_iam';
+
+-- 4. Snapshot grants (for post-rename verification).
+\dp lava_corpus.*
+\dp lava_pipeline.*
+\dp lava_dashboard.*
+```
+
+### Cutover sequence (operator-coordinated)
+
+```
+T+0   Stop: dashboard (systemctl stop lavandula-dashboard)
+      Stop: any running CLI processes (crawler, classifier, etc.) — confirm
+            via `ps -ef | grep python3` and `af status`.
+      Confirm no active connections held by app_user1/ro_user1:
+            SELECT pid, usename, state FROM pg_stat_activity
+            WHERE usename IN ('app_user1','ro_user1');
+
+T+1   ALTER ROLE app_user1 RENAME TO lavandula_app;
+      ALTER ROLE ro_user1  RENAME TO lavandula_ro;
+
+T+2   Update SSM values:
+        aws ssm put-parameter --name /cloud2.lavandulagroup.com/rds-app-user \
+            --type SecureString --value lavandula_app --overwrite
+        aws ssm put-parameter --name /cloud2.lavandulagroup.com/rds-ro-user \
+            --type SecureString --value lavandula_ro  --overwrite
+
+T+3   Update IAM policy on EC2 instance profile (cloud2_lavandulagroup):
+        Replace resource ARN suffixes:
+          arn:aws:rds-db:us-east-1:ACCT:dbuser/DB-RES-ID/app_user1
+          arn:aws:rds-db:us-east-1:ACCT:dbuser/DB-RES-ID/ro_user1
+        with:
+          arn:aws:rds-db:us-east-1:ACCT:dbuser/DB-RES-ID/lavandula_app
+          arn:aws:rds-db:us-east-1:ACCT:dbuser/DB-RES-ID/lavandula_ro
+      IAM propagation is typically <1min but can be up to ~5min.
+
+T+4   Start: dashboard (systemctl start lavandula-dashboard)
+      Watch journalctl -u lavandula-dashboard -f for connect errors.
+      Hit /healthz (or equivalent) to confirm DB connectivity.
+
+T+5   Smoke tests:
+        - Dashboard home page loads
+        - One read query (org list)
+        - One write query (e.g., create a noop Job, then cancel it)
+        - psql as lavandula_ro: SELECT 1 FROM lava_corpus.corpus LIMIT 1
+        - psql as lavandula_app: same query
+```
+
+Estimated outage: 3–10 minutes including verification.
+
+### Source-tree edits (committed in same PR as the runbook)
+
+The 6 source files listed in §"Inventory" are edited via mechanical find/replace:
+
+```
+app_user1   →  lavandula_app
+ro_user1    →  lavandula_ro
+```
+
+These edits do not affect the existing RDS database (the migration files have already been applied and won't re-run). Their purpose is fresh-database correctness: any new RDS instance built from `lavandula/migrations/rds/` will create the new role names directly.
+
+Migrations 001, 002, 010, 011 do NOT need a new migration file (014 → 015) because the migrations create roles that are *expected* to already exist (they only GRANT to them). The `CREATE ROLE` statements live outside the migration system, in the original RDS bootstrap. **However**, if any environment re-applies these migrations against a fresh database, the GRANT-to-nonexistent-role would fail. This is a latent issue today and a known limitation; it is not introduced by this rename.
+
+### Test-suite edits
+
+`lavandula/common/tests/conftest.py` and `lavandula/common/tests/unit/test_db_adapter_0013.py` reference the names as fixture data and assertion strings. Mechanical find/replace, then run the test suite to confirm green.
+
+## Code Changes (final list)
+
+| File | Change |
+|---|---|
+| `lavandula/migrations/rds/001_initial_schema.sql` | s/app_user1/lavandula_app/g, s/ro_user1/lavandula_ro/g |
+| `lavandula/migrations/rds/002_attribution_helper.sql` | Same |
+| `lavandula/migrations/rds/010_990_people_filing_index.sql` | Same |
+| `lavandula/migrations/rds/migration_011_990_index_automation.sql` | Same |
+| `lavandula/common/tests/conftest.py` | Same |
+| `lavandula/common/tests/unit/test_db_adapter_0013.py` | Same |
+| `locard/operations/0037-role-rename-runbook.md` | NEW — operator-facing runbook copy of §"Cutover sequence" with environment-specific values filled in (account ID, DB resource ID). |
+
+NOT edited (intentional):
+- `lavandula/common/db.py` — uses SSM keys; values change in SSM, not in code.
+- `lavandula/dashboard/dashboard/settings.py` — same.
+- Any application code that issues queries — schemas are unchanged.
+
+## Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| IAM policy not updated → all auth fails post-rename | Medium | High (full outage) | Make IAM policy edit a numbered step in the runbook with explicit verification (`aws sts get-caller-identity` + a test connect). Block the dashboard restart on this step. |
+| `lru_cache` retains old SSM value in some forgotten daemon | Low | Medium (silent stale auth) | `ps -ef` audit before T+1; explicit list of services to stop in the runbook. |
+| Active connection still using old role at rename time | Low | Low (existing session keeps working; no harm) | PG allows the rename with active sessions. The rename takes effect for *new* connections only, which is the desired behavior. |
+| Stored MD5 password (vestigial) gets invalidated | Very Low | Low (IAM is the auth path) | Pre-rename check confirms password algorithm. If MD5, document but proceed — IAM auth doesn't depend on it. |
+| Fresh DB rebuild fails because migration 001 expected old role names | Low | Medium (blocks new env) | Source files updated in same PR; verify by running the migration suite against a scratch RDS or local Postgres. |
+| Test suite has hidden references not caught by grep (e.g., parameterized fixtures) | Low | Low (CI catches it) | Run full test suite in the PR before approval. |
+| Rollback needed mid-cutover | Low | Low | `ALTER ROLE … RENAME TO …` is symmetric. SSM value rollback is `put-parameter --overwrite` with the old value. IAM policy rollback is one CloudFormation/console edit. Pre-cutover snapshot of `\du` output captures the previous state. |
+
+## Acceptance Criteria
+
+The work is complete when ALL of the following hold:
+
+1. `\du` on RDS shows `lavandula_app` and `lavandula_ro`; no role named `app_user1` or `ro_user1` exists.
+2. SSM parameter `/cloud2.lavandulagroup.com/rds-app-user` returns `lavandula_app`; `rds-ro-user` returns `lavandula_ro`.
+3. EC2 instance profile IAM policy `rds-db:connect` resource ARNs reference `lavandula_app` and `lavandula_ro` (no references to `app_user1` or `ro_user1` remain).
+4. Dashboard is running and serving requests; `/orgs/`, `/jobs/`, and at least one write endpoint succeed.
+5. Direct psql connect as `lavandula_ro` and `lavandula_app` (via IAM token) both succeed.
+6. Each grant snapshot taken pre-rename matches the post-rename grant snapshot, with only the role name differing. (i.e., no privilege regression.)
+7. The 6 source files in §"Code Changes" have zero remaining `app_user1` or `ro_user1` references (verified by `grep -rn`).
+8. Full test suite passes in the PR (no hidden references).
+9. Runbook `locard/operations/0037-role-rename-runbook.md` is committed.
+10. Lessons-learned added to `locard/resources/lessons-learned.md` if anything unexpected was hit during cutover.
+
+## Rollback Plan
+
+If at any step T+1 through T+5 something fails, rollback is symmetric:
+
+```sql
+ALTER ROLE lavandula_app RENAME TO app_user1;
+ALTER ROLE lavandula_ro  RENAME TO ro_user1;
+```
+
+```bash
+aws ssm put-parameter --name /cloud2.lavandulagroup.com/rds-app-user \
+    --type SecureString --value app_user1 --overwrite
+aws ssm put-parameter --name /cloud2.lavandulagroup.com/rds-ro-user \
+    --type SecureString --value ro_user1  --overwrite
+```
+
+IAM policy: revert the resource ARN edit (keep the prior version cached locally before the change).
+
+Restart dashboard. Total rollback time: ~3 minutes.
+
+The source-tree edits can stay in (they are forward-only and don't break anything operationally) or be reverted via `git revert` of the PR — whichever is cleaner given where the rollback was triggered.
+
+## Open Questions / Decisions
+
+1. **Prefix value.** Recommended: `lavandula`. Alternative: `lava` (matches schema prefix exactly). Operator decides at spec approval. *(Affects all 6 source-file edits and the SSM values.)*
+
+2. **Vestigial `dashboard_user1`.** If `\du` shows it exists, decide: drop it (`DROP ROLE`) or rename it for symmetry (`lavandula_dashboard`)? Recommend **drop** if it has no GRANTs and no `pg_authid.rolconfig` entries. *(Pre-rename check answers this.)*
+
+3. **Source-tree edits in same PR or separate?** Recommend **same PR** so the source tree never disagrees with the live database for more than the cutover window. The PR merges *after* the live cutover (so reviewers can see the runbook executed cleanly).
+
+4. **Should this work create a `015_role_rename_documentation.sql` migration?** No. Migrations write to `lava_corpus.schema_version` to track schema evolution, but role renames are not schema events. Document the rename in the runbook + git log; do not pollute the migration sequence.

--- a/locard/specs/0037-rds-role-rename.md
+++ b/locard/specs/0037-rds-role-rename.md
@@ -10,7 +10,7 @@ Schemas already carry a project prefix (`lava_corpus`, `lava_dashboard`, `lava_p
 
 ### Must Have
 
-1. **Project-prefixed role names.** `app_user1` → `lavandula_app`, `ro_user1` → `lavandula_ro`. The new project will independently create `<newproj>_app`, `<newproj>_ro` under its own SSM path; this spec does not provision or touch the new project's roles.
+1. **Project-prefixed role names.** `app_user1` → `research_app`, `ro_user1` → `research_ro`. The new project will independently create `<newproj>_app`, `<newproj>_ro` under its own SSM path; this spec does not provision or touch the new project's roles.
 
 2. **Zero production-code change in the abstraction layer.** Usernames already flow through SSM keys (`rds-app-user`, `rds-ro-user`). The KEYS stay the same; only the VALUES change. This means `lavandula/common/db.py` and `lavandula/dashboard/dashboard/settings.py` are NOT edited.
 
@@ -81,7 +81,7 @@ Files that mention old names in narrative prose (lower priority; update for hist
 
 | File | Treatment |
 |---|---|
-| `locard/specs/0013-rds-postgres-migration.md` | Add a footnote: "Roles renamed to `lavandula_app`/`lavandula_ro` per Spec 0037 (2026-05-XX)." Do not rewrite history. |
+| `locard/specs/0013-rds-postgres-migration.md` | Add a footnote: "Roles renamed to `research_app`/`research_ro` per Spec 0037 (2026-05-XX)." Do not rewrite history. |
 | `locard/specs/0017-retire-sqlite.md` | Same. |
 | `locard/plans/0013-phase2-backfill.md` | Same. |
 | `locard/plans/0017-retire-sqlite.md` | Same. |
@@ -96,12 +96,12 @@ The `lava_*` prefix already namespaces the schemas. The collision risk is on rol
 
 | Old | New | Justification |
 |---|---|---|
-| `app_user1` | `lavandula_app` | Matches the package directory (`lavandula/`) and conceptually aligns with the `lava_*` schema prefix. |
-| `ro_user1` | `lavandula_ro` | Same. The `_ro` suffix is standard PG convention for read-only roles. |
+| `app_user1` | `research_app` | Matches the repository root name (`research/`) — the natural project identifier as the codebase grows beyond the original `lavandula` package. |
+| `ro_user1` | `research_ro` | Same. The `_ro` suffix is standard PG convention for read-only roles. |
 
 The numeric `1` suffix is dropped — it implied a sequence (`app_user2`?) that never existed.
 
-**Prefix decision:** `lavandula` (final — see Open Questions §1). Operator can veto at spec approval and trigger a global rename of the spec.
+**Prefix decision:** `research` (final, operator-confirmed 2026-05-10). The repo name is the project identifier; new projects added to the shared RDS will use their own distinct prefixes (e.g., `<newproj>_app`).
 
 ## Migration Strategy
 
@@ -195,19 +195,19 @@ T-1   IAM ADDITIVE OVERLAP (do this BEFORE the outage window).
       Edit the EC2 instance-profile policy to ALLOW BOTH old and new ARNs:
         arn:aws:rds-db:us-east-1:ACCT:dbuser/DB-RES-ID/app_user1
         arn:aws:rds-db:us-east-1:ACCT:dbuser/DB-RES-ID/ro_user1
-        arn:aws:rds-db:us-east-1:ACCT:dbuser/DB-RES-ID/lavandula_app   ← new
-        arn:aws:rds-db:us-east-1:ACCT:dbuser/DB-RES-ID/lavandula_ro    ← new
+        arn:aws:rds-db:us-east-1:ACCT:dbuser/DB-RES-ID/research_app   ← new
+        arn:aws:rds-db:us-east-1:ACCT:dbuser/DB-RES-ID/research_ro    ← new
       Wait ≥5 minutes for IAM propagation.
       Verify by ATTEMPTING ACTUAL CONNECT (not just token generation):
         # The new role doesn't exist yet, so the connect should fail with
-        # "role lavandula_app does not exist" — this is the desired result.
+        # "role research_app does not exist" — this is the desired result.
         # It proves IAM is allowing the rds-db:connect call through (otherwise
-        # we'd see "PAM authentication failed for user lavandula_app").
+        # we'd see "PAM authentication failed for user research_app").
         TOK=$(aws rds generate-db-auth-token --hostname $RDS_ENDPOINT \
-              --port 5432 --username lavandula_app --region us-east-1)
-        PGPASSWORD="$TOK" psql -h $RDS_ENDPOINT -U lavandula_app -d $DB \
+              --port 5432 --username research_app --region us-east-1)
+        PGPASSWORD="$TOK" psql -h $RDS_ENDPOINT -U research_app -d $DB \
           --set=sslmode=require -c "SELECT 1" 2>&1 | tee /tmp/iam_warmup.log
-        # Expected output contains "role \"lavandula_app\" does not exist".
+        # Expected output contains "role \"research_app\" does not exist".
         # If output contains "PAM authentication failed" or "permission denied
         # to use this connection method", IAM has not propagated yet — wait
         # another 2 min and retry. Do NOT proceed to T+0 until this confirms.
@@ -215,8 +215,8 @@ T-1   IAM ADDITIVE OVERLAP (do this BEFORE the outage window).
 
 T+0   PRECONDITION: confirm rename has not already happened.
         SELECT rolname FROM pg_roles
-        WHERE rolname IN ('app_user1','ro_user1','lavandula_app','lavandula_ro');
-      Expected: ('app_user1','ro_user1') only. If 'lavandula_app' present,
+        WHERE rolname IN ('app_user1','ro_user1','research_app','research_ro');
+      Expected: ('app_user1','ro_user1') only. If 'research_app' present,
       jump to T+2 (rename already done). If both pairs present, HALT — mixed
       state requires manual investigation.
 
@@ -234,21 +234,21 @@ T+0   PRECONDITION: confirm rename has not already happened.
 T+1   PRECONDITION: app_user1 and ro_user1 still exist (from T+0 query).
       Execute rename in a single transaction:
         BEGIN;
-        ALTER ROLE app_user1 RENAME TO lavandula_app;
-        ALTER ROLE ro_user1  RENAME TO lavandula_ro;
+        ALTER ROLE app_user1 RENAME TO research_app;
+        ALTER ROLE ro_user1  RENAME TO research_ro;
         -- (conditional, if dashboard_user1 branch chosen at pre-check)
-        -- ALTER ROLE dashboard_user1 RENAME TO lavandula_dashboard;
+        -- ALTER ROLE dashboard_user1 RENAME TO research_dashboard;
         -- OR
         -- DROP ROLE dashboard_user1;
         COMMIT;
       Verify:
-        SELECT rolname FROM pg_roles WHERE rolname LIKE 'lavandula\_%' ESCAPE '\';
+        SELECT rolname FROM pg_roles WHERE rolname LIKE 'research\_%' ESCAPE '\';
 
-T+2   PRECONDITION: read SSM current values; if already lavandula_*, skip.
+T+2   PRECONDITION: read SSM current values; if already research_*, skip.
         OLD_APP=$(aws ssm get-parameter --name /cloud2.lavandulagroup.com/rds-app-user --with-decryption --query Parameter.Value --output text)
-        if [[ "$OLD_APP" != "lavandula_app" ]]; then
+        if [[ "$OLD_APP" != "research_app" ]]; then
           aws ssm put-parameter --name /cloud2.lavandulagroup.com/rds-app-user \
-            --type SecureString --value lavandula_app --overwrite
+            --type SecureString --value research_app --overwrite
         fi
       Same for rds-ro-user.
 
@@ -260,14 +260,14 @@ T+4   PRECONDITION: actual IAM-authenticated psql connect as the new role
       authorization check — token generation is local and never fails;
       rds-db:connect is what we actually need.
         TOK=$(aws rds generate-db-auth-token --hostname $RDS_ENDPOINT \
-              --port 5432 --username lavandula_app --region us-east-1)
-        PGPASSWORD="$TOK" psql -h $RDS_ENDPOINT -U lavandula_app -d $DB \
+              --port 5432 --username research_app --region us-east-1)
+        PGPASSWORD="$TOK" psql -h $RDS_ENDPOINT -U research_app -d $DB \
           --set=sslmode=require -c "SELECT current_user, 1 AS ok"
-        # Expected: a row returned with current_user='lavandula_app'.
+        # Expected: a row returned with current_user='research_app'.
         # If "PAM authentication failed": IAM not propagated → wait, retry.
-        # If "role \"lavandula_app\" does not exist": rename didn't apply.
+        # If "role \"research_app\" does not exist": rename didn't apply.
         # If "permission denied for ...": grants didn't follow OID — investigate.
-      Repeat for lavandula_ro before continuing.
+      Repeat for research_ro before continuing.
 
       Start: dashboard (systemctl start lavandula-dashboard)
       Watch: journalctl -u lavandula-dashboard -f
@@ -279,8 +279,8 @@ T+5   Smoke tests (each must pass before T+6):
         - Dashboard home page loads
         - One read query (org list)
         - One write query (create a noop Job, then cancel it)
-        - psql via IAM token as lavandula_ro: SELECT 1 FROM lava_corpus.corpus LIMIT 1
-        - psql via IAM token as lavandula_app: same query
+        - psql via IAM token as research_ro: SELECT 1 FROM lava_corpus.corpus LIMIT 1
+        - psql via IAM token as research_app: same query
 
 T+6   POST-CUTOVER CLEANUP (do this AFTER ≥30 minutes of stable operation).
       Remove old ARNs from the IAM policy:
@@ -308,8 +308,8 @@ Additive overlap eliminates the IAM-propagation race entirely: at T-1 the policy
 The 6 source files listed in §"Inventory" are edited via mechanical find/replace:
 
 ```
-app_user1   →  lavandula_app
-ro_user1    →  lavandula_ro
+app_user1   →  research_app
+ro_user1    →  research_ro
 ```
 
 These edits do not affect the existing RDS database (the migration files have already been applied and won't re-run). Their purpose is fresh-database correctness: any new RDS instance built from `lavandula/migrations/rds/` will create the new role names directly.
@@ -324,7 +324,7 @@ Migrations 001, 002, 010, 011 do NOT need a new migration file (014 → 015) bec
 
 | File | Change |
 |---|---|
-| `lavandula/migrations/rds/001_initial_schema.sql` | s/app_user1/lavandula_app/g, s/ro_user1/lavandula_ro/g |
+| `lavandula/migrations/rds/001_initial_schema.sql` | s/app_user1/research_app/g, s/ro_user1/research_ro/g |
 | `lavandula/migrations/rds/002_attribution_helper.sql` | Same |
 | `lavandula/migrations/rds/010_990_people_filing_index.sql` | Same |
 | `lavandula/migrations/rds/migration_011_990_index_automation.sql` | Same |
@@ -353,12 +353,12 @@ NOT edited (intentional):
 
 The work is complete when ALL of the following hold:
 
-1. `\du` on RDS shows `lavandula_app` and `lavandula_ro`; no role named `app_user1` or `ro_user1` exists.
-2. SSM parameter `/cloud2.lavandulagroup.com/rds-app-user` returns `lavandula_app`; `rds-ro-user` returns `lavandula_ro`.
-3. EC2 instance profile IAM policy `rds-db:connect` resource ARNs reference `lavandula_app` and `lavandula_ro`. Old ARNs (`.../app_user1`, `.../ro_user1`) have been removed at T+6 (no overlap remains in steady state).
+1. `\du` on RDS shows `research_app` and `research_ro`; no role named `app_user1` or `ro_user1` exists.
+2. SSM parameter `/cloud2.lavandulagroup.com/rds-app-user` returns `research_app`; `rds-ro-user` returns `research_ro`.
+3. EC2 instance profile IAM policy `rds-db:connect` resource ARNs reference `research_app` and `research_ro`. Old ARNs (`.../app_user1`, `.../ro_user1`) have been removed at T+6 (no overlap remains in steady state).
 4. Dashboard is running and serving requests; `/orgs/`, `/jobs/`, and at least one write endpoint succeed.
-5. Direct psql connect as `lavandula_ro` and `lavandula_app` (via IAM token) both succeed.
-6. **Privilege parity (no regression) — covers four dimensions.** The four pre-rename snapshots (§"Pre-rename checks" steps 4a-4d) re-collected post-rename, sed-substituted (`s/app_user1/lavandula_app/g; s/ro_user1/lavandula_ro/g`), and `diff`'d against the originals must produce **zero output for each of**:
+5. Direct psql connect as `research_ro` and `research_app` (via IAM token) both succeed.
+6. **Privilege parity (no regression) — covers four dimensions.** The four pre-rename snapshots (§"Pre-rename checks" steps 4a-4d) re-collected post-rename, sed-substituted (`s/app_user1/research_app/g; s/ro_user1/research_ro/g`), and `diff`'d against the originals must produce **zero output for each of**:
    - **4a Object privileges** (`\dp` of `lava_corpus.*`, `lava_pipeline.*`, `lava_dashboard.*`)
    - **4b Default ACLs** (`pg_default_acl` for the same schemas)
    - **4c Ownership** of tables/views/sequences (`pg_class`) and schemas (`pg_namespace`)
@@ -373,7 +373,7 @@ The work is complete when ALL of the following hold:
      ```bash
      # In a local Docker container or ephemeral RDS scratch instance:
      createdb lava_test
-     psql lava_test -c "CREATE ROLE lavandula_app; CREATE ROLE lavandula_ro;"
+     psql lava_test -c "CREATE ROLE research_app; CREATE ROLE research_ro;"
      for f in lavandula/migrations/rds/{001,002,003,004,005,006,007,008,009,010,011,012,013,014}_*.sql; do
        psql lava_test -v ON_ERROR_STOP=1 -f "$f" || { echo "FAIL: $f"; exit 1; }
      done
@@ -395,7 +395,7 @@ The right action depends on WHERE the failure happened. Rollback is symmetric bu
 | **T+1** `ALTER ROLE` fails (lock, permission, role-not-found) | Read the error. If "role does not exist" — rename already happened (idempotent re-run). If "is being used" — drain again, retry. If permission denied — abort, escalate. No rollback needed at this point because nothing was renamed. | Abort. No rollback needed. |
 | **T+1** Both renames succeed but transaction commit fails (extremely rare) | Re-check `pg_roles`. PG renames are atomic within the transaction. | If renames partially applied, manually `ALTER ROLE … RENAME TO …` to converge. |
 | **T+2** SSM `put-parameter` fails | Retry up to 3 times. If still failing, revert via `ALTER ROLE … RENAME TO app_user1` etc. so the system is consistent (old name everywhere). | Full rollback (rename back, no SSM change since none succeeded). |
-| **T+4** Dashboard fails to start with auth error | Check journalctl for specifics. Most common cause: IAM propagation lag (despite T-1 warm-up, edge case). **Wait 5 minutes, retry start.** If still failing after 10 minutes, run a manual `aws rds generate-db-auth-token --db-user lavandula_app` + `psql` to isolate. | If isolated to IAM/role: full rollback. If isolated to dashboard config: investigate code; revert role rename only if dashboard issue cannot be diagnosed quickly. |
+| **T+4** Dashboard fails to start with auth error | Check journalctl for specifics. Most common cause: IAM propagation lag (despite T-1 warm-up, edge case). **Wait 5 minutes, retry start.** If still failing after 10 minutes, run a manual `aws rds generate-db-auth-token --db-user research_app` + `psql` to isolate. | If isolated to IAM/role: full rollback. If isolated to dashboard config: investigate code; revert role rename only if dashboard issue cannot be diagnosed quickly. |
 | **T+5** Smoke test fails on read query | Likely IAM/grant issue. Compare pre/post grant snapshots (AC #6). If snapshots match, IAM propagation issue — wait 5min and retry. | Full rollback. |
 | **T+5** Smoke test fails on write query but read succeeds | Targeted GRANT regression — investigate `\dp` on the affected table. Should not happen if AC #6 passes. | Full rollback. |
 
@@ -407,12 +407,12 @@ systemctl stop lavandula-dashboard
 -- Drain leftover sessions
 SELECT pg_terminate_backend(pid)
 FROM pg_stat_activity
-WHERE usename IN ('lavandula_app','lavandula_ro')
+WHERE usename IN ('research_app','research_ro')
   AND pid <> pg_backend_pid();
 -- Reverse rename
 BEGIN;
-ALTER ROLE lavandula_app RENAME TO app_user1;
-ALTER ROLE lavandula_ro  RENAME TO ro_user1;
+ALTER ROLE research_app RENAME TO app_user1;
+ALTER ROLE research_ro  RENAME TO ro_user1;
 COMMIT;
 ```
 
@@ -438,7 +438,7 @@ Total rollback time: ~3 minutes from decision-to-rollback to dashboard-back-up.
 
 ## Open Questions / Decisions
 
-1. **Prefix value — RESOLVED (pending operator veto at approval).** **Final decision: `lavandula`.** This matches the package directory (`lavandula/`) and is the natural choice given `lava_*` already prefixes the schemas. Alternatives considered: `lava` (rejected — package name is `lavandula`, not `lava`; schema abbreviation is incidental). The operator can veto at spec-approval review and trigger a global rename of the spec, but the spec is now consistent end-to-end on `lavandula_*` and is ready for plan phase as-is.
+1. **Prefix value — RESOLVED.** **Final decision: `research` (operator-confirmed 2026-05-10).** Reflects the repo root name and is the natural project identifier as new projects are added to the shared RDS. Each new project gets its own distinct prefix.
 
 2. **Vestigial `dashboard_user1` — RESOLVED.** Decision rule is now concrete (§"`dashboard_user1` decision rule"). The pre-check answers it deterministically: if absent, no-op; if present without grants, drop; if present with grants, rename and expand scope (operator approval required for that branch).
 


### PR DESCRIPTION
## Summary

Renames two Postgres roles on the shared RDS instance so a second project can coexist without role-name collisions. The codebase already abstracts usernames behind SSM keys — only the SSM **values** change, not the keys. Zero production-code changes to `db.py` or `settings.py`.

- **Source-tree edits**: Mechanical find/replace in 4 SQL migrations + 2 test files (6 files, 35 substitutions)
- **Operator runbook**: Self-contained T-1..T+6 cutover procedure with 10 helper scripts
- **Idempotent cutover SQL**: Rename and rollback scripts with proper guards

### Files changed

**Source-tree (Phase 1)** — `app_user1`→`research_app`, `ro_user1`→`research_ro`:
- `lavandula/migrations/rds/001_initial_schema.sql` (8 refs)
- `lavandula/migrations/rds/002_attribution_helper.sql` (1 ref)
- `lavandula/migrations/rds/010_990_people_filing_index.sql` (5 refs)
- `lavandula/migrations/rds/migration_011_990_index_automation.sql` (7 refs)
- `lavandula/common/tests/conftest.py` (2 refs)
- `lavandula/common/tests/unit/test_db_adapter_0013.py` (11 refs)

**NOT edited** (intentional — reads from SSM):
- `lavandula/common/db.py`
- `lavandula/dashboard/dashboard/settings.py`

**Operator runbook + scripts (Phase 2)** — 11 new files under `locard/operations/0037-*`:
- Runbook, pre-checks SQL, snapshot pre/post scripts, parity diff
- Cutover rename/rollback SQL (idempotent), dashboard-user drop SQL
- IAM policy overlay + final JSON, smoke test script

## Test Results

### Unit tests (from worktree)
```
pytest lavandula/common/tests/unit/test_db_adapter_0013.py -v
  18 passed, 2 skipped (live-RDS gated) in 0.61s

pytest lavandula/common/tests/ -v -k "not slow"
  27 passed, 5 skipped in 1.64s
```

### Scratch-DB migration validation (Postgres 16)
All 14 migrations applied successfully against a fresh `lava_test` database with `CREATE ROLE research_app; CREATE ROLE research_ro`. GRANTs reference new role names only.

**Note**: Migration 007 has a pre-existing `CREATE OR REPLACE VIEW` issue (cannot rename view column in-place) unrelated to this PR. Workaround: `DROP VIEW reports_public` before 007. This is a latent bootstrap bug, not introduced by this rename.

### Helper script validation
- `0037-cutover-rename.sql`: idempotent (no-op on re-run, handles target-exists case)
- `0037-cutover-rollback.sql`: symmetric, idempotent
- `0037-cutover-dashboard-user-drop.sql`: no-op when absent, drops when vestigial, HALTs when has grants

### Grep verification
```
grep -rn -E "app_user1|ro_user1" lavandula/
# zero matches
```

## Merge instructions

**DO NOT merge until the live cutover (Phase 4) succeeds.** The PR merges *after* the operator executes the runbook against production RDS. See `locard/operations/0037-role-rename-runbook.md` for the full procedure.

## Test plan

- [x] `pytest lavandula/common/tests/unit/test_db_adapter_0013.py -v` — 18 passed
- [x] `pytest lavandula/common/tests/ -v -k "not slow"` — 27 passed
- [x] Scratch-DB: all 14 migrations apply with new role names
- [x] Grep: zero remaining `app_user1`/`ro_user1` in `lavandula/`
- [x] `db.py` and `settings.py` byte-identical to master
- [x] Shell scripts pass `bash -n` syntax check
- [x] Cutover rename/rollback idempotent (double-run verified)
- [x] Dashboard-user drop handles absent/vestigial/has-grants branches
- [ ] Live cutover (Phase 4 — operator-only, post-merge-approval)

🤖 Generated with [Claude Code](https://claude.com/claude-code)