### PR TITLE
Fix reconcile_s3 perf: single-pass fetch_log sha index (unblocks --apply)

### DIFF
--- a/lavandula/reports/tests/unit/test_reconcile_s3_fetchlog_index.py
+++ b/lavandula/reports/tests/unit/test_reconcile_s3_fetchlog_index.py
@@ -1,0 +1,52 @@
+"""Unit tests for reconcile_s3 fetch_log sha-index reduction.
+
+Guards the perf fix that replaced a per-orphan `notes LIKE '%sha=...%'`
+scan (one full scan of the multi-million-row fetch_log per orphan) with a
+single-pass {sha: (ein, url_redacted)} index. The reducer MUST preserve
+the old per-sha query's semantics: parse sha from notes, skip empty-ein
+rows, highest-id row wins.
+"""
+from __future__ import annotations
+
+
+def test_index_parses_sha_from_notes():
+    from lavandula.reports.tools.reconcile_s3 import _index_from_fetch_log_rows
+
+    sha = "a" * 64
+    idx = _index_from_fetch_log_rows([("123456789", "https://x/y", f"sha={sha}")])
+    assert idx == {sha: ("123456789", "https://x/y")}
+
+
+def test_index_skips_empty_ein():
+    from lavandula.reports.tools.reconcile_s3 import _index_from_fetch_log_rows
+
+    sha = "b" * 64
+    idx = _index_from_fetch_log_rows([("", "https://x", f"sha={sha}")])
+    assert idx == {}
+
+
+def test_index_skips_notes_without_sha():
+    from lavandula.reports.tools.reconcile_s3 import _index_from_fetch_log_rows
+
+    idx = _index_from_fetch_log_rows([("123456789", "https://x", "no sha here")])
+    assert idx == {}
+
+
+def test_index_handles_none_notes():
+    from lavandula.reports.tools.reconcile_s3 import _index_from_fetch_log_rows
+
+    idx = _index_from_fetch_log_rows([("123456789", "https://x", None)])
+    assert idx == {}
+
+
+def test_index_highest_id_wins():
+    """Rows arrive id-ascending; the later row for a sha overwrites,
+    matching the old query's ORDER BY id DESC LIMIT 1."""
+    from lavandula.reports.tools.reconcile_s3 import _index_from_fetch_log_rows
+
+    sha = "c" * 64
+    idx = _index_from_fetch_log_rows([
+        ("111111111", "https://old", f"sha={sha}"),
+        ("222222222", "https://new", f"sha={sha}"),
+    ])
+    assert idx == {sha: ("222222222", "https://new")}

--- a/lavandula/reports/tools/reconcile_s3.py
+++ b/lavandula/reports/tools/reconcile_s3.py
@@ -12,6 +12,7 @@ import argparse
 import logging
 import re
 import sys
+from collections.abc import Iterable
 from datetime import datetime
 from urllib.parse import unquote, urlparse
 
@@ -34,6 +35,7 @@ log = logging.getLogger("lavandula.reports.reconcile_s3")
 _SHA_RE = re.compile(r"^[a-f0-9]{64}$")
 _KEY_RE = re.compile(r"^(?:.*/)?([a-f0-9]{64})\.pdf$")
 _EIN_RE = re.compile(r"^\d{9}$")
+_NOTES_SHA_RE = re.compile(r"sha=([a-f0-9]{64})")
 
 _ALLOWED_ATTRIBUTION = {"own_domain", "platform_verified", "platform_unverified"}
 _ALLOWED_DISCOVERED_VIA = {
@@ -66,20 +68,44 @@ def _db_shas(engine: Engine) -> set[str]:
         }
 
 
-def _fetch_log_attribution(engine: Engine, sha: str) -> tuple[str, str] | None:
-    """Look up the authoritative (ein, url_redacted) for `sha` in fetch_log."""
+def _index_from_fetch_log_rows(
+    rows: Iterable[tuple[str, str, str]],
+) -> dict[str, tuple[str, str]]:
+    """Reduce (ein, url_redacted, notes) rows — ordered by ascending id —
+    into a {sha: (ein, url_redacted)} index.
+
+    Preserves the semantics of the old per-sha lookup:
+      - sha is parsed from the `notes` field (`sha=<64 hex>`)
+      - rows with an empty `ein` are ignored
+      - the highest-id row for a sha wins (callers pass rows id-ascending,
+        so a later write overwrites — equivalent to ORDER BY id DESC LIMIT 1)
+    """
+    idx: dict[str, tuple[str, str]] = {}
+    for ein, url_redacted, notes in rows:
+        if not ein:
+            continue
+        m = _NOTES_SHA_RE.search(notes or "")
+        if m:
+            idx[m.group(1)] = (ein, url_redacted)
+    return idx
+
+
+def _build_fetch_log_sha_index(engine: Engine) -> dict[str, tuple[str, str]]:
+    """One-pass {sha: (ein, url_redacted)} index from fetch_log notes.
+
+    Replaces a per-orphan `notes LIKE '%sha=...%'` query (one full scan
+    of the multi-million-row fetch_log per orphan) with a single streamed
+    scan, restricted to the rows whose notes carry a sha tag.
+    """
     with engine.connect() as conn:
