### PR TITLE
[Spec 0042] Classifier v3 state × step progress grid

### DIFF
--- a/lavandula/dashboard/pipeline/templates/pipeline/classifier_v3.html
+++ b/lavandula/dashboard/pipeline/templates/pipeline/classifier_v3.html
@@ -8,6 +8,9 @@
 <!-- Auto-polling status block -->
 <div hx-get="{% url 'classifier_v3_status' %}" hx-trigger="load, every 5s" hx-swap="innerHTML"></div>
 
+<!-- State progress grid -->
+<div hx-get="{% url 'classifier_v3_state_grid' %}" hx-trigger="load, every 5s" hx-swap="innerHTML"></div>
+
 <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
 
   <!-- Step 1: Extract Context -->

--- a/lavandula/dashboard/pipeline/templates/pipeline/partials/classifier_v3_state_grid.html
+++ b/lavandula/dashboard/pipeline/templates/pipeline/partials/classifier_v3_state_grid.html
@@ -1,0 +1,45 @@
+<div class="bg-white rounded-lg shadow p-4 mb-4">
+  <h3 class="text-sm font-semibold text-gray-700 mb-2">State Progress</h3>
+  <div class="overflow-x-auto">
+    <table class="min-w-full text-xs">
+      <thead class="bg-gray-100">
+        <tr>
+          <th class="px-2 py-1 text-left">State</th>
+          <th class="px-2 py-1 text-center">Extract</th>
+          <th class="px-2 py-1 text-center">Reclassify</th>
+          <th class="px-2 py-1 text-center">Compare</th>
+          <th class="px-2 py-1 text-center">Resolve</th>
+          <th class="px-2 py-1 text-center">Promote</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for row in grid_rows %}
+        <tr class="border-b">
+          <td class="px-2 py-1 font-medium">{{ row.state }}</td>
+          {% for cell in row.cells %}
+          <td class="px-2 py-1 text-center font-mono">
+            {% if cell.status == "running" %}
+            <span class="text-blue-500 animate-pulse">●</span>
+            {% elif cell.status == "failed" %}
+            <span class="text-red-600 bg-red-50 px-1 rounded">✗</span>
+            {% elif cell.status == "complete" %}
+            {% if cell.pct %}
+            <span class="text-green-600 bg-green-50 px-1 rounded">100%</span>
+            {% else %}
+            <span class="text-green-600 bg-green-50 px-1 rounded">✓</span>
+            {% endif %}
+            {% elif cell.status == "partial" %}
+            <span class="text-yellow-600 bg-yellow-50 px-1 rounded">{{ cell.pct }}%</span>
+            {% else %}
+            <span class="text-gray-400">—</span>
+            {% endif %}
+          </td>
+          {% endfor %}
+        </tr>
+        {% empty %}
+        <tr><td colspan="6" class="px-2 py-4 text-center text-gray-400">No states found</td></tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+</div>

--- a/lavandula/dashboard/pipeline/tests/test_runner.py
+++ b/lavandula/dashboard/pipeline/tests/test_runner.py
@@ -15,7 +15,9 @@ _UNMANAGED_TABLES = [
             resolver_confidence REAL,
             resolver_method TEXT,
             resolver_reason TEXT,
-            resolver_updated_at TEXT
+            resolver_updated_at TEXT,
+            phone TEXT,
+            phone_source TEXT
         )
     """,
     """
@@ -31,7 +33,9 @@ _UNMANAGED_TABLES = [
             file_size_bytes INTEGER NOT NULL,
             page_count INTEGER,
             report_year INTEGER,
-            first_page_text TEXT
+            first_page_text TEXT,
+            content_type TEXT,
+            v3_material_type TEXT
         )
     """,
     """
