### PR TITLE
[Spec 0041] Classifier V3 pipeline operational parity

### DIFF
--- a/lavandula/dashboard/pipeline/job_stats.py
+++ b/lavandula/dashboard/pipeline/job_stats.py
@@ -1,0 +1,30 @@
+import logging
+import threading
+
+log = logging.getLogger(__name__)
+
+
+def merge_stats(job_id, stats_dict):
+    from pipeline.models import Job
+    job = Job.objects.get(pk=job_id)
+    cfg = job.config_json or {}
+    cfg["stats"] = dict(stats_dict)
+    Job.objects.filter(pk=job_id).update(config_json=cfg)
+
+
+def start_stats_flusher(job_id, stats_dict, interval=10):
+    if job_id is None:
+        return threading.Event()
+
+    stop = threading.Event()
+
+    def _flusher():
+        while not stop.wait(interval):
+            try:
+                merge_stats(job_id, stats_dict)
+            except Exception:
+                log.exception("Stats flush failed for job %d", job_id)
+
+    t = threading.Thread(target=_flusher, daemon=True)
+    t.start()
+    return stop

--- a/lavandula/dashboard/pipeline/management/commands/compare_classifications.py
+++ b/lavandula/dashboard/pipeline/management/commands/compare_classifications.py
@@ -34,6 +34,8 @@ class Command(BaseCommand):
                             help="Show v2/v3 reasoning side-by-side for disagreements")
         parser.add_argument("--limit", type=int, default=50,
                             help="Max disagreements to show with --show-reasoning")
+        parser.add_argument("--job-id", type=int, default=None,
+                            help="Job ID for dashboard stats")
 
     def handle(self, *args, **options):
         engine = make_app_engine()
@@ -77,6 +79,14 @@ class Command(BaseCommand):
 
         total_compared = len(agree) + len(disagree_rule) + len(disagree_llm)
         total_disagree = len(disagree_rule) + len(disagree_llm)
+
+        job_id = options.get("job_id")
+        if job_id:
+            from pipeline.job_stats import merge_stats
+            merge_stats(job_id, {
+                "processed": total_compared,
+                "failed": len(v3_errors),
+            })
 
         self.stdout.write(f"\nClassification Comparison: {run_tag} vs corpus (Haiku v2)")
         filter_str = f" (state={state})" if state else ""

--- a/lavandula/dashboard/pipeline/management/commands/promote_classification_run.py
+++ b/lavandula/dashboard/pipeline/management/commands/promote_classification_run.py
@@ -32,6 +32,8 @@ class Command(BaseCommand):
                             help="Limit promotion to a single state (2-letter code)")
         parser.add_argument("--confirm", action="store_true",
                             help="Required safety flag to confirm promotion")
+        parser.add_argument("--job-id", type=int, default=None,
+                            help="Job ID for dashboard stats")
 
     def handle(self, *args, **options):
         run_tag = options["run_tag"]
@@ -136,6 +138,11 @@ class Command(BaseCommand):
                   AND cr.content_sha256 = c.content_sha256
                   {state_where}
             """), {"run_id": run_id, "state": state})
+
+        job_id = options.get("job_id")
+        if job_id:
+            from pipeline.job_stats import merge_stats
+            merge_stats(job_id, {"processed": result_count, "failed": 0})
 
         # Log promotion
         notes = (

--- a/lavandula/dashboard/pipeline/management/commands/reclassify_corpus.py
+++ b/lavandula/dashboard/pipeline/management/commands/reclassify_corpus.py
@@ -279,7 +279,7 @@ class Command(BaseCommand):
                             else:
                                 stats["skip_fp"] += 1
                             stats["total"] += 1
-                        dashboard_stats["processed"] += 1
+                            dashboard_stats["processed"] += 1
                             self._write_result(
                                 engine, run_id, row["content_sha256"],
                                 material_type=None, material_group=None,
@@ -312,7 +312,7 @@ class Command(BaseCommand):
                             )
                             stats["rule_matched"] += 1
                             stats["total"] += 1
-                        dashboard_stats["processed"] += 1
+                            dashboard_stats["processed"] += 1
                             distribution[rule_match.material_type] += 1
                             continue
 
@@ -404,9 +404,9 @@ class Command(BaseCommand):
                                 else:
                                     self._write_error(engine, run_id, row["content_sha256"])
                                     stats["llm_errors"] += 1
-                            dashboard_stats["failed"] += 1
+                                    dashboard_stats["failed"] += 1
                                 stats["total"] += 1
-                        dashboard_stats["processed"] += 1
+                                dashboard_stats["processed"] += 1
 
                             for fut in not_done:
                                 fut.cancel()

--- a/lavandula/dashboard/pipeline/management/commands/reclassify_corpus.py
+++ b/lavandula/dashboard/pipeline/management/commands/reclassify_corpus.py
@@ -83,6 +83,8 @@ class Command(BaseCommand):
                             help="Minimum pages_text length to classify")
         parser.add_argument("--quiet", action="store_true",
                             help="Suppress per-batch progress (keep start/end summary)")
+        parser.add_argument("--job-id", type=int, default=None,
+                            help="Job ID for dashboard stats")
 
     def handle(self, *args, **options):
         engine = make_app_engine()
@@ -222,6 +224,12 @@ class Command(BaseCommand):
         )
         watchdog.start_thread()
 
+        # --- Dashboard stats ---
+        job_id = options.get("job_id")
+        from pipeline.job_stats import start_stats_flusher
+        dashboard_stats = {"processed": 0, "failed": 0}
+        stats_stop = start_stats_flusher(job_id, dashboard_stats)
+
         # --- Rate limit tracking ---
         rate_limit_lock = threading.Lock()
         rate_limit_times = deque(maxlen=20)
@@ -271,6 +279,7 @@ class Command(BaseCommand):
                             else:
                                 stats["skip_fp"] += 1
                             stats["total"] += 1
+                        dashboard_stats["processed"] += 1
                             self._write_result(
                                 engine, run_id, row["content_sha256"],
                                 material_type=None, material_group=None,
@@ -303,6 +312,7 @@ class Command(BaseCommand):
                             )
                             stats["rule_matched"] += 1
                             stats["total"] += 1
+                        dashboard_stats["processed"] += 1
                             distribution[rule_match.material_type] += 1
                             continue
 
@@ -344,6 +354,7 @@ class Command(BaseCommand):
                         else:
                             self._write_error(engine, run_id, row["content_sha256"])
                             stats["llm_errors"] += 1
+                            dashboard_stats["failed"] += 1
                             consecutive_failures += 1
                             if consecutive_failures >= _MAX_CONSECUTIVE_FAILURES:
                                 self.stderr.write(
@@ -353,6 +364,7 @@ class Command(BaseCommand):
                                 shutdown.set()
                                 break
                         stats["total"] += 1
+                        dashboard_stats["processed"] += 1
 
                     # Clean up active_futures
                     active_futures = [f for f in active_futures if not f.done()]
@@ -392,7 +404,9 @@ class Command(BaseCommand):
                                 else:
                                     self._write_error(engine, run_id, row["content_sha256"])
                                     stats["llm_errors"] += 1
+                            dashboard_stats["failed"] += 1
                                 stats["total"] += 1
+                        dashboard_stats["processed"] += 1
 
                             for fut in not_done:
                                 fut.cancel()
@@ -417,10 +431,14 @@ class Command(BaseCommand):
                         break
 
         finally:
+            stats_stop.set()
             watchdog.stop()
             if watchdog._thread is not None:
                 watchdog._thread.join(timeout=2)
             signal.signal(signal.SIGINT, original_handler)
+            if job_id:
+                from pipeline.job_stats import merge_stats
+                merge_stats(job_id, dashboard_stats)
 
         if shutdown.is_set():
             self.stdout.write(f"\nInterrupted. Resume with --resume to continue.")

--- a/lavandula/dashboard/pipeline/management/commands/resolve_disagreements.py
+++ b/lavandula/dashboard/pipeline/management/commands/resolve_disagreements.py
@@ -74,6 +74,8 @@ class Command(BaseCommand):
         parser.add_argument("--dry-run", action="store_true", help="Show counts without resolving")
         parser.add_argument("--sample", type=int, default=None, help="Sample N disagreements")
         parser.add_argument("--definition", type=str, default=None, help="Classifier definition name")
+        parser.add_argument("--job-id", type=int, default=None,
+                            help="Job ID for dashboard stats")
 
     def handle(self, *args, **options):
         engine = make_app_engine()
@@ -167,6 +169,11 @@ class Command(BaseCommand):
         distribution = defaultdict(int)
         start_time = time.monotonic()
 
+        job_id = options.get("job_id")
+        from pipeline.job_stats import start_stats_flusher
+        dashboard_stats = {"processed": 0, "failed": 0}
+        stats_stop = start_stats_flusher(job_id, dashboard_stats)
+
         with ThreadPoolExecutor(max_workers=workers) as pool:
             futures = {}
             for i, row in enumerate(disagreements):
@@ -183,10 +190,12 @@ class Command(BaseCommand):
                 except Exception:
                     log.exception("Tiebreaker exception for sha=%s", row["content_sha256"][:12])
                     stats["errors"] += 1
+                    dashboard_stats["failed"] += 1
                     continue
 
                 if result is None:
                     stats["errors"] += 1
+                    dashboard_stats["failed"] += 1
                     continue
 
                 winner = result.get("winner")
@@ -208,6 +217,7 @@ class Command(BaseCommand):
                     log.warning("Tiebreaker invented type %r, skipping sha=%s",
                                 material_type, row["content_sha256"][:12])
                     stats["invalid"] += 1
+                    dashboard_stats["failed"] += 1
                     continue
 
                 cat = definition.get_category(material_type)
@@ -229,7 +239,13 @@ class Command(BaseCommand):
                     stats["winner_neither"] += 1
 
                 stats["resolved"] += 1
+                dashboard_stats["processed"] += 1
                 distribution[material_type] += 1
+
+        stats_stop.set()
+        if job_id:
+            from pipeline.job_stats import merge_stats
+            merge_stats(job_id, dashboard_stats)
 
         # Finalize
         elapsed = time.monotonic() - start_time

--- a/lavandula/dashboard/pipeline/orchestrator.py
+++ b/lavandula/dashboard/pipeline/orchestrator.py
@@ -261,7 +261,7 @@ def check_phase_conflict(phase: str, state_code: str | None = None) -> bool:
     For per-state phases, only conflicts with the same state block.
     NULL state_code -> global conflict check.
     """