-        row = conn.execute(
+        result = conn.execution_options(stream_results=True).execute(
             text(
-                "SELECT ein, url_redacted FROM lava_corpus.fetch_log "
-                " WHERE kind = 'pdf-get' AND notes LIKE :pat "
-                " ORDER BY id DESC LIMIT 1"
-            ),
-            {"pat": f"%sha={sha}%"},
-        ).fetchone()
-    if row is None or not row[0]:
-        return None
-    return row[0], row[1]
+                "SELECT ein, url_redacted, notes FROM lava_corpus.fetch_log "
+                " WHERE kind = 'pdf-get' AND notes LIKE '%sha=%' "
+                " ORDER BY id"
+            )
+        )
+        return _index_from_fetch_log_rows(iter(result))
 
 
 def _valid_metadata(md: dict) -> tuple[bool, dict, str]:
@@ -182,13 +208,15 @@ def reconcile(
         if sha not in db_shas:
             orphans.append((key, sha))
 
+    fl_index = _build_fetch_log_sha_index(engine)
+
     for key, sha in orphans:
         head = client.head_object(Bucket=bucket, Key=key)
         md = head.get("Metadata", {}) or {}
         ok, clean, reason = _valid_metadata(md)
         size = head.get("ContentLength", 0)
 
-        fl = _fetch_log_attribution(engine, sha)
+        fl = fl_index.get(sha)
         ein: str | None = None
         source_redacted: str | None = None
         fetched_at = ""


### PR DESCRIPTION
## Summary

`reconcile_s3.reconcile()` called `_fetch_log_attribution()` **once per orphan**, each doing a leading-wildcard `notes LIKE '%sha=...%'` scan of the multi-million-row `fetch_log`. With the current ~22,981 orphan backlog that is ~23K full table scans — `reconcile_s3 --apply` hangs for hours and is effectively unrunnable.

This replaces it with `_build_fetch_log_sha_index()`: **one** streamed scan, restricted to rows whose `notes` carry a `sha=` tag, reduced into a `{sha: (ein, url_redacted)}` map looked up O(1) per orphan.

The change is **behavior-preserving**. `_index_from_fetch_log_rows()` keeps the old per-sha query's exact semantics:
- sha parsed from `notes` (`sha=<64 hex>`)
- rows with empty `ein` ignored
- highest-id row for a sha wins (rows fed id-ascending → later overwrites → equivalent to the old `ORDER BY id DESC LIMIT 1`)

The now-unused `_fetch_log_attribution()` is removed so the pathologically-slow path can't be reused.

## Context

Surfaced while quantifying the Spec 0047 orphan backlog (authoritative S3-vs-`corpus` reconciliation, read-only):
- **22,981** PDF objects physically in S3 with no `corpus` row
- Full census: **100%** carry valid S3 metadata → all 22,981 cleanly recoverable via `reconcile_s3 --apply`
- `fetch_log` notes carry **0** `sha=` tags, so the removed per-orphan query returned nothing for every orphan anyway — pure dead weight

This PR unblocks running `--apply` to backfill those ~23K documents into `corpus` (they arrive unclassified and still need a classification pass).

## Test plan

- [x] New unit tests `test_reconcile_s3_fetchlog_index.py` (5) — sha parse, empty-ein skip, no-sha skip, None notes, highest-id-wins
- [x] Existing `test_cross_origin_pdf_recovery_0047.py` (27) pass — no collateral
- [x] Import sanity: module imports, new symbols present, `_fetch_log_attribution` removed
- [ ] Reviewer: confirm streamed single-scan approach acceptable on prod `fetch_log` size

🤖 Generated with [Claude Code](https://claude.com/claude-code)