@@ -90,6 +94,28 @@ _UNMANAGED_TABLES = [
             is_former INTEGER DEFAULT 0,
             extracted_at TEXT,
             run_id TEXT
+        )
+    """,
+    """
+        CREATE TABLE IF NOT EXISTS classification_context (
+            content_sha256 TEXT PRIMARY KEY,
+            extraction_method TEXT
+        )
+    """,
+    """
+        CREATE TABLE IF NOT EXISTS classification_runs (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            run_tag TEXT,
+            started_at TEXT,
+            finished_at TEXT
+        )
+    """,
+    """
+        CREATE TABLE IF NOT EXISTS classification_results (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            content_sha256 TEXT NOT NULL,
+            run_id INTEGER NOT NULL,
+            material_type TEXT
         )
     """,
 ]

--- a/lavandula/dashboard/pipeline/tests/test_v3_state_grid.py
+++ b/lavandula/dashboard/pipeline/tests/test_v3_state_grid.py
@@ -1,0 +1,319 @@
+"""Tests for Spec 0042: Classifier V3 State Progress Grid."""
+from django.contrib.auth.models import User
+from django.db import connections
+from django.test import Client, TestCase
+from django.urls import reverse
+
+from pipeline.models import Job
+from pipeline.views import _v3_state_grid
+
+
+def _insert_seed(cur, ein, state):
+    cur.execute(
+        "INSERT INTO nonprofits_seed (ein, state) VALUES (%s, %s)",
+        [ein, state],
+    )
+
+
+def _insert_corpus(cur, sha, ein, content_type="application/pdf", v3_material_type=None):
+    cur.execute(
+        "INSERT INTO corpus (content_sha256, source_org_ein, archived_at, "
+        "file_size_bytes, content_type, v3_material_type) VALUES (%s, %s, '2024-01-01', 1000, %s, %s)",
+        [sha, ein, content_type, v3_material_type],
+    )
+
+
+def _insert_context(cur, sha, method="llm"):
+    cur.execute(
+        "INSERT INTO classification_context (content_sha256, extraction_method) VALUES (%s, %s)",
+        [sha, method],
+    )
+
+
+def _insert_run(cur, run_id, finished=True):
+    cur.execute(
+        "INSERT INTO classification_runs (id, run_tag, started_at, finished_at) VALUES (%s, %s, '2024-01-01', %s)",
+        [run_id, f"run-{run_id}", "2024-01-01" if finished else None],
+    )
+
+
+def _insert_result(cur, sha, run_id):
+    cur.execute(
+        "INSERT INTO classification_results (content_sha256, run_id) VALUES (%s, %s)",
+        [sha, run_id],
+    )
+
+
+class StateGridTestBase(TestCase):
+    databases = "__all__"
+
+    def setUp(self):
+        self.cur = connections["pipeline"].cursor()
+
+    def tearDown(self):
+        for table in [
+            "classification_results",
+            "classification_runs",
+            "classification_context",
+            "corpus",
+            "nonprofits_seed",
+        ]:
+            self.cur.execute(f"DELETE FROM {table}")
+        self.cur.close()
+
+
+class ZeroDocStateTest(StateGridTestBase):
+    def test_zero_doc_state(self):
+        _insert_seed(self.cur, "000000001", "ZZ")
+        result = _v3_state_grid()
+        rows = result["grid_rows"]
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["state"], "ZZ")
+        for cell in rows[0]["cells"]:
+            self.assertEqual(cell["status"], "none")
+
+
+class PartialExtractionTest(StateGridTestBase):
+    def test_partial_extraction(self):
+        for i in range(10):
+            _insert_seed(self.cur, f"10000000{i}", "TX")
+            _insert_corpus(self.cur, f"sha_tx_{i}", f"10000000{i}")
+        for i in range(5):
+            _insert_context(self.cur, f"sha_tx_{i}")
+
+        result = _v3_state_grid()
+        rows = result["grid_rows"]
+        self.assertEqual(len(rows), 1)
+        extract_cell = rows[0]["cells"][0]
+        self.assertEqual(extract_cell["status"], "partial")
+        self.assertEqual(extract_cell["pct"], 50)
+
+
+class CompleteExtractionTest(StateGridTestBase):
+    def test_complete_extraction(self):
+        for i in range(5):
+            _insert_seed(self.cur, f"20000000{i}", "CA")
+            _insert_corpus(self.cur, f"sha_ca_{i}", f"20000000{i}")
+            _insert_context(self.cur, f"sha_ca_{i}")
+
+        result = _v3_state_grid()
+        rows = result["grid_rows"]
+        extract_cell = rows[0]["cells"][0]
+        self.assertEqual(extract_cell["status"], "complete")
+        self.assertEqual(extract_cell["pct"], 100)
+
+    def test_failed_extraction_counts_as_extracted(self):
+        _insert_seed(self.cur, "200000010", "NY")
+        _insert_corpus(self.cur, "sha_ny_0", "200000010")
+        _insert_context(self.cur, "sha_ny_0", method="failed:encrypted")
+
+        result = _v3_state_grid()
+        ny_row = [r for r in result["grid_rows"] if r["state"] == "NY"][0]
+        self.assertEqual(ny_row["cells"][0]["status"], "complete")
+
+
+class RunningJobOverlayTest(StateGridTestBase):
+    def test_running_job_overlay(self):
+        _insert_seed(self.cur, "300000001", "FL")
+        _insert_corpus(self.cur, "sha_fl_0", "300000001")
+        _insert_context(self.cur, "sha_fl_0")
+
+        Job.objects.create(
+            phase="extract-context", state_code="FL", status="running", host="localhost"
+        )
+        result = _v3_state_grid()
+        fl_row = [r for r in result["grid_rows"] if r["state"] == "FL"][0]
+        self.assertEqual(fl_row["cells"][0]["status"], "running")
+
+
+class FailedJobOverlayTest(StateGridTestBase):
+    def test_failed_job_overlay(self):
+        _insert_seed(self.cur, "400000001", "OH")
+        _insert_corpus(self.cur, "sha_oh_0", "400000001")
+
+        Job.objects.create(
+            phase="reclassify", state_code="OH", status="failed", host="localhost"
+        )
+        result = _v3_state_grid()
+        oh_row = [r for r in result["grid_rows"] if r["state"] == "OH"][0]
+        self.assertEqual(oh_row["cells"][1]["status"], "failed")
+
+
+class NationwideFallbackTest(StateGridTestBase):
+    def test_nationwide_fallback(self):
+        _insert_seed(self.cur, "500000001", "WA")
+        _insert_seed(self.cur, "500000002", "OR")
+
+        Job.objects.create(
+            phase="extract-context", state_code=None, status="running", host="localhost"
+        )
+        result = _v3_state_grid()
+        for row in result["grid_rows"]:
+            self.assertEqual(row["cells"][0]["status"], "running")
+
+
+class StateSpecificOverridesNationwideTest(StateGridTestBase):
+    def test_state_specific_overrides_nationwide_job_based(self):
+        _insert_seed(self.cur, "600000001", "GA")
+        _insert_seed(self.cur, "600000002", "SC")
+
+        Job.objects.create(
+            phase="compare-classify", state_code=None, status="running", host="localhost"
+        )
+        Job.objects.create(
+            phase="compare-classify", state_code="GA", status="completed", host="localhost"
+        )
+        result = _v3_state_grid()
+        ga_row = [r for r in result["grid_rows"] if r["state"] == "GA"][0]
+        sc_row = [r for r in result["grid_rows"] if r["state"] == "SC"][0]
+        self.assertEqual(ga_row["cells"][2]["status"], "complete")
+        self.assertEqual(sc_row["cells"][2]["status"], "running")
+
+    def test_state_specific_overrides_nationwide_pct(self):
+        _insert_seed(self.cur, "600000003", "TN")
+        _insert_seed(self.cur, "600000004", "KY")
+
+        Job.objects.create(
+            phase="extract-context", state_code=None, status="running", host="localhost"
+        )
+        Job.objects.create(
+            phase="extract-context", state_code="TN", status="completed", host="localhost"
+        )
+        result = _v3_state_grid()
+        tn_row = [r for r in result["grid_rows"] if r["state"] == "TN"][0]
+        ky_row = [r for r in result["grid_rows"] if r["state"] == "KY"][0]
+        self.assertNotEqual(tn_row["cells"][0]["status"], "running")
+        self.assertEqual(ky_row["cells"][0]["status"], "running")
+
+
+class JobBasedStepsNoPartialTest(StateGridTestBase):
+    def test_job_based_complete(self):
+        _insert_seed(self.cur, "700000001", "IL")
+        Job.objects.create(
+            phase="compare-classify", state_code="IL", status="completed", host="localhost"
+        )
+        result = _v3_state_grid()
+        il_row = [r for r in result["grid_rows"] if r["state"] == "IL"][0]
+        self.assertEqual(il_row["cells"][2]["status"], "complete")
+
+    def test_job_based_none(self):
+        _insert_seed(self.cur, "700000002", "MI")
+        result = _v3_state_grid()
+        mi_row = [r for r in result["grid_rows"] if r["state"] == "MI"][0]
+        self.assertEqual(mi_row["cells"][2]["status"], "none")
+        self.assertEqual(mi_row["cells"][3]["status"], "none")
+
+    def test_job_based_never_partial(self):
+        _insert_seed(self.cur, "700000003", "WI")
+        result = _v3_state_grid()
+        wi_row = [r for r in result["grid_rows"] if r["state"] == "WI"][0]
+        for cell in [wi_row["cells"][2], wi_row["cells"][3]]:
+            self.assertNotEqual(cell["status"], "partial")
+
+
+class SortingActionabilityTest(StateGridTestBase):
+    def test_sorting_order(self):
+        _insert_seed(self.cur, "800000001", "AA")
+        _insert_seed(self.cur, "800000002", "BB")
+        _insert_corpus(self.cur, "sha_bb_0", "800000002")
+        _insert_context(self.cur, "sha_bb_0")
+        _insert_seed(self.cur, "800000003", "CC")
+        _insert_seed(self.cur, "800000004", "DD")
+        _insert_seed(self.cur, "800000005", "EE")
+
+        Job.objects.create(
+            phase="extract-context", state_code="DD", status="failed", host="localhost"
+        )
+        Job.objects.create(
+            phase="reclassify", state_code="EE", status="running", host="localhost"
+        )
+
+        result = _v3_state_grid()
+        states = [r["state"] for r in result["grid_rows"]]
+        dd_idx = states.index("DD")
+        ee_idx = states.index("EE")
+        bb_idx = states.index("BB")
+        aa_idx = states.index("AA")
+        cc_idx = states.index("CC")
+        self.assertLess(dd_idx, ee_idx)
+        self.assertLess(ee_idx, bb_idx)
+        self.assertLess(bb_idx, aa_idx)
+        self.assertLess(bb_idx, cc_idx)
+
+
+class RowCountMatchesStatesTest(StateGridTestBase):
+    def test_row_count(self):
+        _insert_seed(self.cur, "900000001", "PA")
+        _insert_seed(self.cur, "900000002", "NJ")
+        _insert_corpus(self.cur, "sha_pa_0", "900000001")
+        _insert_corpus(self.cur, "sha_nj_0", "900000002")
+        _insert_seed(self.cur, "900000003", "DE")
+
+        result = _v3_state_grid()
+        states = {r["state"] for r in result["grid_rows"]}
+        self.assertEqual(states, {"PA", "NJ", "DE"})
+        de_row = [r for r in result["grid_rows"] if r["state"] == "DE"][0]
+        self.assertEqual(de_row["total_docs"], 0)
+
+
+class MultipleSeedsSameStateTest(StateGridTestBase):
+    def test_multiple_seeds(self):
+        for i in range(5):
+            _insert_seed(self.cur, f"A0000000{i}", "MA")
+            _insert_corpus(self.cur, f"sha_ma_{i}a", f"A0000000{i}")
+            _insert_corpus(self.cur, f"sha_ma_{i}b", f"A0000000{i}")
+
+        result = _v3_state_grid()
+        ma_row = [r for r in result["grid_rows"] if r["state"] == "MA"][0]
+        self.assertEqual(ma_row["total_docs"], 10)
+
+
+class InProgressRunIgnoredTest(StateGridTestBase):
+    def test_in_progress_run_ignored(self):
+        _insert_seed(self.cur, "B000000001", "CO")
+        _insert_corpus(self.cur, "sha_co_0", "B000000001")
+        _insert_run(self.cur, 1, finished=True)
+        _insert_run(self.cur, 2, finished=False)
+        _insert_result(self.cur, "sha_co_0", 1)
+
+        result = _v3_state_grid()
+        co_row = [r for r in result["grid_rows"] if r["state"] == "CO"][0]
+        self.assertEqual(co_row["cells"][1]["status"], "complete")
+        self.assertEqual(co_row["cells"][1]["pct"], 100)
+
+
+class HtmxPartialResponseTest(TestCase):
+    databases = "__all__"
+
+    def setUp(self):
+        self.user = User.objects.create_user("testuser", password="testpassword1234")
+        self.client = Client()
+        self.client.login(username="testuser", password="testpassword1234")
+
+    def test_partial_returns_200(self):
+        resp = self.client.get(reverse("classifier_v3_state_grid"))
+        self.assertEqual(resp.status_code, 200)
+
+    def test_partial_is_fragment(self):
+        resp = self.client.get(reverse("classifier_v3_state_grid"))
+        content = resp.content.decode()
+        self.assertNotIn("<html", content)
+        self.assertIn("<table", content)
+
+    def test_partial_requires_login(self):
+        self.client.logout()
+        resp = self.client.get(reverse("classifier_v3_state_grid"))
+        self.assertEqual(resp.status_code, 302)
+
+
+class PdfOnlyDenominatorTest(StateGridTestBase):
+    def test_pdf_only(self):
+        _insert_seed(self.cur, "C000000001", "AZ")
+        for i in range(5):
+            _insert_corpus(self.cur, f"sha_az_pdf_{i}", "C000000001", content_type="application/pdf")
+        for i in range(3):
+            _insert_corpus(self.cur, f"sha_az_html_{i}", "C000000001", content_type="text/html")
+
+        result = _v3_state_grid()
+        az_row = [r for r in result["grid_rows"] if r["state"] == "AZ"][0]
+        self.assertEqual(az_row["total_docs"], 5)

--- a/lavandula/dashboard/pipeline/urls.py
+++ b/lavandula/dashboard/pipeline/urls.py
@@ -31,6 +31,7 @@ urlpatterns = [
     path("classifier-v3/", views.ClassifierV3View.as_view(), name="classifier_v3"),
     path("classifier-v3/status/", views.ClassifierV3StatusPartial.as_view(), name="classifier_v3_status"),
     path("classifier-v3/queue/", views.ClassifierV3JobCreateView.as_view(), name="classifier_v3_job_create"),
+    path("classifier-v3/state-grid/", views.ClassifierV3StateGridPartial.as_view(), name="classifier_v3_state_grid"),
     path("classifier-v3/log/<str:filename>/", views.ProcessLogPartial.as_view(), name="process_log_partial"),
 
     # Phone Enrichment

--- a/lavandula/dashboard/pipeline/views.py
+++ b/lavandula/dashboard/pipeline/views.py
@@ -3,7 +3,7 @@ import socket
 from django.contrib import messages
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.db import models
-from django.db.models import Count, Q
+from django.db.models import Count, Max, Q
 from django.http import HttpResponse, HttpResponseRedirect
 from django.shortcuts import get_object_or_404, redirect
 from django.urls import reverse
@@ -836,6 +836,118 @@ class ClassifierV3StatusPartial(HtmxLoginRequiredMixin, TemplateView):
         ctx["steps"] = steps
         ctx["runs"] = runs
         ctx["recent_logs"] = _scan_v3_logs(limit=10)
+        return ctx
+
+
+_PHASE_LIST = [
+    ("extract-context", "extracted", True),
+    ("reclassify", "reclassified", True),
+    ("compare-classify", None, False),
+    ("resolve-disagree", None, False),
+    ("promote-classify", "promoted", True),
+]
+
+
+def _v3_state_grid():
+    from django.db import connections
+
+    with connections["pipeline"].cursor() as cur:
+        cur.execute("""
+            SELECT
+                s.state,
+                COUNT(DISTINCT c.content_sha256) AS total_docs,
+                COUNT(DISTINCT cc.content_sha256) AS extracted,
+                COUNT(DISTINCT cr.content_sha256) AS reclassified,
+                COUNT(DISTINCT CASE WHEN c.v3_material_type IS NOT NULL
+                      THEN c.content_sha256 END) AS promoted
+            FROM nonprofits_seed s
+            LEFT JOIN corpus c
+                ON s.ein = c.source_org_ein AND c.content_type = 'application/pdf'
+            LEFT JOIN classification_context cc
+                ON c.content_sha256 = cc.content_sha256
+            LEFT JOIN classification_results cr
+                ON c.content_sha256 = cr.content_sha256
+                AND cr.run_id = (SELECT MAX(id) FROM classification_runs
+                                 WHERE finished_at IS NOT NULL)
+            GROUP BY s.state
+            ORDER BY s.state
+        """)
+        columns = [col[0] for col in cur.description]
+        state_rows = [dict(zip(columns, row)) for row in cur.fetchall()]
+
+    latest_per_phase_state = (
+        Job.objects
+        .filter(phase__in=_V3_PHASES)
+        .exclude(status__in=["pending", "cancelled"])
+        .values("phase", "state_code")
+        .annotate(latest_id=Max("id"))
+    )
+    job_ids = [e["latest_id"] for e in latest_per_phase_state]
+    jobs = Job.objects.filter(pk__in=job_ids).values("id", "phase", "state_code", "status")
+
+    state_job_map = {}
+    nationwide_job_map = {}
+    for j in jobs:
+        if j["state_code"] is None:
+            nationwide_job_map[j["phase"]] = j["status"]
+        else:
+            state_job_map[(j["phase"], j["state_code"])] = j["status"]
+
+    for state_row in state_rows:
+        cells = []
+        for phase, doc_key, is_pct in _PHASE_LIST:
+            state_specific = state_job_map.get((phase, state_row["state"]))
+            nationwide = nationwide_job_map.get(phase)
+            job_status = state_specific if state_specific is not None else nationwide
+
+            if job_status == "running":
+                cells.append({"status": "running"})
+            elif job_status == "failed":
+                cells.append({"status": "failed"})
+            elif is_pct:
+                total = state_row["total_docs"]
+                done = state_row.get(doc_key, 0)
+                if total == 0:
+                    cells.append({"status": "none"})
+                else:
+                    pct = round(done / total * 100)
+                    if pct >= 100:
+                        cells.append({"status": "complete", "pct": 100})
+                    elif pct > 0:
+                        cells.append({"status": "partial", "pct": pct})
+                    else:
+                        cells.append({"status": "none"})
+            else:
+                if job_status == "completed":
+                    cells.append({"status": "complete"})
+                else:
+                    cells.append({"status": "none"})
+        state_row["cells"] = cells
+
+    def _action_score(row):
+        statuses = [c["status"] for c in row["cells"]]
+        if "failed" in statuses:
+            return 0
+        if "running" in statuses:
+            return 1
+        has_progress = any(s in ("complete", "partial") for s in statuses)
+        has_none = any(s == "none" for s in statuses)
+        if has_progress and has_none:
+            return 2
+        if has_progress:
+            return 3
+        return 4
+
+    state_rows.sort(key=lambda r: (_action_score(r), -r["total_docs"]))
+    return {"grid_rows": state_rows}
+
+
+class ClassifierV3StateGridPartial(HtmxLoginRequiredMixin, TemplateView):
+    template_name = "pipeline/partials/classifier_v3_state_grid.html"
+
+    def get_context_data(self, **kwargs):
+        ctx = super().get_context_data(**kwargs)
+        ctx.update(_v3_state_grid())
         return ctx
 
 


### PR DESCRIPTION
## Summary
- Adds a state × step progress grid to the classifier v3 dashboard page, showing all 51 states across 5 pipeline steps (extract, reclassify, compare, resolve, promote)
- Percentage-based steps show completion percentages; job-based steps show check/X icons. Cells are color-coded: blue pulse (running), red (failed), green (complete), yellow (partial), gray (not started)
- States sorted by actionability: failed first, then running, then partially complete, then fully done, then not started
- Auto-refreshes via HTMX partial every 5 seconds, matching existing v3 status bar pattern
- All data derived from live SQL queries against existing tables — no new database columns or tables

## Files changed
- `pipeline/views.py` — `_v3_state_grid()` helper + `ClassifierV3StateGridPartial` view class (~100 lines)
- `pipeline/urls.py` — new URL pattern for state-grid partial
- `pipeline/templates/pipeline/classifier_v3.html` — HTMX div for auto-refresh
- `pipeline/templates/pipeline/partials/classifier_v3_state_grid.html` — grid partial template (new)
- `pipeline/tests/test_v3_state_grid.py` — 20 tests covering all acceptance criteria (new)
- `pipeline/tests/test_runner.py` — add classification_context/results/runs tables + missing columns

## Test plan
- [x] 20 unit tests pass covering: zero-doc states, partial/complete extraction, running/failed job overlay, nationwide fallback, state-specific override, job-based steps (no partial), actionability sorting, row count, multiple seeds per state, in-progress run ignored, HTMX partial response, PDF-only denominator
- [ ] Manual verification on production dashboard after deploy
- [ ] Query performance under 3 seconds on production with warm buffer cache

🤖 Generated with [Claude Code](https://claude.com/claude-code)