-    qs = Job.objects.filter(phase=phase, status="running")
+    qs = Job.objects.filter(phase=phase, status__in=["running", "scheduled"])
     if state_code and phase in _PER_STATE_PHASES:
         qs = qs.filter(state_code=state_code)
     if qs.exists():
@@ -311,7 +311,7 @@ def create_state_jobs(
             for phase in phases:
                 existing = (
                     Job.objects.select_for_update()
-                    .filter(state_code=sc, phase=phase, status__in=["pending", "running"])
+                    .filter(state_code=sc, phase=phase, status__in=["pending", "scheduled", "running"])
                     .first()
                 )
                 if existing:
@@ -353,7 +353,7 @@ def create_resolve_job(config_overrides: dict, host: str, depends_on: Job | None
     state = config_overrides.get("state")
     with transaction.atomic():
         qs = Job.objects.select_for_update().filter(
-            phase="resolve", status__in=["pending", "running"],
+            phase="resolve", status__in=["pending", "scheduled", "running"],
         )
         if state:
             qs = qs.filter(state_code=state)
@@ -387,7 +387,7 @@ def create_crawl_job(config_overrides: dict, host: str, depends_on: Job | None =
     state = config_overrides.get("state") or None
     with transaction.atomic():
         qs = Job.objects.select_for_update().filter(
-            phase="crawl", status__in=["pending", "running"],
+            phase="crawl", status__in=["pending", "scheduled", "running"],
         )
         if state:
             qs = qs.filter(state_code=state)
@@ -417,7 +417,7 @@ def create_classify_job(config_overrides: dict, host: str, depends_on: Job | Non
     state = config_overrides.get("state") or None
     with transaction.atomic():
         qs = Job.objects.select_for_update().filter(
-            phase="classify", status__in=["pending", "running"],
+            phase="classify", status__in=["pending", "scheduled", "running"],
         )
         if state:
             qs = qs.filter(state_code=state)
@@ -461,7 +461,7 @@ def create_990_index_job(config_overrides: dict, host: str) -> Job:
         _990_advisory_lock()
 
         existing = Job.objects.select_for_update().filter(
-            phase__in=_990_PHASES, status__in=["pending", "running"]
+            phase__in=_990_PHASES, status__in=["pending", "scheduled", "running"]
         ).first()
         if existing:
             raise DuplicateJobError(
@@ -489,7 +489,7 @@ def create_990_parse_job(config_overrides: dict, host: str) -> Job:
         _990_advisory_lock()
 
         existing = Job.objects.select_for_update().filter(
-            phase__in=_990_PHASES, status__in=["pending", "running"]
+            phase__in=_990_PHASES, status__in=["pending", "scheduled", "running"]
         ).first()
         if existing:
             raise DuplicateJobError(
@@ -515,7 +515,7 @@ def create_phone_enrich_job(config_overrides: dict, host: str) -> Job:
     with transaction.atomic():
         existing = (
             Job.objects.select_for_update()
-            .filter(phase="enrich-phone", status__in=["pending", "running"])
+            .filter(phase="enrich-phone", status__in=["pending", "scheduled", "running"])
             .first()
         )
         if existing:

--- a/lavandula/dashboard/pipeline/templates/pipeline/classifier_v3.html
+++ b/lavandula/dashboard/pipeline/templates/pipeline/classifier_v3.html
@@ -24,13 +24,19 @@
     {% if extract_context_running %}
     <div class="mb-3 space-y-1">
       {% for job in extract_context_running %}
-      <div class="text-xs bg-blue-50 rounded p-2">
-        <span class="font-mono">Job #{{ job.pk }}</span>
-        <span class="text-gray-500">{{ job.state_code|default:"nationwide" }}</span>
-        <span class="text-gray-400">{{ job.elapsed }}</span>
-        {% if job.host_display_name %}<span class="text-gray-400">@ {{ job.host_display_name }}</span>{% endif %}
-        {% if job.stats_processed %}<span class="text-blue-600 ml-1">{{ job.stats_processed }} processed</span>{% endif %}
-        {% if job.stats_failed %}<span class="text-red-600 ml-1">{{ job.stats_failed }} failed</span>{% endif %}
+      <div class="text-xs bg-blue-50 rounded p-2 flex items-center justify-between">
+        <span>
+          <span class="font-mono">Job #{{ job.pk }}</span>
+          <span class="text-gray-500">{{ job.state_code|default:"nationwide" }}</span>
+          <span class="text-gray-400">{{ job.elapsed }}</span>
+          {% if job.host_display_name %}<span class="text-gray-400">@ {{ job.host_display_name }}</span>{% endif %}
+          {% if job.stats_processed %}<span class="text-blue-600 ml-1">{{ job.stats_processed }} processed</span>{% endif %}
+          {% if job.stats_failed %}<span class="text-red-600 ml-1">{{ job.stats_failed }} failed</span>{% endif %}
+        </span>
+        <form method="post" action="{% url 'job_cancel' job.pk %}?next={% url 'classifier_v3' %}" class="inline ml-2">
+          {% csrf_token %}
+          <button type="submit" class="text-red-600 hover:text-red-800 text-xs" title="Cancel job #{{ job.pk }}">Cancel</button>
+        </form>
       </div>
       {% endfor %}
     </div>
@@ -58,6 +64,7 @@
         </select>
       </div>
       {% endif %}
+      {% include "pipeline/partials/_depends_on.html" %}
       <button type="submit" class="w-full bg-blue-600 text-white py-2 rounded text-sm hover:bg-blue-700">Queue Job</button>
     </form>
 
@@ -89,11 +96,19 @@
     {% if reclassify_running %}
     <div class="mb-3 space-y-1">
       {% for job in reclassify_running %}
-      <div class="text-xs bg-indigo-50 rounded p-2">
-        <span class="font-mono">Job #{{ job.pk }}</span>
-        <span class="text-gray-500">{{ job.state_code|default:"nationwide" }}</span>
-        <span class="text-gray-400">{{ job.elapsed }}</span>
-        {% if job.host_display_name %}<span class="text-gray-400">@ {{ job.host_display_name }}</span>{% endif %}
+      <div class="text-xs bg-indigo-50 rounded p-2 flex items-center justify-between">
+        <span>
+          <span class="font-mono">Job #{{ job.pk }}</span>
+          <span class="text-gray-500">{{ job.state_code|default:"nationwide" }}</span>
+          <span class="text-gray-400">{{ job.elapsed }}</span>
+          {% if job.host_display_name %}<span class="text-gray-400">@ {{ job.host_display_name }}</span>{% endif %}
+          {% if job.stats_processed %}<span class="text-indigo-600 ml-1">{{ job.stats_processed }} processed</span>{% endif %}
+          {% if job.stats_failed %}<span class="text-red-600 ml-1">{{ job.stats_failed }} failed</span>{% endif %}
+        </span>
+        <form method="post" action="{% url 'job_cancel' job.pk %}?next={% url 'classifier_v3' %}" class="inline ml-2">
+          {% csrf_token %}
+          <button type="submit" class="text-red-600 hover:text-red-800 text-xs" title="Cancel job #{{ job.pk }}">Cancel</button>
+        </form>
       </div>
       {% endfor %}
     </div>
@@ -121,6 +136,7 @@
         </select>
       </div>
       {% endif %}
+      {% include "pipeline/partials/_depends_on.html" %}
       <button type="submit" class="w-full bg-indigo-600 text-white py-2 rounded text-sm hover:bg-indigo-700">Queue Job</button>
     </form>
 
@@ -152,10 +168,18 @@
     {% if compare_classify_running %}
     <div class="mb-3 space-y-1">
       {% for job in compare_classify_running %}
-      <div class="text-xs bg-amber-50 rounded p-2">
-        <span class="font-mono">Job #{{ job.pk }}</span>
-        <span class="text-gray-500">{{ job.state_code|default:"nationwide" }}</span>
-        <span class="text-gray-400">{{ job.elapsed }}</span>
+      <div class="text-xs bg-amber-50 rounded p-2 flex items-center justify-between">
+        <span>
+          <span class="font-mono">Job #{{ job.pk }}</span>
+          <span class="text-gray-500">{{ job.state_code|default:"nationwide" }}</span>
+          <span class="text-gray-400">{{ job.elapsed }}</span>
+          {% if job.stats_processed %}<span class="text-amber-600 ml-1">{{ job.stats_processed }} processed</span>{% endif %}
+          {% if job.stats_failed %}<span class="text-red-600 ml-1">{{ job.stats_failed }} failed</span>{% endif %}
+        </span>
+        <form method="post" action="{% url 'job_cancel' job.pk %}?next={% url 'classifier_v3' %}" class="inline ml-2">
+          {% csrf_token %}
+          <button type="submit" class="text-red-600 hover:text-red-800 text-xs" title="Cancel job #{{ job.pk }}">Cancel</button>
+        </form>
       </div>
       {% endfor %}
     </div>
@@ -183,6 +207,7 @@
         </select>
       </div>
       {% endif %}
+      {% include "pipeline/partials/_depends_on.html" %}
       <button type="submit" class="w-full bg-amber-600 text-white py-2 rounded text-sm hover:bg-amber-700">Queue Job</button>
     </form>
 
@@ -214,11 +239,19 @@
     {% if resolve_disagree_running %}
     <div class="mb-3 space-y-1">
       {% for job in resolve_disagree_running %}
-      <div class="text-xs bg-purple-50 rounded p-2">
-        <span class="font-mono">Job #{{ job.pk }}</span>
-        <span class="text-gray-500">{{ job.state_code|default:"nationwide" }}</span>
-        <span class="text-gray-400">{{ job.elapsed }}</span>
-        {% if job.host_display_name %}<span class="text-gray-400">@ {{ job.host_display_name }}</span>{% endif %}
+      <div class="text-xs bg-purple-50 rounded p-2 flex items-center justify-between">
+        <span>
+          <span class="font-mono">Job #{{ job.pk }}</span>
+          <span class="text-gray-500">{{ job.state_code|default:"nationwide" }}</span>
+          <span class="text-gray-400">{{ job.elapsed }}</span>
+          {% if job.host_display_name %}<span class="text-gray-400">@ {{ job.host_display_name }}</span>{% endif %}
+          {% if job.stats_processed %}<span class="text-purple-600 ml-1">{{ job.stats_processed }} processed</span>{% endif %}
+          {% if job.stats_failed %}<span class="text-red-600 ml-1">{{ job.stats_failed }} failed</span>{% endif %}
+        </span>
+        <form method="post" action="{% url 'job_cancel' job.pk %}?next={% url 'classifier_v3' %}" class="inline ml-2">
+          {% csrf_token %}
+          <button type="submit" class="text-red-600 hover:text-red-800 text-xs" title="Cancel job #{{ job.pk }}">Cancel</button>
+        </form>
       </div>
       {% endfor %}
     </div>
@@ -246,6 +279,7 @@
         </select>
       </div>
       {% endif %}
+      {% include "pipeline/partials/_depends_on.html" %}
       <button type="submit" class="w-full bg-purple-600 text-white py-2 rounded text-sm hover:bg-purple-700">Queue Job</button>
     </form>
 
@@ -277,10 +311,18 @@
     {% if promote_classify_running %}
     <div class="mb-3 space-y-1">
       {% for job in promote_classify_running %}
-      <div class="text-xs bg-green-50 rounded p-2">
-        <span class="font-mono">Job #{{ job.pk }}</span>
-        <span class="text-gray-500">{{ job.state_code|default:"nationwide" }}</span>
-        <span class="text-gray-400">{{ job.elapsed }}</span>
+      <div class="text-xs bg-green-50 rounded p-2 flex items-center justify-between">
+        <span>
+          <span class="font-mono">Job #{{ job.pk }}</span>
+          <span class="text-gray-500">{{ job.state_code|default:"nationwide" }}</span>
+          <span class="text-gray-400">{{ job.elapsed }}</span>
+          {% if job.stats_processed %}<span class="text-green-600 ml-1">{{ job.stats_processed }} processed</span>{% endif %}
+          {% if job.stats_failed %}<span class="text-red-600 ml-1">{{ job.stats_failed }} failed</span>{% endif %}
+        </span>
+        <form method="post" action="{% url 'job_cancel' job.pk %}?next={% url 'classifier_v3' %}" class="inline ml-2">
+          {% csrf_token %}
+          <button type="submit" class="text-red-600 hover:text-red-800 text-xs" title="Cancel job #{{ job.pk }}">Cancel</button>
+        </form>
       </div>
       {% endfor %}
     </div>
@@ -308,6 +350,7 @@
         </select>
       </div>
       {% endif %}
+      {% include "pipeline/partials/_depends_on.html" %}
       <button type="submit" class="w-full bg-green-600 text-white py-2 rounded text-sm hover:bg-green-700">Queue Job</button>
     </form>
 

--- a/lavandula/dashboard/pipeline/tests/test_v3_job_queue.py
+++ b/lavandula/dashboard/pipeline/tests/test_v3_job_queue.py
@@ -324,9 +324,37 @@ class ClassifierV3JobCreateViewTest(TestCase):
         self.assertEqual(resp.status_code, 302)
         self.assertEqual(Job.objects.filter(phase="extract-context").count(), 0)
 
-    def test_terminal_depends_on_rejected(self):
+    def test_completed_depends_on_accepted(self):
         dep = Job.objects.create(
             phase="extract-context", status="completed", host="localhost",
+        )
+        resp = self.client.post(reverse("classifier_v3_job_create"), {
+            "phase": "reclassify",
+            "run_tag": "test1",
+            "backend": "deepseek",
+            "depends_on": str(dep.pk),
+        })
+        self.assertEqual(resp.status_code, 302)
+        job = Job.objects.filter(phase="reclassify").first()
+        self.assertIsNotNone(job)
+        self.assertEqual(job.depends_on, dep)
+
+    def test_failed_depends_on_rejected(self):
+        dep = Job.objects.create(
+            phase="extract-context", status="failed", host="localhost",
+        )
+        resp = self.client.post(reverse("classifier_v3_job_create"), {
+            "phase": "reclassify",
+            "run_tag": "test1",
+            "backend": "deepseek",
+            "depends_on": str(dep.pk),
+        })
+        self.assertEqual(resp.status_code, 302)
+        self.assertEqual(Job.objects.filter(phase="reclassify").count(), 0)
+
+    def test_cancelled_depends_on_rejected(self):
+        dep = Job.objects.create(
+            phase="extract-context", status="cancelled", host="localhost",
         )
         resp = self.client.post(reverse("classifier_v3_job_create"), {
             "phase": "reclassify",
@@ -435,3 +463,83 @@ class CleanupV3PipelineProcessesTest(TestCase):
         call_command("cleanup_v3_pipeline_processes")
         proc.refresh_from_db()
         self.assertEqual(proc.status, "stopped")
+
+
+# ---------------------------------------------------------------------------
+# Spec 0041: check_phase_conflict with scheduled status
+# ---------------------------------------------------------------------------
+
+from pipeline.orchestrator import check_phase_conflict
+
+
+class CheckPhaseConflictScheduledTest(TestCase):
+    def test_scheduled_triggers_conflict(self):
+        Job.objects.create(phase="crawl", status="scheduled", host="localhost")
+        self.assertTrue(check_phase_conflict("crawl"))
+
+    def test_scheduled_per_state_same_state(self):
+        Job.objects.create(
+            phase="extract-context", status="scheduled",
+            state_code="TX", host="localhost",
+        )
+        self.assertTrue(check_phase_conflict("extract-context", "TX"))
+
+    def test_scheduled_per_state_different_state(self):
+        Job.objects.create(
+            phase="extract-context", status="scheduled",
+            state_code="TX", host="localhost",
+        )
+        self.assertFalse(check_phase_conflict("extract-context", "CA"))
+
+    def test_no_conflict_when_only_completed(self):
+        Job.objects.create(phase="crawl", status="completed", host="localhost")
+        self.assertFalse(check_phase_conflict("crawl"))
+
+
+# ---------------------------------------------------------------------------
+# Spec 0041: JobCancelView redirect with next parameter
+# ---------------------------------------------------------------------------
+
+class JobCancelViewRedirectTest(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user("testuser", password="testpassword1234")
+        self.client = Client()
+        self.client.login(username="testuser", password="testpassword1234")
+
+    def test_cancel_redirects_to_next(self):
+        job = Job.objects.create(
+            phase="extract-context", status="pending", host="localhost",
+        )
+        resp = self.client.post(
+            f"/pipeline/jobs/{job.pk}/cancel/?next=/pipeline/classifier-v3/"
+        )
+        self.assertEqual(resp.status_code, 302)
+        self.assertEqual(resp.url, "/pipeline/classifier-v3/")
+
+    def test_cancel_rejects_absolute_next(self):
+        job = Job.objects.create(
+            phase="extract-context", status="pending", host="localhost",
+        )
+        resp = self.client.post(
+            f"/pipeline/jobs/{job.pk}/cancel/?next=https://evil.com/"
+        )
+        self.assertEqual(resp.status_code, 302)
+        self.assertIn(f"/pipeline/jobs/{job.pk}/", resp.url)
+
+    def test_cancel_rejects_protocol_relative_next(self):
+        job = Job.objects.create(
+            phase="extract-context", status="pending", host="localhost",
+        )
+        resp = self.client.post(
+            f"/pipeline/jobs/{job.pk}/cancel/?next=//evil.com/"
+        )
+        self.assertEqual(resp.status_code, 302)
+        self.assertIn(f"/pipeline/jobs/{job.pk}/", resp.url)
+
+    def test_cancel_without_next_goes_to_job_detail(self):
+        job = Job.objects.create(
+            phase="extract-context", status="pending", host="localhost",
+        )
+        resp = self.client.post(f"/pipeline/jobs/{job.pk}/cancel/")
+        self.assertEqual(resp.status_code, 302)
+        self.assertIn(f"/pipeline/jobs/{job.pk}/", resp.url)

--- a/lavandula/dashboard/pipeline/views.py
+++ b/lavandula/dashboard/pipeline/views.py
@@ -88,8 +88,13 @@ def _resolve_depends_on(request):
 
 
 def _get_dependency_choices(phase=None):
-    """Return running/pending jobs suitable as dependency targets."""
-    qs = Job.objects.filter(status__in=["running", "pending"]).select_related("depends_on").order_by("-created_at")
+    """Return running/pending/recently-completed jobs suitable as dependency targets."""
+    from datetime import timedelta
+    cutoff = timezone.now() - timedelta(hours=24)
+    qs = Job.objects.filter(
+        Q(status__in=["running", "pending"]) |
+        Q(status="completed", finished_at__gte=cutoff)
+    ).select_related("depends_on").order_by("-created_at")
     if phase:
         qs = qs.filter(phase=phase)
     choices = []
@@ -98,7 +103,11 @@ def _get_dependency_choices(phase=None):
     )
     for j in qs[:20]:
         host_label = worker_names.get(j.host) or j.host.split("-")[-1]
-        choices.append((j.pk, f"#{j.pk} {j.phase} {j.state_code or 'global'} [{j.status}] @ {host_label}"))
+        status_display = j.status
+        if j.status == "completed" and j.finished_at:
+            mins_ago = int((timezone.now() - j.finished_at).total_seconds() // 60)
+            status_display = f"done {mins_ago}m ago"
+        choices.append((j.pk, f"#{j.pk} {j.phase} {j.state_code or 'global'} [{status_display}] @ {host_label}"))
     return choices
 
 
@@ -480,6 +489,9 @@ class JobCancelView(LoginRequiredMixin, View):
         cancel_job(job)
         _log_audit(request, "job_cancel", job.phase, {"job_id": job.pk})
         messages.success(request, f"Cancelled job #{job.pk}")
+        next_url = request.GET.get("next", "")
+        if next_url and next_url.startswith("/") and not next_url.startswith("//"):
+            return redirect(next_url)
         return redirect("job_detail", pk=pk)
 
 
@@ -861,11 +873,11 @@ class ClassifierV3JobCreateView(LoginRequiredMixin, View):
             except (ValueError, Job.DoesNotExist):
                 messages.error(request, f"Dependency job #{depends_on_raw} not found")
                 return redirect("classifier_v3")
-            if dep_job.status in Job.TERMINAL_STATUSES:
+            if dep_job.status in ("failed", "cancelled"):
                 messages.error(
                     request,
                     f"Dependency job #{dep_id} is {dep_job.status} "
-                    f"— cannot depend on a terminal job",
+                    f"— cannot depend on a failed or cancelled job",
                 )
                 return redirect("classifier_v3")
             depends_on = dep_job

--- a/locard/plans/0041-v3-pipeline-operational-parity.md
+++ b/locard/plans/0041-v3-pipeline-operational-parity.md
@@ -1,0 +1,343 @@
+# Plan 0041: Classifier V3 Pipeline — Operational Parity
+
+**Spec:** `locard/specs/0041-v3-pipeline-operational-parity.md`
+**Date:** 2026-05-13
+
+---
+
+## Implementation Order
+
+The 6 changes have no dependencies on each other. Order them by risk (lowest-risk first) so each step can be verified independently before moving on.
+
+## Step 1: Delete `_launch_immediately()` dead code
+
+**Risk:** None. This is uncommitted code removal.
+
+**File:** `lavandula/dashboard/pipeline/views.py`
+
+Revert the uncommitted changes in `ClassifierV3JobCreateView.post()`:
+
+1. Remove `run_now = request.POST.get("action") == "run_now"` (line 873)
+2. Remove the `if run_now and not depends_on:` / `else:` branching (lines 880-884)
+3. Restore the single success message: `messages.success(request, f"Queued {phase} job #{job.pk} for {state_label}")`
+4. Delete the entire `_launch_immediately()` method (lines 892-922)
+
+**After this step:** `git diff -- lavandula/dashboard/pipeline/views.py` shows only the stats-related changes from triage commit `6f61bc1`, not the `_launch_immediately` additions.
+
+**Verify:** `grep -n "_launch_immediately\|run_now" lavandula/dashboard/pipeline/views.py` returns nothing.
+
+## Step 2: Fix `check_phase_conflict()` and legacy factory conflict checks
+
+**Risk:** Low. Adding `scheduled` to existing conflict queries. Makes conflict detection stricter (fewer false negatives), not looser.
+
+**File:** `lavandula/dashboard/pipeline/orchestrator.py`
+
+### 2a. `check_phase_conflict()` (line 264)
+
+Change:
+```python
+qs = Job.objects.filter(phase=phase, status="running")
+```
+To:
+```python
+qs = Job.objects.filter(phase=phase, status__in=["running", "scheduled"])
+```
+
+### 2b. All 7 legacy factory functions
+
+Each has a duplicate-detection query using `status__in=["pending", "running"]`. Add `"scheduled"` to each:
+
+| Function | Current line | Change |
+|---|---|---|
+| `create_state_jobs` | ~314 | `["pending", "running"]` → `["pending", "scheduled", "running"]` |
+| `create_resolve_job` | ~356 | same |
+| `create_crawl_job` | ~390 | same |
+| `create_classify_job` | ~420 | same |
+| `create_990_index_job` | ~464 | same |
+| `create_990_parse_job` | ~492 | same |
+| `create_phone_enrich_job` | ~518 | same |
+
+Use `replace_all` to change all 7 instances of `status__in=["pending", "running"]` to `status__in=["pending", "scheduled", "running"]` in one pass. But verify each one first — make sure no other uses of that pattern exist that shouldn't change.
+
+**Verify:** `grep -n '"pending", "running"' lavandula/dashboard/pipeline/orchestrator.py` returns no matches. `grep -n '"pending", "scheduled", "running"' lavandula/dashboard/pipeline/orchestrator.py` returns 7 matches (factory functions) plus the 1 in `create_v3_job` that already had it.
+
+## Step 3: Fix `depends_on` validation
+
+**Risk:** Low. One-line change, makes validation more permissive (allows completed deps).
+
+**File:** `lavandula/dashboard/pipeline/views.py`
+
+In `ClassifierV3JobCreateView.post()`, find:
+```python
+if dep_job.status in Job.TERMINAL_STATUSES:
+```
+Change to:
+```python
+if dep_job.status in ("failed", "cancelled"):
+```
+
+**Verify:** Read the changed line. Confirm `completed` is no longer rejected.
+
+## Step 4: Expand `_get_dependency_choices()` to include completed jobs
+
+**Risk:** Low. Shared function — affects crawler/resolver/classifier pages too, but those already allow completed dependencies at the backend.
+
+**File:** `lavandula/dashboard/pipeline/views.py`
+
+In `_get_dependency_choices()` (line 90-102), change:
+```python
+qs = Job.objects.filter(status__in=["running", "pending"]).select_related("depends_on").order_by("-created_at")
+```
+To:
+```python
+from datetime import timedelta
+cutoff = timezone.now() - timedelta(hours=24)
+qs = Job.objects.filter(
+    Q(status__in=["running", "pending"]) |
+    Q(status="completed", finished_at__gte=cutoff)
+).select_related("depends_on").order_by("-created_at")
+```
+
+The `Q` import is already at the top of views.py. The `timedelta` import may need to be added — check if it already exists.
+
+Update the label to include a duration indicator for completed jobs so the dropdown is readable:
+```python
+status_display = j.status
+if j.status == "completed" and j.finished_at:
+    mins_ago = int((timezone.now() - j.finished_at).total_seconds() // 60)
+    status_display = f"done {mins_ago}m ago"
+choices.append((j.pk, f"#{j.pk} {j.phase} {j.state_code or 'global'} [{status_display}] @ {host_label}"))
+```
+
+**Verify:** Navigate to `/pipeline/classifier-v3/` and `/pipeline/crawler/`. Confirm the "Queue after job" dropdown shows completed jobs if any exist within the last 24 hours.
+
+## Step 5: Add dependency dropdown and cancel button to v3 template
+
+**Risk:** Low. Template-only changes using existing partials and views.
+
+**File:** `lavandula/dashboard/pipeline/templates/pipeline/classifier_v3.html`
+
+### 5a. Dependency dropdown
+
+Add `{% include "pipeline/partials/_depends_on.html" %}` inside each of the 5 `<form>` elements, immediately before the `<button type="submit">` line. There are 5 forms (one per step card), each posting to `{% url 'classifier_v3_job_create' %}`.
+
+The exact insertion point for each is between the host `</select></div>{% endif %}` block and the submit button. Example for extract-context (Step 1):
+
+```html
+      {% endif %}
+      {% include "pipeline/partials/_depends_on.html" %}
+      <button type="submit" ...>Queue Job</button>
+```
+
+Repeat for all 5 step cards.
+
+### 5b. Cancel button on running jobs
+
+In each step card's "running jobs" loop (the `{% for job in X_running %}` blocks), add a cancel form after the job info line:
+
+```html
+<div class="text-xs bg-blue-50 rounded p-2">
+  <span class="font-mono">Job #{{ job.pk }}</span>
+  ...existing content...
+  <form method="post" action="{% url 'job_cancel' job.pk %}?next={% url 'classifier_v3' %}" class="inline ml-2">
+    {% csrf_token %}
+    <button type="submit" class="text-red-600 hover:text-red-800 text-xs"
+            title="Cancel job #{{ job.pk }}">Cancel</button>
+  </form>
+</div>
+```
+
+There are 5 step cards with running job loops. The loop variable names are:
+- `extract_context_running` (bg-blue-50)
+- `reclassify_running` (bg-indigo-50)
+- `compare_classify_running` (bg-amber-50)
+- `resolve_disagree_running` (bg-purple-50)
+- `promote_classify_running` (bg-green-50)
+
+### 5c. Modify `JobCancelView` to support `next` parameter
+
+**File:** `lavandula/dashboard/pipeline/views.py`, `JobCancelView` (line 477)
+
+Change:
+```python
+class JobCancelView(LoginRequiredMixin, View):
+    def post(self, request, pk):
+        job = get_object_or_404(Job, pk=pk)
+        cancel_job(job)
+        _log_audit(request, "job_cancel", job.phase, {"job_id": job.pk})
+        messages.success(request, f"Cancelled job #{job.pk}")
+        return redirect("job_detail", pk=pk)
+```
+To:
+```python
+class JobCancelView(LoginRequiredMixin, View):
+    def post(self, request, pk):
+        job = get_object_or_404(Job, pk=pk)
+        cancel_job(job)
+        _log_audit(request, "job_cancel", job.phase, {"job_id": job.pk})
+        messages.success(request, f"Cancelled job #{job.pk}")
+        next_url = request.GET.get("next", "")
+        if next_url and next_url.startswith("/") and not next_url.startswith("//"):
+            return redirect(next_url)
+        return redirect("job_detail", pk=pk)
+```
+
+**Verify:**
+1. Navigate to `/pipeline/classifier-v3/`, confirm "Queue after job" dropdown appears in all 5 step cards
+2. Queue a job, confirm Cancel button appears next to running job
+3. Click Cancel, confirm redirect back to `/pipeline/classifier-v3/` (not job detail)
+4. Navigate to a job detail page, cancel from there — confirm it still redirects to job detail
+
+## Step 6: Add `--job-id` and stats flushing to 4 management commands
+
+**Risk:** Medium. Touches 4 production management commands. Each change is small and additive (`--job-id` is optional, existing behavior unchanged when absent).
+
+### 6a. Create shared stats helper
+
+**New file:** `lavandula/dashboard/pipeline/job_stats.py`
+
+```python
+import logging
+import threading
+
+log = logging.getLogger(__name__)
+
+
+def merge_stats(job_id, stats_dict):
+    from pipeline.models import Job
+    job = Job.objects.get(pk=job_id)
+    cfg = job.config_json or {}
+    cfg["stats"] = dict(stats_dict)
+    Job.objects.filter(pk=job_id).update(config_json=cfg)
+
+
+def start_stats_flusher(job_id, stats_dict, interval=10):
+    if job_id is None:
+        return threading.Event()  # no-op: caller can still call stop.set()
+
+    stop = threading.Event()
+
+    def _flusher():
+        while not stop.wait(interval):
+            try:
+                merge_stats(job_id, stats_dict)
+            except Exception:
+                log.exception("Stats flush failed for job %d", job_id)
+
+    t = threading.Thread(target=_flusher, daemon=True)
+    t.start()
+    return stop
+```
+
+### 6b. `reclassify_corpus.py`
+
+**File:** `lavandula/dashboard/pipeline/management/commands/reclassify_corpus.py`
+
+1. Add argument: `parser.add_argument("--job-id", type=int, default=None, help="Job ID for dashboard stats")`
+
+2. At the top of `handle()` (line ~87), after `engine = make_app_engine()`:
+   ```python
+   job_id = options.get("job_id")
+   ```
+
+3. The command already has a `stats = defaultdict(int)` dict with keys `total`, `llm_classified`, `llm_errors`, `skip_ctx`, `skip_fp`, `rule_matched`. Map to dashboard convention:
+
+   After the watchdog setup (line ~223), start the flusher:
+   ```python
+   from pipeline.job_stats import start_stats_flusher
+   dashboard_stats = {"processed": 0, "failed": 0}
+   stats_stop = start_stats_flusher(job_id, dashboard_stats)
+   ```
+
+4. In the processing loop, wherever `stats["total"] += 1` appears (lines ~273, ~305, ~355, ~395), add `dashboard_stats["processed"] += 1` immediately after. Wherever `stats["llm_errors"] += 1` appears (lines ~346, ~394), add `dashboard_stats["failed"] += 1`.
+
+5. At the end of `_run()`, before the summary output:
+   ```python
+   stats_stop.set()
+   if job_id:
+       from pipeline.job_stats import merge_stats
+       merge_stats(job_id, dashboard_stats)
+   ```
+
+### 6c. `compare_classifications.py`
+
+**File:** `lavandula/dashboard/pipeline/management/commands/compare_classifications.py`
+
+1. Add argument: `parser.add_argument("--job-id", type=int, default=None, help="Job ID for dashboard stats")`
+
+2. This is a batch command (fetches all rows, iterates in memory). No streaming loop, so no periodic flush is needed. Just report final counts.
+
+   After the categorization loop (after line ~76, where `agree`, `disagree_rule`, `disagree_llm`, `v3_errors` are populated):
+   ```python
+   job_id = options.get("job_id")
+   if job_id:
+       from pipeline.job_stats import merge_stats
+       merge_stats(job_id, {
+           "processed": len(agree) + len(disagree_rule) + len(disagree_llm),
+           "failed": len(v3_errors),
+       })
+   ```
+
+   This is a fast in-memory operation, so a periodic flusher would add overhead for no benefit. One final merge is sufficient.
+
+### 6d. `resolve_disagreements.py`
+
+**File:** `lavandula/dashboard/pipeline/management/commands/resolve_disagreements.py`
+
+1. Add argument: `parser.add_argument("--job-id", type=int, default=None, help="Job ID for dashboard stats")`
+
+2. After `stats = defaultdict(int)` (line ~166), start the flusher:
+   ```python
+   job_id = options.get("job_id")
+   from pipeline.job_stats import start_stats_flusher
+   dashboard_stats = {"processed": 0, "failed": 0}
+   stats_stop = start_stats_flusher(job_id, dashboard_stats)
+   ```
+
+3. In the `as_completed` loop:
+   - After `stats["resolved"] += 1` (line ~231): add `dashboard_stats["processed"] += 1`
+   - After `stats["errors"] += 1` (lines ~185, ~189): add `dashboard_stats["failed"] += 1`
+   - After `stats["invalid"] += 1` (line ~210): add `dashboard_stats["failed"] += 1`
+
+4. After the finalize section (after `conn.execute` that updates `classification_runs`):
+   ```python
+   stats_stop.set()
+   if job_id:
+       merge_stats(job_id, dashboard_stats)
+   ```
+
+### 6e. `promote_classification_run.py`
+
+**File:** `lavandula/dashboard/pipeline/management/commands/promote_classification_run.py`
+
+1. Add argument: `parser.add_argument("--job-id", type=int, default=None, help="Job ID for dashboard stats")`
+
+2. This is a batch SQL command — two UPDATE statements that run atomically. No streaming loop. Report final count after completion.
+
+   After the second `conn.execute` (line ~138), before the notes update:
+   ```python
+   job_id = options.get("job_id")
+   if job_id:
+       from pipeline.job_stats import merge_stats
+       merge_stats(job_id, {"processed": result_count, "failed": 0})
+   ```
+
+### 6f. Migrate `extract_classification_context.py` to shared helper (optional)
+
+The existing `_merge_stats` and `stats_flusher` in `extract_classification_context.py` work fine as-is. Migrating to the shared helper would reduce duplication but isn't required for this spec. If the builder has time, refactor it; if not, leave it.
+
+**Verify for all 4 commands:**
+1. Run each command manually with `--job-id <N>` where N is an existing pending/running Job ID
+2. Check `Job.objects.get(pk=N).config_json["stats"]` shows `processed` and `failed` counts
+3. Verify the dashboard status partial shows the stats for running jobs
+
+## Step 7: Commit and verify
+
+1. Run `python3 lavandula/dashboard/manage.py check` to confirm no Django errors
+2. Restart gunicorn/dashboard
+3. Walk through the verification plan from the spec:
+   - Dependency dropdown appears in all 5 step cards
+   - Cancel button appears on running jobs, redirects back to v3 page
+   - Stats visible for extract-context (already working) and for a manually-launched reclassify with `--job-id`
+   - Completed dependency accepted
+4. Spot-check other pipeline pages (crawler, resolver) to confirm no regressions

--- a/locard/plans/0041-v3-pipeline-operational-parity.md
+++ b/locard/plans/0041-v3-pipeline-operational-parity.md
@@ -15,7 +15,7 @@ The 6 changes have no dependencies on each other. Order them by risk (lowest-ris
 
 **File:** `lavandula/dashboard/pipeline/views.py`
 
-Revert the uncommitted changes in `ClassifierV3JobCreateView.post()`:
+Surgically remove only the `run_now` and `_launch_immediately` additions from `ClassifierV3JobCreateView`. Do NOT use `git checkout` or `git restore` on the whole file — there are other uncommitted changes (stats from triage) that must be preserved.
 
 1. Remove `run_now = request.POST.get("action") == "run_now"` (line 873)
 2. Remove the `if run_now and not depends_on:` / `else:` branching (lines 880-884)
@@ -331,7 +331,71 @@ The existing `_merge_stats` and `stats_flusher` in `extract_classification_conte
 2. Check `Job.objects.get(pk=N).config_json["stats"]` shows `processed` and `failed` counts
 3. Verify the dashboard status partial shows the stats for running jobs
 
-## Step 7: Commit and verify
+## Step 7: Add tests
+
+**Risk:** Low. Tests cannot run yet (DB infrastructure blocker), but should be written now so they're ready when the infrastructure is fixed.
+
+**File:** `lavandula/dashboard/pipeline/tests/test_v3_job_queue.py` (append to existing file)
+
+Add tests for the 3 logic changes in this spec:
+
+### 7a. `check_phase_conflict` with `scheduled` status
+
+```python
+def test_check_phase_conflict_includes_scheduled(self):
+    """Scheduled jobs should trigger conflict detection."""
+    Job.objects.create(phase="crawl", status="scheduled", host="test")
+    self.assertTrue(check_phase_conflict("crawl"))
+
+def test_check_phase_conflict_scheduled_per_state(self):
+    """Per-state scheduled jobs should only conflict with same state."""
+    Job.objects.create(phase="extract-context", status="scheduled", state_code="TX", host="test")
+    self.assertTrue(check_phase_conflict("extract-context", "TX"))
+    self.assertFalse(check_phase_conflict("extract-context", "CA"))
+```
+
+### 7b. `depends_on` allowing completed jobs
+
+```python
+def test_v3_job_create_allows_completed_dependency(self):
+    """Completed jobs should be valid dependency targets."""
+    dep = Job.objects.create(phase="extract-context", status="completed", host="test")
+    # Should not raise — completed is a valid dependency
+    job = create_v3_job("reclassify", {"run_tag": "test"}, "test", depends_on=dep)
+    self.assertEqual(job.depends_on, dep)
+
+def test_v3_job_create_rejects_failed_dependency(self):
+    """Failed jobs should still be rejected as dependency targets."""
+    dep = Job.objects.create(phase="extract-context", status="failed", host="test")
+    # The view rejects failed deps; create_v3_job itself doesn't check terminal status,
+    # so this test validates the view-layer check
+```
+
+### 7c. `JobCancelView` redirect with `next` parameter
+
+```python
+def test_cancel_view_redirects_to_next(self):
+    """Cancel should redirect to ?next URL when provided."""
+    job = Job.objects.create(phase="extract-context", status="running", host="test")
+    response = self.client.post(f"/pipeline/jobs/{job.pk}/cancel/?next=/pipeline/classifier-v3/")
+    self.assertRedirects(response, "/pipeline/classifier-v3/")
+
+def test_cancel_view_rejects_absolute_next(self):
+    """Cancel should ignore absolute URLs in next parameter."""
+    job = Job.objects.create(phase="extract-context", status="running", host="test")
+    response = self.client.post(f"/pipeline/jobs/{job.pk}/cancel/?next=https://evil.com/")
+    self.assertRedirects(response, f"/pipeline/jobs/{job.pk}/")
+
+def test_cancel_view_rejects_protocol_relative_next(self):
+    """Cancel should ignore protocol-relative URLs in next parameter."""
+    job = Job.objects.create(phase="extract-context", status="running", host="test")
+    response = self.client.post(f"/pipeline/jobs/{job.pk}/cancel/?next=//evil.com/")
+    self.assertRedirects(response, f"/pipeline/jobs/{job.pk}/")
+```
+
+These tests follow the patterns in the existing `test_v3_job_queue.py`. They cannot run until the test DB infrastructure is fixed, but they document the expected behavior and will catch regressions once tests are enabled.
+
+## Step 8: Commit and verify
 
 1. Run `python3 lavandula/dashboard/manage.py check` to confirm no Django errors
 2. Restart gunicorn/dashboard

--- a/locard/plans/0041-v3-pipeline-operational-parity.md
+++ b/locard/plans/0041-v3-pipeline-operational-parity.md
@@ -405,3 +405,18 @@ These tests follow the patterns in the existing `test_v3_job_queue.py`. They can
    - Stats visible for extract-context (already working) and for a manually-launched reclassify with `--job-id`
    - Completed dependency accepted
 4. Spot-check other pipeline pages (crawler, resolver) to confirm no regressions
+
+## Consultation Log
+
+### Round 1: Plan Review (2026-05-13)
+
+**Gemini**: APPROVE (HIGH confidence) — no issues.
+
+**Codex (GPT-5.4)**: REQUEST_CHANGES (HIGH confidence)
+- Step 1 "revert" language ambiguous in dirty worktree → **Fixed**: clarified to "surgically remove"
+- Missing tests from spec requirement → **Fixed**: added Step 7 with 7 test cases covering scheduled conflict, completed deps, and next-parameter redirect
+
+### Round 2: Red Team Security Review (2026-05-13)
+
+**Gemini (red team)**: REQUEST_CHANGES (0 CRITICAL, 0 HIGH)
+- MEDIUM: `config_json` content policy lacks enforcement → **Already documented** in spec Security Assumptions. Job arguments are validated by `param_validators.py`. No credentials or secrets flow through `config_json`.

--- a/locard/projectlist.md
+++ b/locard/projectlist.md
@@ -615,6 +615,19 @@ projects:
     tags: [classifier, pipeline, job-queue, multi-host, operations]
     notes: "Motivated by classifier v3 running as ad-hoc PipelineProcess while all other stages use the Job queue. No queue visibility, no state isolation, no multi-host dispatch. User needs to run multiple state-isolated classifier jobs simultaneously for national-scale reclassification."
 
+  - id: "0041"
+    title: "Classifier V3 Pipeline — Operational Parity"
+    summary: "Fix 6 gaps left by Spec 0040 builder: add dependency chaining dropdown, cancel button, progress stats for all 5 stages, allow completed dependencies, fix check_phase_conflict scheduled status bug, delete dead _launch_immediately code."
+    status: conceived
+    priority: high
+    files:
+      spec: locard/specs/0041-v3-pipeline-operational-parity.md
+      plan: null
+      review: null
+    dependencies: ["0040"]
+    tags: [classifier, pipeline, job-queue, operations, bugfix]
+    notes: "Motivated by audit finding that 0040 delivered correct data model but regressed operator experience. Pre-0040 PipelineProcess UI had run/stop buttons that worked. Post-0040, no dependency chaining, no stop button, no progress stats for 4/5 stages. Triage patched visibility for extract-context only. This spec brings v3 to parity with crawler/resolver/classifier pages."
+
   - id: "0039"
     title: "SSM Parameter Type Optimization (KMS Cost Reduction)"
     summary: "Convert non-sensitive SSM parameters (rds-endpoint, rds-port, rds-database, rds-schema) from SecureString to String type, eliminating unnecessary KMS Decrypt calls. Every process startup currently makes 5+ KMS calls for config values that aren't secrets. With 22+ concurrent crawlers plus Django workers, this generates ~17K KMS requests/month approaching the 20K free tier limit."
@@ -631,7 +644,7 @@ projects:
 
 ## Next Available Number
 
-**0041** - Reserve this number for your next project
+**0042** - Reserve this number for your next project
 
 ---
 

--- a/locard/projectlist.md
+++ b/locard/projectlist.md
@@ -618,7 +618,7 @@ projects:
   - id: "0041"
     title: "Classifier V3 Pipeline — Operational Parity"
     summary: "Fix 6 gaps left by Spec 0040 builder: add dependency chaining dropdown, cancel button, progress stats for all 5 stages, allow completed dependencies, fix check_phase_conflict scheduled status bug, delete dead _launch_immediately code."
-    status: specified
+    status: implementing
     priority: high
     files:
       spec: locard/specs/0041-v3-pipeline-operational-parity.md
@@ -626,7 +626,7 @@ projects:
       review: null
     dependencies: ["0040"]
     tags: [classifier, pipeline, job-queue, operations, bugfix]
-    notes: "Motivated by audit finding that 0040 delivered correct data model but regressed operator experience. Pre-0040 PipelineProcess UI had run/stop buttons that worked. Post-0040, no dependency chaining, no stop button, no progress stats for 4/5 stages. Triage patched visibility for extract-context only. This spec brings v3 to parity with crawler/resolver/classifier pages."
+    notes: "Motivated by audit finding that 0040 delivered correct data model but regressed operator experience. Pre-0040 PipelineProcess UI had run/stop buttons that worked. Post-0040, no dependency chaining, no stop button, no progress stats for 4/5 stages. Triage patched visibility for extract-context only. This spec brings v3 to parity with crawler/resolver/classifier pages. Builder spawned 2026-05-13."
 
   - id: "0039"
     title: "SSM Parameter Type Optimization (KMS Cost Reduction)"

--- a/locard/projectlist.md
+++ b/locard/projectlist.md
@@ -618,11 +618,11 @@ projects:
   - id: "0041"
     title: "Classifier V3 Pipeline — Operational Parity"
     summary: "Fix 6 gaps left by Spec 0040 builder: add dependency chaining dropdown, cancel button, progress stats for all 5 stages, allow completed dependencies, fix check_phase_conflict scheduled status bug, delete dead _launch_immediately code."
-    status: conceived
+    status: specified
     priority: high
     files:
       spec: locard/specs/0041-v3-pipeline-operational-parity.md
-      plan: null
+      plan: locard/plans/0041-v3-pipeline-operational-parity.md
       review: null
     dependencies: ["0040"]
     tags: [classifier, pipeline, job-queue, operations, bugfix]

--- a/locard/specs/0041-v3-pipeline-operational-parity.md
+++ b/locard/specs/0041-v3-pipeline-operational-parity.md
@@ -53,7 +53,9 @@ These are not new features. They are gaps between what 0040 was supposed to deli
 
 Add `{% include "pipeline/partials/_depends_on.html" %}` inside each of the 5 form elements, before the submit button. The partial already exists and renders a `<select name="depends_on">` dropdown populated from `dependency_choices` in the template context.
 
-The context variable `dependency_choices` is already passed by `ClassifierV3View.get_context_data()` (views.py:757). No view changes needed.
+The context variable `dependency_choices` is already passed by `ClassifierV3View.get_context_data()` (views.py:757).
+
+**View change needed:** `_get_dependency_choices()` currently filters to `status__in=["running", "pending"]`. This must be expanded to include `"completed"` so operators can chain after finished jobs (e.g., queue reclassify after a completed extract-context). The dropdown should show running, pending, and recently-completed jobs (completed within the last 24 hours, to avoid an unbounded list).
 
 ### 2. Template: Add cancel button to running v3 jobs
 
@@ -69,7 +71,13 @@ For each running job displayed in a step card, add a small cancel form that post
 </form>
 ```
 
-The `JobCancelView` (views.py:477) already handles this — it calls `cancel_job()` which sends SIGTERM, waits, escalates to SIGKILL, and cascades to dependents. The view currently redirects to `job_detail`; it should redirect back to the referrer or `classifier_v3` when the job is a v3 phase. Modify `JobCancelView` to check `request.META.get("HTTP_REFERER")` and redirect to `classifier_v3` if the cancelled job's phase is in `_V3_PHASES`.
+The `JobCancelView` (views.py:477) already handles this — it calls `cancel_job()` which sends SIGTERM, waits, escalates to SIGKILL, and cascades to dependents. The view currently redirects to `job_detail`; modify it to accept an optional `next` query parameter and redirect there instead. The cancel form should include a hidden `next` field:
+
+```html
+<form method="post" action="{% url 'job_cancel' job.pk %}?next={% url 'classifier_v3' %}" class="inline">
+```
+
+Do NOT use `HTTP_REFERER` for redirect — it can be missing, forged, or cross-origin. The `next` parameter is explicit, predictable, and already a Django convention. The `JobCancelView` should validate that `next` is a relative URL (starts with `/`) before redirecting, falling back to `job_detail` if absent or invalid.
 
 ### 3. Management commands: Add `--job-id` and stats flushing
 
@@ -171,7 +179,7 @@ Restore the original builder code which unconditionally shows "Queued {phase} jo
 
 ## Acceptance Criteria
 
-1. Each of the 5 v3 step cards on `/pipeline/classifier-v3/` has a "Queue after job" dropdown showing running and pending jobs
+1. Each of the 5 v3 step cards on `/pipeline/classifier-v3/` has a "Queue after job" dropdown showing running, pending, and recently-completed jobs
 2. Each running v3 job on the pipeline page has a "Cancel" button that stops the process
 3. All 5 v3 management commands accept `--job-id` and report `processed`/`failed` counts visible on the dashboard within 10 seconds of progress
 4. An operator can queue reclassify with `depends_on` set to a completed extract-context job without error
@@ -183,7 +191,7 @@ Restore the original builder code which unconditionally shows "Queued {phase} jo
 
 1. **Don't modify the `_depends_on.html` partial** — it's shared by 3 other pages. If you need v3-specific behavior, add a new partial or conditionally render.
 
-2. **Don't change `JobCancelView` signature** — it's already used by the job detail page. Only change where it redirects, and only for v3 phases.
+2. **Don't change `JobCancelView` signature** — it's already used by the job detail page. The `next` parameter is additive; the existing job_detail redirect is the fallback when `next` is absent.
 
 3. **Stats merge is not atomic** — `_merge_stats()` does read-then-write on `config_json`. Two concurrent flushers for the same job could clobber each other. This is fine because each job has exactly one process, so exactly one flusher. Don't "fix" this with a lock.
 
@@ -192,6 +200,16 @@ Restore the original builder code which unconditionally shows "Queued {phase} jo
 5. **Don't add stats flushing to the view layer** — the view reads stats from `config_json`, the management command writes them. The 5-second HTMX poll and 10-second flush interval mean stats lag by at most 15 seconds. That's fine.
 
 6. **Keep `reclassify_corpus.py`'s `--where` parameter** — the CLI still accepts it for direct command-line use. The STAGE_REGISTRY and web form correctly exclude it. Don't remove `--where` from the management command itself.
+
+7. **Validate the `next` parameter on `JobCancelView`** — only redirect to relative URLs (must start with `/`). Reject absolute URLs, protocol-relative URLs (`//evil.com`), and missing values. This prevents open redirect. Use `django.utils.http.url_has_allowed_host_and_scheme()` or a simple `startswith("/")` check.
+
+8. **`_get_dependency_choices` change affects all pages** — expanding it to include completed jobs will also show completed jobs in the crawler/resolver/classifier dependency dropdowns. This is acceptable — those pages already allow completed dependencies at the view layer. But be aware of the shared impact.
+
+## Testing Constraints
+
+The 45 existing tests (`test_v3_job_queue.py`) cannot run — Django's test runner needs `CREATE DATABASE` permission that the RDS app user doesn't have, and no SQLite test settings exist. This is a separate infrastructure issue (audit finding C3).
+
+Given this constraint, verification is manual against the live dashboard. The builder should add tests for the new logic (conflict check with `scheduled`, `depends_on` allowing `completed`, `next`-parameter redirect) but expect them to be validated when the test infrastructure is fixed, not as part of this spec.
 
 ## Verification Plan
 
@@ -202,3 +220,19 @@ For each item, the builder should manually verify on the running dashboard:
 3. Queue an extract-context job with `--state=RI` (small state), watch stats counters update on the dashboard while it runs
 4. Let an extract-context complete, then queue reclassify with `depends_on` set to the completed job — confirm it's accepted
 5. Run the management commands directly with `--job-id` and verify stats appear in the Job's `config_json`
+
+## Consultation Log
+
+### Round 1: Spec Review (2026-05-13)
+
+**Gemini**: COMMENT (HIGH confidence)
+- Suggested using `next` parameter instead of `HTTP_REFERER` for cancel redirect → **Adopted**
+- Noted `check_phase_conflict` verification hard to test manually → **Acknowledged in Testing Constraints**
+
+**Codex (GPT-5.4)**: REQUEST_CHANGES (HIGH confidence)
+- Cancel redirect via `HTTP_REFERER` is unsafe → **Adopted**: switched to `next` query parameter with relative-URL validation
+- AC1 says "running and pending" but AC4 requires completed deps → **Fixed**: expanded `_get_dependency_choices` to include recently-completed, updated AC1
+- Testing strategy too weak → **Acknowledged**: added Testing Constraints section explaining DB infrastructure blocker
+- Stats flush error handling underspecified → **Noted but not adopted**: single-operator system, daemon threads are fire-and-forget, swallowed exceptions are logged by the helper. Over-specifying this adds complexity without operator value.
+- AuthZ on cancel button → **Noted but not adopted**: `JobCancelView` already has `LoginRequiredMixin`. This is a single-operator system. There's one user.
+- Regression verification scope → **Noted but not adopted**: shared codepaths (`_depends_on.html`, `JobCancelView`, `check_phase_conflict`) are identified in Traps to Avoid. Specifying a formal regression test matrix for a system with no runnable tests is performative.

--- a/locard/specs/0041-v3-pipeline-operational-parity.md
+++ b/locard/specs/0041-v3-pipeline-operational-parity.md
@@ -1,0 +1,204 @@
+# Spec 0041: Classifier V3 Pipeline — Operational Parity
+
+**Status:** Draft
+**Author:** Architect
+**Date:** 2026-05-13
+**Dependencies:** Spec 0040 (Classifier V3 Job Queue Integration)
+
+---
+
+## Problem Statement
+
+Spec 0040 migrated the classifier v3 pipeline (extract-context, reclassify, compare-classify, resolve-disagree, promote-classify) from PipelineProcess to the Job queue. The data model migration is correct: `create_v3_job()`, STAGE_REGISTRY entries, conflict detection, and orchestrator dispatch all work.
+
+But the operator experience regressed. The pre-0040 PipelineProcess UI had a "Run" button that launched a process and a "Stop" button that killed it. Post-0040, the v3 dashboard page can queue jobs but:
+
+1. **No dependency chaining UI** — the "Queue after job" dropdown (`_depends_on.html` partial) is used by crawler, resolver, and classifier pages but was never added to the v3 page. The backend supports it (`ClassifierV3JobCreateView` parses `depends_on`, `create_v3_job()` validates it), but no form element exposes it. An operator cannot queue reclassify to run after extract-context completes.
+
+2. **No stop/cancel affordance** — the builder removed v3 phases from `ProcessStopView` (correctly — they're no longer PipelineProcess) but didn't add a Job-based cancel control. `JobCancelView` exists at `jobs/<pk>/cancel/` and works, but the operator has to navigate to the job detail page to use it. The v3 pipeline page has no stop button.
+
+3. **No progress visibility for 4/5 stages** — only `extract_classification_context.py` accepts `--job-id` and flushes stats (`processed`, `failed`) into `config_json` every 10 seconds. The other four commands (`reclassify_corpus`, `compare_classifications`, `resolve_disagreements`, `promote_classification_run`) don't accept `--job-id` at all — they don't know they're running as a Job. Their step cards show only "Nm ago" with no progress counters.
+
+4. **`depends_on` rejects completed jobs** — `ClassifierV3JobCreateView` (views.py:864) rejects any dependency where `dep_job.status in Job.TERMINAL_STATUSES`, which includes `completed`. But queuing work after an already-completed job is a valid workflow (e.g., queue reclassify after a completed extract-context). The orchestrator's `get_eligible_jobs()` already handles this correctly.
+
+5. **`check_phase_conflict()` misses `scheduled` status** — only checks `status="running"`, not `scheduled`. The v3 code (`create_v3_job()`) got this right with `status__in=["pending", "scheduled", "running"]`, but `check_phase_conflict()` is still called by `_start_eligible_jobs()` as a double-check before launch. All 7 legacy factory functions have the same bug.
+
+6. **Uncommitted `_launch_immediately()` dead code** — broken imports (`from pipeline.stages import ...`), leaks file handle, bypasses orchestrator audit trail. No template element triggers it. Must be deleted.
+
+These are not new features. They are gaps between what 0040 was supposed to deliver and what it actually delivered, measured against what the other pipeline pages already provide.
+
+## Goals
+
+1. **Dependency chaining on the v3 page** — every step card gets the "Queue after job" dropdown, matching crawler/resolver/classifier UX
+2. **Cancel button on running v3 jobs** — inline on the v3 pipeline page, not requiring navigation to job detail
+3. **Progress stats for all 5 stages** — every v3 management command accepts `--job-id` and flushes `processed`/`failed` counters into `config_json`
+4. **Allow completed dependencies** — `depends_on` validation only rejects `failed` and `cancelled`, not `completed`
+5. **Fix `check_phase_conflict()` to include `scheduled`** — backport to all legacy factory functions too
+6. **Remove `_launch_immediately()` dead code** — delete the uncommitted changes
+
+## Non-Goals
+
+- No new pipeline phases or stages
+- No STAGE_REGISTRY or COMMAND_MAP unification (that's a separate spec)
+- No PipelineProcess retirement (deferred)
+- No fd 3 protocol upgrade for v3 stages (the `config_json` stats pattern is sufficient for now)
+- No changes to the orchestrator daemon, scheduler, or Job model
+- No new tests beyond what's needed to validate these fixes (the 45 existing tests still can't run due to DB infrastructure — that's a separate issue)
+
+## Technical Implementation
+
+### 1. Template: Add dependency dropdown to all 5 step cards
+
+**File:** `lavandula/dashboard/pipeline/templates/pipeline/classifier_v3.html`
+
+Add `{% include "pipeline/partials/_depends_on.html" %}` inside each of the 5 form elements, before the submit button. The partial already exists and renders a `<select name="depends_on">` dropdown populated from `dependency_choices` in the template context.
+
+The context variable `dependency_choices` is already passed by `ClassifierV3View.get_context_data()` (views.py:757). No view changes needed.
+
+### 2. Template: Add cancel button to running v3 jobs
+
+**File:** `lavandula/dashboard/pipeline/templates/pipeline/classifier_v3.html`
+
+For each running job displayed in a step card, add a small cancel form that posts to the existing `job_cancel` URL:
+
+```html
+<form method="post" action="{% url 'job_cancel' job.pk %}" class="inline">
+  {% csrf_token %}
+  <button type="submit" class="text-red-600 hover:text-red-800 text-xs ml-2"
+          title="Cancel job #{{ job.pk }}">Cancel</button>
+</form>
+```
+
+The `JobCancelView` (views.py:477) already handles this — it calls `cancel_job()` which sends SIGTERM, waits, escalates to SIGKILL, and cascades to dependents. The view currently redirects to `job_detail`; it should redirect back to the referrer or `classifier_v3` when the job is a v3 phase. Modify `JobCancelView` to check `request.META.get("HTTP_REFERER")` and redirect to `classifier_v3` if the cancelled job's phase is in `_V3_PHASES`.
+
+### 3. Management commands: Add `--job-id` and stats flushing
+
+**Pattern to replicate** (from `extract_classification_context.py`):
+
+```python
+# In add_arguments():
+parser.add_argument("--job-id", type=int, default=None, help="Job ID for stats reporting")
+
+# In handle():
+job_id = options.get("job_id")
+stats = {"processed": 0, "failed": 0}
+stats_stop = threading.Event()
+
+def stats_flusher():
+    while not stats_stop.wait(10):
+        try:
+            _merge_stats(job_id, stats)
+        except Exception:
+            pass
+
+if job_id:
+    stats_thread = threading.Thread(target=stats_flusher, daemon=True)
+    stats_thread.start()
+
+# At completion:
+stats_stop.set()
+if job_id:
+    _merge_stats(job_id, stats)
+```
+
+**Files to modify:**
+
+| Command | File | What to count |
+|---|---|---|
+| `reclassify_corpus` | `management/commands/reclassify_corpus.py` | orgs classified / failed |
+| `compare_classifications` | `management/commands/compare_classifications.py` | results compared |
+| `resolve_disagreements` | `management/commands/resolve_disagreements.py` | disagreements resolved / failed |
+| `promote_classification_run` | `management/commands/promote_classification_run.py` | rows promoted |
+
+Each command already has an inner loop that processes items. Add `stats["processed"] += 1` and `stats["failed"] += 1` at the appropriate points. The `_merge_stats` helper reads the current `config_json` from the Job, merges the stats dict, and writes it back — identical to `extract_classification_context.py:396-401`.
+
+Factor the shared stats flusher into a small helper (e.g., `pipeline/job_stats.py`) to avoid duplicating the threading boilerplate in 4 files. The helper should provide:
+- `start_stats_flusher(job_id, stats_dict, interval=10)` → returns a stop event
+- `merge_stats(job_id, stats_dict)` — the atomic read-merge-write
+
+### 4. Fix `depends_on` validation
+
+**File:** `lavandula/dashboard/pipeline/views.py`, line 864
+
+Change:
+```python
+if dep_job.status in Job.TERMINAL_STATUSES:
+```
+
+To:
+```python
+if dep_job.status in ("failed", "cancelled"):
+```
+
+This allows `completed` as a valid dependency status. The orchestrator's `get_eligible_jobs()` already handles this: `Q(depends_on__status="completed")` is in the filter, so a job depending on a completed job is immediately eligible.
+
+### 5. Fix `check_phase_conflict()` to include `scheduled`
+
+**File:** `lavandula/dashboard/pipeline/orchestrator.py`, line 264
+
+Change:
+```python
+qs = Job.objects.filter(phase=phase, status="running")
+```
+
+To:
+```python
+qs = Job.objects.filter(phase=phase, status__in=["running", "scheduled"])
+```
+
+**Also fix all 7 legacy factory functions** (same file) that use `status__in=["pending", "running"]` — add `"scheduled"` to each:
+
+| Function | Line | Current | Fixed |
+|---|---|---|---|
+| `create_state_jobs` | 314 | `["pending", "running"]` | `["pending", "scheduled", "running"]` |
+| `create_resolve_job` | 356 | `["pending", "running"]` | `["pending", "scheduled", "running"]` |
+| `create_crawl_job` | 390 | `["pending", "running"]` | `["pending", "scheduled", "running"]` |
+| `create_classify_job` | 420 | `["pending", "running"]` | `["pending", "scheduled", "running"]` |
+| `create_990_index_job` | 464 | `["pending", "running"]` | `["pending", "scheduled", "running"]` |
+| `create_990_parse_job` | 492 | `["pending", "running"]` | `["pending", "scheduled", "running"]` |
+| `create_phone_enrich_job` | 518 | `["pending", "running"]` | `["pending", "scheduled", "running"]` |
+
+### 6. Delete `_launch_immediately()` and `run_now` logic
+
+**File:** `lavandula/dashboard/pipeline/views.py`
+
+Revert the uncommitted changes that added:
+- `run_now = request.POST.get("action") == "run_now"` (line 873)
+- The `if run_now and not depends_on:` branch (lines 880-884)
+- The entire `_launch_immediately()` method (lines 892-922)
+
+Restore the original builder code which unconditionally shows "Queued {phase} job".
+
+## Acceptance Criteria
+
+1. Each of the 5 v3 step cards on `/pipeline/classifier-v3/` has a "Queue after job" dropdown showing running and pending jobs
+2. Each running v3 job on the pipeline page has a "Cancel" button that stops the process
+3. All 5 v3 management commands accept `--job-id` and report `processed`/`failed` counts visible on the dashboard within 10 seconds of progress
+4. An operator can queue reclassify with `depends_on` set to a completed extract-context job without error
+5. `check_phase_conflict()` returns True for phases that are `scheduled` (not yet running)
+6. No `_launch_immediately` method exists in `views.py`
+7. No regressions to existing pipeline pages (crawler, resolver, classifier, 990, phone enrich)
+
+## Traps to Avoid
+
+1. **Don't modify the `_depends_on.html` partial** — it's shared by 3 other pages. If you need v3-specific behavior, add a new partial or conditionally render.
+
+2. **Don't change `JobCancelView` signature** — it's already used by the job detail page. Only change where it redirects, and only for v3 phases.
+
+3. **Stats merge is not atomic** — `_merge_stats()` does read-then-write on `config_json`. Two concurrent flushers for the same job could clobber each other. This is fine because each job has exactly one process, so exactly one flusher. Don't "fix" this with a lock.
+
+4. **`--job-id` is passed by the orchestrator** — the triage fix (`91b9f4a`) already adds `--job-id` to argv for all launched jobs. The management commands just need to accept the argument. Don't add `--job-id` passing logic — it already exists.
+
+5. **Don't add stats flushing to the view layer** — the view reads stats from `config_json`, the management command writes them. The 5-second HTMX poll and 10-second flush interval mean stats lag by at most 15 seconds. That's fine.
+
+6. **Keep `reclassify_corpus.py`'s `--where` parameter** — the CLI still accepts it for direct command-line use. The STAGE_REGISTRY and web form correctly exclude it. Don't remove `--where` from the management command itself.
+
+## Verification Plan
+
+For each item, the builder should manually verify on the running dashboard:
+
+1. Navigate to `/pipeline/classifier-v3/`, confirm "Queue after job" dropdown appears in each step card
+2. Queue an extract-context job, confirm it appears as running, confirm Cancel button appears next to it, click Cancel, confirm it transitions to cancelled
+3. Queue an extract-context job with `--state=RI` (small state), watch stats counters update on the dashboard while it runs
+4. Let an extract-context complete, then queue reclassify with `depends_on` set to the completed job — confirm it's accepted
+5. Run the management commands directly with `--job-id` and verify stats appear in the Job's `config_json`

--- a/locard/specs/0041-v3-pipeline-operational-parity.md
+++ b/locard/specs/0041-v3-pipeline-operational-parity.md
@@ -221,6 +221,14 @@ For each item, the builder should manually verify on the running dashboard:
 4. Let an extract-context complete, then queue reclassify with `depends_on` set to the completed job — confirm it's accepted
 5. Run the management commands directly with `--job-id` and verify stats appear in the Job's `config_json`
 
+## Security Assumptions
+
+This system is single-operator (one authenticated user: `ronp`). All views use `LoginRequiredMixin`. There is no multi-user authorization model, no role-based access control, and no need for one. If the system ever scales to multiple operators with different privilege levels, job cancellation and queue controls would need per-user or per-role authorization. Until then, `LoginRequiredMixin` is the authorization boundary.
+
+The `next` parameter on `JobCancelView` is validated to be a relative URL (starts with `/`, not `//`) to prevent open redirect. No other redirect parameters are introduced.
+
+`config_json` contains job arguments (state codes, run tags, flags) and stats counters. It does not contain credentials, API keys, or secrets. Job arguments are validated by `param_validators.py` before being stored. The dashboard displays `config_json` contents; this is intentional and expected.
+
 ## Consultation Log
 
 ### Round 1: Spec Review (2026-05-13)
@@ -236,3 +244,10 @@ For each item, the builder should manually verify on the running dashboard:
 - Stats flush error handling underspecified → **Noted but not adopted**: single-operator system, daemon threads are fire-and-forget, swallowed exceptions are logged by the helper. Over-specifying this adds complexity without operator value.
 - AuthZ on cancel button → **Noted but not adopted**: `JobCancelView` already has `LoginRequiredMixin`. This is a single-operator system. There's one user.
 - Regression verification scope → **Noted but not adopted**: shared codepaths (`_depends_on.html`, `JobCancelView`, `check_phase_conflict`) are identified in Traps to Avoid. Specifying a formal regression test matrix for a system with no runnable tests is performative.
+
+### Round 2: Red Team Security Review (2026-05-13)
+
+**Gemini (red team)**: REQUEST_CHANGES (HIGH confidence)
+- HIGH: Job cancellation lacks granular authorization → **Documented in Security Assumptions**: single-operator system, `LoginRequiredMixin` is the authorization boundary. No RBAC needed for one user.
+- MEDIUM: `config_json` could leak sensitive data → **Documented in Security Assumptions**: config_json contains only validated job arguments and stats, never credentials or secrets.
+- LOW: Test infrastructure gap is a long-term risk → **Acknowledged**: already tracked as audit finding C3, separate from this spec.


### PR DESCRIPTION
## Summary

Closes the operational gaps between the v3 classifier pipeline page and the existing crawler/resolver/classifier pages:

- **Dependency chaining**: All 5 v3 step cards now have the "Queue after job" dropdown (uses existing `_depends_on.html` partial), showing running, pending, and recently-completed jobs (24h window)
- **Cancel button**: Each running v3 job displays an inline Cancel button that redirects back to the v3 page (via `?next=` parameter on `JobCancelView`, with relative-URL validation to prevent open redirect)
- **Progress stats for all 5 stages**: The 4 remaining management commands (`reclassify_corpus`, `compare_classifications`, `resolve_disagreements`, `promote_classification_run`) now accept `--job-id` and flush `processed`/`failed` counters into `config_json` — shared helper in `pipeline/job_stats.py`
- **Completed dependencies allowed**: `depends_on` validation now only rejects `failed` and `cancelled` (not `completed`), matching the orchestrator's existing behavior
- **`check_phase_conflict()` includes `scheduled`**: Also backported to all 7 legacy factory function conflict checks
- **No `_launch_immediately` dead code**: Already absent from the codebase (no-op)

## Files changed

| File | Change |
|------|--------|
| `pipeline/orchestrator.py` | `check_phase_conflict` + 7 factory functions include `scheduled` |
| `pipeline/views.py` | `_get_dependency_choices` includes completed; `depends_on` allows completed; `JobCancelView` accepts `?next=` |
| `pipeline/templates/pipeline/classifier_v3.html` | 5 dependency dropdowns, 5 cancel buttons, stats display on all running job cards |
| `pipeline/job_stats.py` | New shared stats helper (merge_stats + start_stats_flusher) |
| `pipeline/management/commands/reclassify_corpus.py` | `--job-id` + periodic dashboard stats |
| `pipeline/management/commands/compare_classifications.py` | `--job-id` + final stats merge |
| `pipeline/management/commands/resolve_disagreements.py` | `--job-id` + periodic dashboard stats |
| `pipeline/management/commands/promote_classification_run.py` | `--job-id` + final stats merge |
| `pipeline/tests/test_v3_job_queue.py` | Updated: completed deps accepted; added: scheduled conflict, cancel redirect tests |

## Test plan

- [ ] `python3 manage.py check` passes (verified)
- [ ] Navigate to `/pipeline/classifier-v3/`, confirm dependency dropdown in all 5 step cards
- [ ] Queue a job, confirm Cancel button appears, click Cancel → redirects back to v3 page
- [ ] Cancel from job detail page still works (fallback redirect)
- [ ] Queue reclassify with `depends_on` set to a completed extract-context job → accepted
- [ ] Queue reclassify with `depends_on` set to a failed job → rejected
- [ ] Check crawler/resolver pages still show dependency dropdown (shared function)
- [ ] Run management command with `--job-id` → stats appear in config_json

🤖 Generated with [Claude Code](https://claude.com/claude-code)