### PR TITLE
[Spec 0055] Multi-instance parse with SKIP LOCKED work queue

### DIFF
--- a/lavandula/dashboard/pipeline/forms.py
+++ b/lavandula/dashboard/pipeline/forms.py
@@ -405,6 +405,12 @@ class ParseRunForm(forms.Form):
         widget=forms.Select(attrs={"class": _SELECT}),
         label="Instance Type",
     )
+    workers = forms.IntegerField(
+        initial=1, min_value=1, max_value=4,
+        widget=forms.NumberInput(attrs={"class": _SELECT}),
+        label="Workers",
+        help_text="Concurrent GPU instances (1-4)",
+    )
     no_spot = forms.BooleanField(
         required=False,
         label="Use on-demand (not spot)",

--- a/lavandula/dashboard/pipeline/management/commands/parse_documents.py
+++ b/lavandula/dashboard/pipeline/management/commands/parse_documents.py
@@ -66,6 +66,8 @@ class Command(BaseCommand):
                             help="Hours to retry when no spot capacity (1-12)")
         parser.add_argument("--job-id", type=int, default=None,
                             help="Dashboard Job ID to update progress on")
+        parser.add_argument("--workers", type=int, default=1,
+                            help="Number of concurrent GPU instances (1-4)")
 
     def handle(self, *args, **options):
         run_tag = options["run_tag"]
@@ -78,6 +80,9 @@ class Command(BaseCommand):
 
         if not (10 <= options["batch_size"] <= 5000):
             raise CommandError("--batch-size must be 10-5000")
+
+        if not (1 <= options["workers"] <= 4):
+            raise CommandError("--workers must be 1-4")
 
         priority_values = [v.strip() for v in options["priority"].split(",")]
         if not config.validate_priority_values(priority_values):
@@ -118,15 +123,27 @@ class Command(BaseCommand):
         est_cost = est_hours * rate
         pricing_label = f"spot @ ${SPOT_RATE_PER_HOUR}/hr" if use_spot else f"on-demand @ ${ONDEMAND_RATE_PER_HOUR}/hr"
 
-        self.stdout.write(
-            f"Eligible documents: {count:,}\n"
-            f"Estimated pages:    ~{est_pages:,.0f}\n"
-            f"Estimated GPU time: ~{est_hours:.1f} hours\n"
-            f"Estimated cost:     ~${est_cost:.0f} ({pricing_label})\n"
-            f"Priority filter:    {', '.join(priority)}\n"
-            f"NTEE filter:        {ntee_filter or 'all'}\n"
-            f"Instance type:      {options['instance_type']}\n"
-        )
+        workers = options.get("workers", 1)
+        lines = [
+            f"Eligible documents: {count:,}",
+            f"Estimated pages:    ~{est_pages:,.0f}",
+            f"Estimated GPU time: ~{est_hours:.1f} hours (total compute)",
+            f"Estimated cost:     ~${est_cost:.0f} ({pricing_label})",
+        ]
+        if workers > 1 or count > 0:
+            for n in (1, 2, 4):
+                wall = est_hours / n
+                lines.append(
+                    f"  {n} worker{'s' if n > 1 else ''}:  ~{wall:.1f}h wall time, "
+                    f"~${est_cost:.0f} ({pricing_label})"
+                )
+        lines.extend([
+            f"Priority filter:    {', '.join(priority)}",
+            f"NTEE filter:        {ntee_filter or 'all'}",
+            f"Instance type:      {options['instance_type']}",
+            f"Workers:            {workers}",
+        ])
+        self.stdout.write("\n".join(lines) + "\n")
 
     def _show_status(self, run_tag: str) -> None:
         conn = self._get_conn()
@@ -160,14 +177,25 @@ class Command(BaseCommand):
         import boto3
 
         ec2 = boto3.client("ec2", region_name="us-east-1")
+
+        # Terminate all instances for all slots
+        terminated = 0
+        for slot_idx in range(4):
+            instance_id = self._find_instance(ec2, run_tag, slot_index=slot_idx)
+            if instance_id:
+                ec2.terminate_instances(InstanceIds=[instance_id])
+                self.stdout.write(f"Terminated instance {instance_id} (slot {slot_idx})\n")
+                terminated += 1
+
+        # Also try the old-style tag (no slot index) for backward compat
         instance_id = self._find_instance(ec2, run_tag)
+        if instance_id:
+            ec2.terminate_instances(InstanceIds=[instance_id])
+            self.stdout.write(f"Terminated instance {instance_id}\n")
+            terminated += 1
 
-        if not instance_id:
-            self.stdout.write("No running instance found for this run tag.\n")
-            return
-
-        ec2.terminate_instances(InstanceIds=[instance_id])
-        self.stdout.write(f"Terminated instance {instance_id}\n")
+        if terminated == 0:
+            self.stdout.write("No running instances found for this run tag.\n")
 
         conn = self._get_conn()
         try:
@@ -220,11 +248,64 @@ class Command(BaseCommand):
         except Exception:
             logger.exception("Failed to update Job %s progress", job_id)
 
+    def _populate_or_resume_queue(self, conn, run_id, priority, ntee_filter):
+        """Populate work queue or resume from existing queue."""
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT COUNT(*) FROM lava_parse.work_queue WHERE run_id = %s",
+                (run_id,),
+            )
+            existing = cur.fetchone()[0]
+
+        if existing > 0:
+            reclaimed = db.reclaim_all_stale_claims(conn, run_id)
+            self.stdout.write(
+                f"Resuming: {existing} queue items, {reclaimed} stale claims reclaimed\n"
+            )
+            return existing
+        else:
+            count = db.populate_work_queue(conn, run_id, priority, ntee_filter)
+            self.stdout.write(f"Populated work queue: {count} items\n")
+            return count
+
+    def _terminate_all(self, ec2, slots):
+        """Terminate all running instances across all slots."""
+        for slot in slots:
+            if slot["instance_id"] and slot["status"] == "running":
+                self._safe_terminate(ec2, slot["instance_id"])
+                slot["status"] = "terminated"
+
+    def _get_worker_last_activity(self, conn, run_id, worker_id):
+        """Get the most recent completed_at for a worker (heartbeat signal)."""
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT MAX(completed_at)
+                FROM lava_parse.work_queue
+                WHERE run_id = %s AND claimed_by = %s AND completed_at IS NOT NULL
+                """,
+                (run_id, worker_id),
+            )
+            row = cur.fetchone()
+            return row[0] if row else None
+
+    def _update_instance_ids(self, conn, run_id, slots):
+        """Update parse_runs with current instance ID list."""
+        active_ids = [s["instance_id"] for s in slots if s["instance_id"]]
+        first_id = active_ids[0] if active_ids else None
+        with conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "UPDATE lava_parse.parse_runs SET instance_id = %s, instance_ids = %s WHERE id = %s",
+                    (first_id, active_ids or None, run_id),
+                )
+
     def _execute_run(self, conn, run_tag: str, priority: list[str], ntee_filter: str | None, options: dict) -> None:
         import boto3
 
         ec2 = boto3.client("ec2", region_name="us-east-1")
         job_id = options.get("job_id")
+        workers = options.get("workers", 1)
 
         # Scheduled start: wait until start_at time
         start_at_str = options.get("start_at")
@@ -254,6 +335,7 @@ class Command(BaseCommand):
             "retry_errors": options["retry_errors"],
             "reparse": options["reparse"],
             "min_version": options.get("min_version"),
+            "workers": workers,
         }
 
         try:
@@ -269,142 +351,187 @@ class Command(BaseCommand):
         if options["reparse"] and options.get("min_version"):
             self._delete_old_version_rows(conn, priority, options["min_version"])
 
-        eligible_count = db.get_eligible_count(conn, priority, ntee_filter=ntee_filter)
+        # Populate or resume work queue
+        eligible_count = self._populate_or_resume_queue(conn, run_id, priority, ntee_filter)
+        if eligible_count == 0:
+            self.stdout.write("No eligible documents. Nothing to do.\n")
+            db.finish_run(conn, run_id, {"total": 0, "succeeded": 0, "failed": 0})
+            self._update_job_progress(job_id, 0, 0, "completed")
+            return
+
         self._update_job_progress(job_id, 0, eligible_count, "running")
 
         start_time = time.time()
         max_seconds = options["max_hours"] * 3600
-        relaunch_count = 0
         final_status = "completed"
 
-        instance_id = self._launch_with_capacity_retry(ec2, conn, run_id, run_tag, priority, ntee_filter, options)
-        if instance_id is None:
+        # Initialize slots
+        slots = [
+            {"instance_id": None, "status": "pending", "relaunch_count": 0}
+            for _ in range(workers)
+        ]
+
+        # Launch N instances
+        launched = 0
+        for idx, slot in enumerate(slots):
+            iid = self._launch_with_capacity_retry(
+                ec2, conn, run_id, run_tag, priority, ntee_filter, options, slot_index=idx
+            )
+            if iid:
+                slot["instance_id"] = iid
+                slot["status"] = "running"
+                launched += 1
+            else:
+                slot["status"] = "capacity_exhausted"
+
+        if launched == 0:
+            self.stderr.write("Failed to launch any instances. Run failed.\n")
             self._update_job_progress(job_id, 0, eligible_count, "failed")
+            db.finish_run(conn, run_id, {"total": 0, "succeeded": 0, "failed": 0})
             return
 
-        last_stats_update = time.time()
-        last_total = 0
+        self._update_instance_ids(conn, run_id, slots)
 
+        if launched < workers:
+            self.stdout.write(
+                f"Partial launch: {launched}/{workers} workers active\n"
+            )
+
+        # Multi-instance poll loop
         while True:
             time.sleep(POLL_INTERVAL_SECONDS)
 
             if self._shutdown_requested:
-                self.stdout.write("Shutdown requested. Terminating instance.\n")
-                self._safe_terminate(ec2, instance_id)
+                self.stdout.write("Shutdown requested. Terminating all instances.\n")
+                self._terminate_all(ec2, slots)
                 final_status = "cancelled"
                 break
 
             elapsed = time.time() - start_time
             if elapsed >= max_seconds:
-                self.stdout.write(f"Max hours ({options['max_hours']}) reached. Terminating.\n")
-                self._safe_terminate(ec2, instance_id)
+                self.stdout.write(f"Max hours ({options['max_hours']}) reached. Terminating all.\n")
+                self._terminate_all(ec2, slots)
                 break
 
-            # Check if worker reported completion
-            status = db.get_run_status(conn, run_tag)
-            if status and status.get("finished_at"):
-                self.stdout.write("Worker reported completion.\n")
-                self._safe_terminate(ec2, instance_id)
-                break
+            # Check each slot
+            for slot in slots:
+                if slot["status"] != "running":
+                    continue
+                iid = slot["instance_id"]
+                state = self._get_instance_state(ec2, iid)
 
-            # Check instance state — spot interruption detection
-            state = self._get_instance_state(ec2, instance_id)
-            if state in ("terminated", "shutting-down"):
-                self.stdout.write(f"Instance {instance_id} terminated (spot reclaimed or crash).\n")
+                if state in ("terminated", "shutting-down"):
+                    self.stdout.write(f"Instance {iid} terminated.\n")
+                    db.reclaim_stale_claims(conn, run_id, iid)
 
-                # Check if there's still work to do
-                remaining = db.get_eligible_count(conn, priority)
-                if remaining == 0:
-                    self.stdout.write("No remaining work. Run complete.\n")
-                    break
+                    progress = db.get_queue_progress(conn, run_id)
+                    remaining = progress["total"] - progress["completed"] - progress["errored"]
+                    if remaining == 0:
+                        slot["status"] = "done"
+                        continue
 
-                # Attempt relaunch
-                relaunch_count += 1
-                if relaunch_count > MAX_RELAUNCH_ATTEMPTS:
-                    self.stderr.write(
-                        f"Exceeded max relaunch attempts ({MAX_RELAUNCH_ATTEMPTS}). "
-                        f"Stopping. {remaining:,} docs remain.\n"
+                    slot["relaunch_count"] += 1
+                    if slot["relaunch_count"] > MAX_RELAUNCH_ATTEMPTS:
+                        slot["status"] = "capacity_exhausted"
+                        self.stderr.write(f"Slot exceeded max relaunches.\n")
+                        continue
+
+                    self.stdout.write(
+                        f"Relaunching slot (attempt {slot['relaunch_count']}/{MAX_RELAUNCH_ATTEMPTS})...\n"
                     )
-                    final_status = "failed"
-                    break
+                    self._safe_terminate(ec2, iid)
+                    new_id = self._launch_with_capacity_retry(
+                        ec2, conn, run_id, run_tag, priority, ntee_filter, options,
+                        slot_index=slots.index(slot),
+                    )
+                    if new_id:
+                        slot["instance_id"] = new_id
+                        slot["status"] = "running"
+                        self._update_instance_ids(conn, run_id, slots)
+                    else:
+                        slot["status"] = "capacity_exhausted"
+                    continue
 
-                self.stdout.write(
-                    f"Relaunching (attempt {relaunch_count}/{MAX_RELAUNCH_ATTEMPTS}, "
-                    f"{remaining:,} docs remaining)...\n"
+                # Heartbeat: detect stale worker on running instance
+                last_activity = self._get_worker_last_activity(conn, run_id, iid)
+                progress = db.get_queue_progress(conn, run_id)
+                unclaimed = progress["total"] - progress["claimed"]
+                stale = (
+                    last_activity is not None
+                    and (time.time() - last_activity.timestamp()) > HEARTBEAT_STALE_MINUTES * 60
+                    and unclaimed > 0
                 )
-                instance_id = self._launch_with_capacity_retry(ec2, conn, run_id, run_tag, priority, ntee_filter, options)
-                if instance_id is None:
-                    final_status = "failed"
-                    break
-                last_stats_update = time.time()
-                continue
+                if stale:
+                    self.stderr.write(f"Worker stale on {iid}. Terminating.\n")
+                    self._safe_terminate(ec2, iid)
+                    db.reclaim_stale_claims(conn, run_id, iid)
+                    slot["relaunch_count"] += 1
+                    if slot["relaunch_count"] > MAX_RELAUNCH_ATTEMPTS:
+                        slot["status"] = "capacity_exhausted"
+                    else:
+                        new_id = self._launch_with_capacity_retry(
+                            ec2, conn, run_id, run_tag, priority, ntee_filter, options,
+                            slot_index=slots.index(slot),
+                        )
+                        if new_id:
+                            slot["instance_id"] = new_id
+                            slot["status"] = "running"
+                            self._update_instance_ids(conn, run_id, slots)
+                        else:
+                            slot["status"] = "capacity_exhausted"
 
-            # Heartbeat: detect stale worker (crash without instance termination)
-            stats = status.get("stats_json") if status else None
-            current_total = 0
-            succeeded = 0
-            if stats:
-                if isinstance(stats, str):
-                    stats = json.loads(stats)
-                current_total = stats.get("total", 0)
-                succeeded = stats.get("succeeded", 0)
-                self.stdout.write(
-                    f"  Progress: {succeeded:,} ok, "
-                    f"{stats.get('failed', 0):,} err, "
-                    f"{current_total:,} total "
-                    f"({elapsed/60:.0f}m elapsed)\n"
-                )
-                self._update_job_progress(job_id, succeeded, eligible_count)
+            # Aggregate progress
+            progress = db.get_queue_progress(conn, run_id)
+            completed = progress["completed"]
+            errored = progress["errored"]
+            total = progress["total"]
 
-            if current_total > last_total:
-                last_stats_update = time.time()
-                last_total = current_total
-            elif (time.time() - last_stats_update) > HEARTBEAT_STALE_MINUTES * 60:
-                self.stderr.write(
-                    f"Worker stale — no progress in {HEARTBEAT_STALE_MINUTES} minutes. "
-                    f"Terminating instance.\n"
-                )
-                self._safe_terminate(ec2, instance_id)
+            self.stdout.write(
+                f"  Progress: {completed:,} ok, {errored:,} err, "
+                f"{total:,} total ({elapsed/60:.0f}m elapsed)\n"
+            )
+            self._update_job_progress(job_id, completed, total)
 
-                # Treat as crash, attempt relaunch
-                remaining = db.get_eligible_count(conn, priority)
-                if remaining == 0:
-                    break
-                relaunch_count += 1
-                if relaunch_count > MAX_RELAUNCH_ATTEMPTS:
-                    self.stderr.write(f"Exceeded max relaunch attempts. Stopping.\n")
-                    final_status = "failed"
-                    break
+            # All work done?
+            if completed + errored >= total:
+                self.stdout.write("All work items processed.\n")
+                self._terminate_all(ec2, slots)
+                break
 
-                self.stdout.write(f"Relaunching after stale worker...\n")
-                instance_id = self._launch_with_capacity_retry(ec2, conn, run_id, run_tag, priority, ntee_filter, options)
-                if instance_id is None:
-                    final_status = "failed"
-                    break
-                last_stats_update = time.time()
-                continue
+            # All slots dead?
+            active = [s for s in slots if s["status"] == "running"]
+            if not active:
+                self.stderr.write("All worker slots exhausted or done. Stopping.\n")
+                final_status = "failed"
+                break
 
-        # Mark run finished if not already
+        # Cleanup and finalize
+        self._terminate_all(ec2, slots)
+
+        progress = db.get_queue_progress(conn, run_id)
+        final_completed = progress["completed"]
+        final_errored = progress["errored"]
+
+        db.cleanup_work_queue(conn, run_id)
+
         status = db.get_run_status(conn, run_tag)
-        final_succeeded = 0
-        if status:
-            if not status.get("finished_at"):
-                db.finish_run(conn, status["id"], status.get("stats_json") or {})
-            s = status.get("stats_json") or {}
-            if isinstance(s, str):
-                s = json.loads(s)
-            final_succeeded = s.get("succeeded", 0)
+        if status and not status.get("finished_at"):
+            db.finish_run(conn, status["id"], {
+                "succeeded": final_completed,
+                "failed": final_errored,
+                "total": final_completed + final_errored,
+            })
 
         if final_status == "cancelled":
-            self._update_job_progress(job_id, final_succeeded, eligible_count, "cancelled")
+            self._update_job_progress(job_id, final_completed, eligible_count, "cancelled")
         elif final_status == "failed":
-            self._update_job_progress(job_id, final_succeeded, eligible_count, "failed")
+            self._update_job_progress(job_id, final_completed, eligible_count, "failed")
         else:
-            self._update_job_progress(job_id, final_succeeded, eligible_count, "completed")
+            self._update_job_progress(job_id, final_completed, eligible_count, "completed")
 
         self.stdout.write("Parse run complete.\n")
 
-    def _launch_with_capacity_retry(self, ec2, conn, run_id, run_tag, priority, ntee_filter, options):
+    def _launch_with_capacity_retry(self, ec2, conn, run_id, run_tag, priority, ntee_filter, options, slot_index=0):
         """Wrap _launch_and_start with spot capacity retry loop.
 
         Returns instance_id on success, None if capacity exhausted or shutdown requested.
@@ -416,7 +543,7 @@ class Command(BaseCommand):
 
         for attempt in range(max_retries + 1):
             try:
-                return self._launch_and_start(ec2, conn, run_id, run_tag, priority, ntee_filter, options)
+                return self._launch_and_start(ec2, conn, run_id, run_tag, priority, ntee_filter, options, slot_index=slot_index)
             except (ClientError, CommandError) as e:
                 err_code = ""
                 if isinstance(e, ClientError):
@@ -447,25 +574,18 @@ class Command(BaseCommand):
                     time.sleep(min(30, CAPACITY_RETRY_INTERVAL - slept))
                     slept += 30
 
-    def _launch_and_start(self, ec2, conn, run_id: int, run_tag: str, priority: list[str], ntee_filter: str | None, options: dict) -> str:
+    def _launch_and_start(self, ec2, conn, run_id: int, run_tag: str, priority: list[str], ntee_filter: str | None, options: dict, slot_index: int = 0) -> str:
         """Launch a spot instance and start the worker. Returns instance_id."""
-        # Terminate any existing instance for this purpose
-        existing = self._find_instance(ec2, run_tag)
+        # Terminate any existing instance for this slot
+        existing = self._find_instance(ec2, run_tag, slot_index=slot_index)
         if existing:
             self.stdout.write(f"Terminating existing instance {existing}\n")
             ec2.terminate_instances(InstanceIds=[existing])
             self._wait_for_termination(ec2, existing)
 
-        instance_id = self._launch_instance(ec2, run_tag, options)
+        instance_id = self._launch_instance(ec2, run_tag, options, slot_index=slot_index)
         mode = "on-demand" if options["no_spot"] else "spot"
-        self.stdout.write(f"Launched {mode} instance {instance_id}\n")
-
-        with conn:
-            with conn.cursor() as cur:
-                cur.execute(
-                    "UPDATE lava_parse.parse_runs SET instance_id = %s WHERE id = %s",
-                    (instance_id, run_id),
-                )
+        self.stdout.write(f"Launched {mode} instance {instance_id} (slot {slot_index})\n")
 
         time.sleep(5)  # EC2 eventual consistency — wait before polling
         self._wait_for_running(ec2, instance_id)
@@ -484,7 +604,7 @@ class Command(BaseCommand):
             ec2.terminate_instances(InstanceIds=[instance_id])
             self.stdout.write(f"Terminated instance {instance_id}\n")
 
-    def _launch_instance(self, ec2, run_tag: str, options: dict) -> str:
+    def _launch_instance(self, ec2, run_tag: str, options: dict, slot_index: int = 0) -> str:
         import boto3
 
         ami_id = options.get("ami_id")
@@ -505,9 +625,10 @@ class Command(BaseCommand):
                 {
                     "ResourceType": "instance",
                     "Tags": [
-                        {"Key": "Name", "Value": f"docling-worker-{run_tag}"},
+                        {"Key": "Name", "Value": f"docling-worker-{run_tag}-{slot_index}"},
                         {"Key": "Project", "Value": "lavandula"},
                         {"Key": "Purpose", "Value": INSTANCE_TAG_PURPOSE},
+                        {"Key": "Slot", "Value": str(slot_index)},
                     ],
                 }
             ],
@@ -518,14 +639,16 @@ class Command(BaseCommand):
         response = ec2.run_instances(**kwargs)
         return response["Instances"][0]["InstanceId"]
 
-    def _find_instance(self, ec2, run_tag: str) -> str | None:
+    def _find_instance(self, ec2, run_tag: str, slot_index: int | None = None) -> str | None:
         """Find running/pending instance tagged for docling-parse."""
-        response = ec2.describe_instances(
-            Filters=[
-                {"Name": "tag:Purpose", "Values": [INSTANCE_TAG_PURPOSE]},
-                {"Name": "instance-state-name", "Values": ["running", "pending"]},
-            ]
-        )
+        name_pattern = f"docling-worker-{run_tag}-{slot_index}" if slot_index is not None else f"docling-worker-{run_tag}*"
+        filters = [
+            {"Name": "tag:Purpose", "Values": [INSTANCE_TAG_PURPOSE]},
+            {"Name": "instance-state-name", "Values": ["running", "pending"]},
+        ]
+        if slot_index is not None:
+            filters.append({"Name": "tag:Slot", "Values": [str(slot_index)]})
+        response = ec2.describe_instances(Filters=filters)
         for reservation in response.get("Reservations", []):
             for instance in reservation.get("Instances", []):
                 return instance["InstanceId"]
@@ -596,6 +719,7 @@ class Command(BaseCommand):
 
         max_docs_flag = f" --max-docs {options['max_docs']}" if options["max_docs"] else ""
         ntee_flag = f" --ntee {ntee_filter}" if ntee_filter else ""
+        worker_id_flag = f" --worker-id {instance_id}"
         worker_cmd = (
             f"/opt/docling/bin/python -m lavandula.parse.worker "
             f"--run-id {run_id} "
@@ -606,6 +730,7 @@ class Command(BaseCommand):
             f"--batch-size {options['batch_size']}"
             f"{max_docs_flag}"
             f"{ntee_flag}"
+            f"{worker_id_flag}"
         )
 
         # Deploy worker code and start as a background process

--- a/lavandula/dashboard/pipeline/management/commands/parse_documents.py
+++ b/lavandula/dashboard/pipeline/management/commands/parse_documents.py
@@ -641,13 +641,15 @@ class Command(BaseCommand):
 
     def _find_instance(self, ec2, run_tag: str, slot_index: int | None = None) -> str | None:
         """Find running/pending instance tagged for docling-parse."""
-        name_pattern = f"docling-worker-{run_tag}-{slot_index}" if slot_index is not None else f"docling-worker-{run_tag}*"
         filters = [
             {"Name": "tag:Purpose", "Values": [INSTANCE_TAG_PURPOSE]},
             {"Name": "instance-state-name", "Values": ["running", "pending"]},
         ]
         if slot_index is not None:
+            filters.append({"Name": "tag:Name", "Values": [f"docling-worker-{run_tag}-{slot_index}"]})
             filters.append({"Name": "tag:Slot", "Values": [str(slot_index)]})
+        else:
+            filters.append({"Name": "tag:Name", "Values": [f"docling-worker-{run_tag}"]})
         response = ec2.describe_instances(Filters=filters)
         for reservation in response.get("Reservations", []):
             for instance in reservation.get("Instances", []):

--- a/lavandula/dashboard/pipeline/migrations/0011_parse_runs_instance_ids.py
+++ b/lavandula/dashboard/pipeline/migrations/0011_parse_runs_instance_ids.py
@@ -1,0 +1,18 @@
+"""No-op stub: documents parse_runs.instance_ids TEXT[] column.
+
+The actual DDL lives in lavandula/migrations/parse/003_work_queue.sql
+and is applied manually on RDS by the operator. This migration exists
+to keep the Django migration sequence consistent.
+"""
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    dependencies = [("pipeline", "0010_add_parse_phase")]
+    operations = [
+        migrations.RunSQL(
+            sql=migrations.RunSQL.noop,
+            reverse_sql=migrations.RunSQL.noop,
+            state_operations=[],
+        ),
+    ]

--- a/lavandula/dashboard/pipeline/orchestrator.py
+++ b/lavandula/dashboard/pipeline/orchestrator.py
@@ -181,6 +181,7 @@ COMMAND_MAP: dict[str, dict[str, Any]] = {
             "ami_id": {"type": "text", "pattern": r"^ami-[a-f0-9]{8,17}$", "flag": "--ami-id"},
             "start_at": {"type": "text", "pattern": r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}$", "flag": "--start-at"},
             "capacity_wait_hours": {"type": "int", "min": 1, "max": 12, "flag": "--capacity-wait-hours"},
+            "workers": {"type": "int", "min": 1, "max": 4, "flag": "--workers"},
         },
     },
 }

--- a/lavandula/dashboard/pipeline/templates/pipeline/partials/parse_progress.html
+++ b/lavandula/dashboard/pipeline/templates/pipeline/partials/parse_progress.html
@@ -23,7 +23,58 @@
   <span class="font-medium">{{ job.config_json.run_tag }}</span>
 </div>
 
-{% if parse_run %}
+{% if queue_progress %}
+{# Multi-instance progress from work_queue #}
+<div class="grid grid-cols-2 sm:grid-cols-4 gap-3 mb-3">
+  <div>
+    <div class="text-xs text-gray-500">Completed</div>
+    <div class="text-lg font-mono font-semibold text-green-700">{{ queue_progress.completed|intcomma }}</div>
+  </div>
+  <div>
+    <div class="text-xs text-gray-500">Errored</div>
+    <div class="text-lg font-mono font-semibold {% if queue_progress.errored %}text-red-600{% else %}text-gray-400{% endif %}">{{ queue_progress.errored|intcomma }}</div>
+  </div>
+  <div>
+    <div class="text-xs text-gray-500">In Flight</div>
+    <div class="text-lg font-mono font-semibold text-blue-600">{{ queue_progress.claimed|intcomma }}</div>
+  </div>
+  <div>
+    <div class="text-xs text-gray-500">Total</div>
+    <div class="text-lg font-mono font-semibold">{{ queue_progress.total|intcomma }}</div>
+  </div>
+</div>
+
+{% if queue_progress.total > 0 %}
+{% widthratio queue_progress.completed queue_progress.total 100 as pct %}
+<div class="w-full bg-gray-200 rounded-full h-2 mb-3">
+  <div class="bg-blue-600 h-2 rounded-full" style="width: {{ pct }}%"></div>
+</div>
+{% endif %}
+
+{% if worker_stats|length > 1 %}
+<div class="mt-3">
+  <h3 class="text-xs font-semibold text-gray-500 uppercase mb-2">
+    {{ worker_stats|length }} Worker{{ worker_stats|length|pluralize }}
+  </h3>
+  <div class="grid grid-cols-1 sm:grid-cols-2 gap-2">
+    {% for ws in worker_stats %}
+    <div class="border border-gray-200 rounded p-2 text-xs">
+      <div class="font-mono text-gray-600">{{ ws.claimed_by|truncatechars:19 }}</div>
+      <div class="flex justify-between mt-1">
+        <span class="text-green-700">{{ ws.completed }} done</span>
+        <span class="text-blue-600">{{ ws.in_progress }} active</span>
+        {% if ws.throughput %}
+        <span class="text-gray-500">{{ ws.throughput }} docs/hr</span>
+        {% endif %}
+      </div>
+    </div>
+    {% endfor %}
+  </div>
+</div>
+{% endif %}
+
+{% elif parse_run %}
+{# Single-instance fallback (stats_json from worker) #}
 {% with stats=parse_run.stats %}
 <div class="grid grid-cols-2 sm:grid-cols-4 gap-3 mb-3">
   <div>
@@ -60,11 +111,12 @@
   {% if stats.succeeded and job.started_at %}
   <p>Rate: <strong>{{ stats.succeeded|floatformat:0 }}</strong> docs in {{ job.started_at|elapsed_since }}</p>
   {% endif %}
-  {% if stats.duration_seconds %}
-  <p>Cost so far: <strong>${{ stats.duration_seconds|floatformat:0 }}</strong></p>
-  {% endif %}
 </div>
 {% endwith %}
+
+{% else %}
+<div class="text-sm text-gray-500">Waiting for first batch...</div>
+{% endif %}
 
 {% if instance_state %}
 <div class="mt-3 flex items-center gap-2 text-sm">
@@ -81,11 +133,10 @@
   {% if instance_state.az %}
   <span class="text-xs text-gray-400">{{ instance_state.az }}</span>
   {% endif %}
+  {% if parse_run.instance_ids|length > 1 %}
+  <span class="text-xs text-gray-400">+{{ parse_run.instance_ids|length|add:"-1" }} more</span>
+  {% endif %}
 </div>
-{% endif %}
-
-{% else %}
-<div class="text-sm text-gray-500">Waiting for first batch...</div>
 {% endif %}
 
 {% else %}

--- a/lavandula/dashboard/pipeline/tests/test_parse.py
+++ b/lavandula/dashboard/pipeline/tests/test_parse.py
@@ -744,3 +744,114 @@ class TestParseConfigAllowlist(SimpleTestCase):
     def test_workers_in_parse_allowlist(self):
         from pipeline.views import _CONFIG_ALLOWLIST
         self.assertIn("workers", _CONFIG_ALLOWLIST["parse"])
+
+
+# ---------------------------------------------------------------------------
+# Spec 0055: Multi-Instance Parse — PostgreSQL SKIP LOCKED integration test
+# ---------------------------------------------------------------------------
+
+import unittest
+from django.db import connection as django_connection
+
+
+@unittest.skipUnless(
+    django_connection.vendor == "postgresql",
+    "SKIP LOCKED requires PostgreSQL",
+)
+class TestSkipLockedNoOverlap(TestCase):
+    """Validate that FOR UPDATE SKIP LOCKED produces non-overlapping batches.
+
+    This is the single most important test in Spec 0055: it proves the core
+    no-double-processing guarantee. Requires a real PostgreSQL backend.
+    """
+
+    def setUp(self):
+        from django.db import connections
+
+        self.conn = connections["default"]
+        with self.conn.cursor() as cur:
+            cur.execute("""
+                CREATE TABLE IF NOT EXISTS lava_parse.work_queue_test (
+                    id BIGSERIAL PRIMARY KEY,
+                    run_id INTEGER NOT NULL,
+                    content_sha256 TEXT NOT NULL,
+                    source_org_ein TEXT NOT NULL,
+                    claimed_by TEXT,
+                    claimed_at TIMESTAMPTZ,
+                    completed_at TIMESTAMPTZ,
+                    error TEXT,
+                    UNIQUE (run_id, content_sha256)
+                )
+            """)
+            cur.execute("DELETE FROM lava_parse.work_queue_test")
+            for i in range(20):
+                cur.execute(
+                    "INSERT INTO lava_parse.work_queue_test "
+                    "(run_id, content_sha256, source_org_ein) "
+                    "VALUES (%s, %s, %s)",
+                    (999, f"sha_{i:04d}", "12-3456789"),
+                )
+
+    def tearDown(self):
+        with self.conn.cursor() as cur:
+            cur.execute("DROP TABLE IF EXISTS lava_parse.work_queue_test")
+
+    def test_concurrent_claims_no_overlap(self):
+        import psycopg2
+        import psycopg2.extras
+
+        db_settings = django_connection.settings_dict
+        connect_kwargs = {
+            "host": db_settings["HOST"],
+            "port": db_settings.get("PORT", 5432),
+            "dbname": db_settings["NAME"],
+            "user": db_settings["USER"],
+            "password": db_settings.get("PASSWORD", ""),
+        }
+
+        conn_a = psycopg2.connect(**connect_kwargs)
+        conn_b = psycopg2.connect(**connect_kwargs)
+        conn_a.autocommit = False
+        conn_b.autocommit = False
+
+        try:
+            claim_sql = """
+                WITH claimed AS (
+                    SELECT id, content_sha256
+                    FROM lava_parse.work_queue_test
+                    WHERE run_id = 999 AND claimed_by IS NULL
+                    ORDER BY id
+                    LIMIT 10
+                    FOR UPDATE SKIP LOCKED
+                )
+                UPDATE lava_parse.work_queue_test wq
+                SET claimed_by = %(worker)s, claimed_at = NOW()
+                FROM claimed
+                WHERE wq.id = claimed.id
+                RETURNING wq.content_sha256
+            """
+
+            with conn_a.cursor() as cur_a:
+                cur_a.execute(claim_sql, {"worker": "worker-a"})
+                batch_a = {row[0] for row in cur_a.fetchall()}
+
+            with conn_b.cursor() as cur_b:
+                cur_b.execute(claim_sql, {"worker": "worker-b"})
+                batch_b = {row[0] for row in cur_b.fetchall()}
+
+            conn_a.commit()
+            conn_b.commit()
+
+            self.assertEqual(len(batch_a), 10, "Worker A should claim 10 rows")
+            self.assertEqual(len(batch_b), 10, "Worker B should claim 10 rows")
+            self.assertEqual(
+                batch_a & batch_b, set(),
+                "SKIP LOCKED must produce non-overlapping batches"
+            )
+            self.assertEqual(
+                len(batch_a | batch_b), 20,
+                "Together, both workers should cover all 20 rows"
+            )
+        finally:
+            conn_a.close()
+            conn_b.close()

--- a/lavandula/dashboard/pipeline/tests/test_parse.py
+++ b/lavandula/dashboard/pipeline/tests/test_parse.py
@@ -131,6 +131,7 @@ class TestParseRunForm(SimpleTestCase):
             "instance_type": "g6.2xlarge",
             "max_hours": 24,
             "batch_size": 500,
+            "workers": 1,
         }
         data.update(overrides)
         return ParseRunForm(data)
@@ -303,6 +304,7 @@ class TestParseLaunch(ParseViewTestBase):
             "instance_type": "g6.2xlarge",
             "max_hours": 24,
             "batch_size": 500,
+            "workers": 1,
         })
         self.assertEqual(resp.status_code, 302)
         mock_create.assert_called_once()
@@ -318,6 +320,7 @@ class TestParseLaunch(ParseViewTestBase):
             "instance_type": "g6.2xlarge",
             "max_hours": 24,
             "batch_size": 500,
+            "workers": 1,
         })
         self.assertEqual(resp.status_code, 302)
 
@@ -329,6 +332,7 @@ class TestParseLaunch(ParseViewTestBase):
             "instance_type": "g6.2xlarge",
             "max_hours": 24,
             "batch_size": 500,
+            "workers": 1,
         })
         self.assertEqual(resp.status_code, 302)
 
@@ -456,3 +460,287 @@ class TestParseNavigation(ParseViewTestBase):
     def test_nav_link_present(self, *mocks):
         resp = self.client.get(reverse("parse"))
         self.assertContains(resp, "Docling Parse")
+
+
+# ---------------------------------------------------------------------------
+# Spec 0055: Multi-Instance Parse — build_argv workers flag
+# ---------------------------------------------------------------------------
+
+class TestBuildArgvParseWorkers(SimpleTestCase):
+    def test_workers_flag_in_argv(self):
+        argv = build_argv("parse", {"run_tag": "t", "workers": 2})
+        idx = argv.index("--workers")
+        self.assertEqual(argv[idx + 1], "2")
+
+    def test_workers_default_omitted(self):
+        argv = build_argv("parse", {"run_tag": "t"})
+        self.assertNotIn("--workers", argv)
+
+    def test_workers_max_valid(self):
+        argv = build_argv("parse", {"run_tag": "t", "workers": 4})
+        self.assertIn("--workers", argv)
+        self.assertIn("4", argv)
+
+    def test_workers_over_max_rejected(self):
+        with self.assertRaises(InvalidParameterError):
+            build_argv("parse", {"run_tag": "t", "workers": 5})
+
+    def test_workers_under_min_rejected(self):
+        with self.assertRaises(InvalidParameterError):
+            build_argv("parse", {"run_tag": "t", "workers": 0})
+
+
+# ---------------------------------------------------------------------------
+# Spec 0055: Multi-Instance Parse — Form workers field
+# ---------------------------------------------------------------------------
+
+class TestParseRunFormWorkers(SimpleTestCase):
+    def _form(self, **overrides):
+        data = {
+            "run_tag": "test-run",
+            "priority": "annual,impact",
+            "instance_type": "g6.2xlarge",
+            "max_hours": 24,
+            "batch_size": 500,
+            "workers": 1,
+        }
+        data.update(overrides)
+        return ParseRunForm(data)
+
+    def test_workers_default_valid(self):
+        self.assertTrue(self._form(workers=1).is_valid())
+
+    def test_workers_2_valid(self):
+        self.assertTrue(self._form(workers=2).is_valid())
+
+    def test_workers_4_valid(self):
+        self.assertTrue(self._form(workers=4).is_valid())
+
+    def test_workers_0_rejected(self):
+        self.assertFalse(self._form(workers=0).is_valid())
+
+    def test_workers_5_rejected(self):
+        self.assertFalse(self._form(workers=5).is_valid())
+
+    def test_workers_negative_rejected(self):
+        self.assertFalse(self._form(workers=-1).is_valid())
+
+
+# ---------------------------------------------------------------------------
+# Spec 0055: Multi-Instance Parse — DB function unit tests
+# ---------------------------------------------------------------------------
+
+class TestCompleteWorkItemErrorTruncation(SimpleTestCase):
+    @patch("lavandula.parse.db.psycopg2")
+    def test_error_truncated_to_200(self, mock_pg):
+        from lavandula.parse import db as parse_db
+
+        mock_conn = MagicMock()
+        mock_cur = MagicMock()
+        mock_cur.__enter__ = lambda self: self
+        mock_cur.__exit__ = MagicMock(return_value=False)
+        mock_conn.cursor.return_value = mock_cur
+        mock_conn.__enter__ = lambda self: self
+        mock_conn.__exit__ = MagicMock(return_value=False)
+
+        long_error = "x" * 300
+        parse_db.complete_work_item(mock_conn, 1, "abc123", error=long_error)
+
+        call_args = mock_cur.execute.call_args
+        params = call_args[0][1]
+        self.assertEqual(len(params["error"]), 200)
+
+    @patch("lavandula.parse.db.psycopg2")
+    def test_short_error_preserved(self, mock_pg):
+        from lavandula.parse import db as parse_db
+
+        mock_conn = MagicMock()
+        mock_cur = MagicMock()
+        mock_cur.__enter__ = lambda self: self
+        mock_cur.__exit__ = MagicMock(return_value=False)
+        mock_conn.cursor.return_value = mock_cur
+        mock_conn.__enter__ = lambda self: self
+        mock_conn.__exit__ = MagicMock(return_value=False)
+
+        parse_db.complete_work_item(mock_conn, 1, "abc123", error="corrupt_pdf")
+
+        call_args = mock_cur.execute.call_args
+        params = call_args[0][1]
+        self.assertEqual(params["error"], "corrupt_pdf")
+
+    @patch("lavandula.parse.db.psycopg2")
+    def test_no_error_passes_none(self, mock_pg):
+        from lavandula.parse import db as parse_db
+
+        mock_conn = MagicMock()
+        mock_cur = MagicMock()
+        mock_cur.__enter__ = lambda self: self
+        mock_cur.__exit__ = MagicMock(return_value=False)
+        mock_conn.cursor.return_value = mock_cur
+        mock_conn.__enter__ = lambda self: self
+        mock_conn.__exit__ = MagicMock(return_value=False)
+
+        parse_db.complete_work_item(mock_conn, 1, "abc123")
+
+        call_args = mock_cur.execute.call_args
+        params = call_args[0][1]
+        self.assertIsNone(params["error"])
+
+
+class TestGetQueueProgress(SimpleTestCase):
+    def test_returns_dict_keys(self):
+        from lavandula.parse import db as parse_db
+
+        mock_conn = MagicMock()
+        mock_cur = MagicMock()
+        mock_cur.__enter__ = lambda self: self
+        mock_cur.__exit__ = MagicMock(return_value=False)
+        mock_cur.fetchone.return_value = (100, 30, 20, 5)
+        mock_conn.cursor.return_value = mock_cur
+
+        result = parse_db.get_queue_progress(mock_conn, 1)
+        self.assertEqual(result, {
+            "total": 100, "claimed": 30, "completed": 20, "errored": 5,
+        })
+
+
+class TestReclaimStaleClaims(SimpleTestCase):
+    def test_reclaim_returns_rowcount(self):
+        from lavandula.parse import db as parse_db
+
+        mock_conn = MagicMock()
+        mock_cur = MagicMock()
+        mock_cur.__enter__ = lambda self: self
+        mock_cur.__exit__ = MagicMock(return_value=False)
+        mock_cur.rowcount = 7
+        mock_conn.cursor.return_value = mock_cur
+        mock_conn.__enter__ = lambda self: self
+        mock_conn.__exit__ = MagicMock(return_value=False)
+
+        result = parse_db.reclaim_stale_claims(mock_conn, 1, "i-abc123")
+        self.assertEqual(result, 7)
+
+    def test_reclaim_uses_worker_id_in_query(self):
+        from lavandula.parse import db as parse_db
+
+        mock_conn = MagicMock()
+        mock_cur = MagicMock()
+        mock_cur.__enter__ = lambda self: self
+        mock_cur.__exit__ = MagicMock(return_value=False)
+        mock_cur.rowcount = 0
+        mock_conn.cursor.return_value = mock_cur
+        mock_conn.__enter__ = lambda self: self
+        mock_conn.__exit__ = MagicMock(return_value=False)
+
+        parse_db.reclaim_stale_claims(mock_conn, 42, "i-deadbeef")
+
+        call_args = mock_cur.execute.call_args
+        params = call_args[0][1]
+        self.assertEqual(params["run_id"], 42)
+        self.assertEqual(params["worker"], "i-deadbeef")
+
+
+class TestReclaimAllStaleClaims(SimpleTestCase):
+    def test_reclaim_all_returns_rowcount(self):
+        from lavandula.parse import db as parse_db
+
+        mock_conn = MagicMock()
+        mock_cur = MagicMock()
+        mock_cur.__enter__ = lambda self: self
+        mock_cur.__exit__ = MagicMock(return_value=False)
+        mock_cur.rowcount = 15
+        mock_conn.cursor.return_value = mock_cur
+        mock_conn.__enter__ = lambda self: self
+        mock_conn.__exit__ = MagicMock(return_value=False)
+
+        result = parse_db.reclaim_all_stale_claims(mock_conn, 1)
+        self.assertEqual(result, 15)
+
+
+class TestCleanupWorkQueue(SimpleTestCase):
+    def test_cleanup_returns_rowcount(self):
+        from lavandula.parse import db as parse_db
+
+        mock_conn = MagicMock()
+        mock_cur = MagicMock()
+        mock_cur.__enter__ = lambda self: self
+        mock_cur.__exit__ = MagicMock(return_value=False)
+        mock_cur.rowcount = 500
+        mock_conn.cursor.return_value = mock_cur
+        mock_conn.__enter__ = lambda self: self
+        mock_conn.__exit__ = MagicMock(return_value=False)
+
+        result = parse_db.cleanup_work_queue(mock_conn, 1)
+        self.assertEqual(result, 500)
+
+
+# ---------------------------------------------------------------------------
+# Spec 0055: Multi-Instance Parse — Dashboard dry run multi-estimate
+# ---------------------------------------------------------------------------
+
+class TestParseDryRunMultiEstimate(ParseViewTestBase):
+    @patch.object(
+        __import__("pipeline.views", fromlist=["ParseJobCreateView"]).ParseJobCreateView,
+        "_get_parse_conn",
+    )
+    def test_dry_run_shows_worker_estimates(self, mock_get_conn):
+        mock_conn = MagicMock()
+        mock_cur = MagicMock()
+        mock_cur.fetchone.return_value = (1000,)
+        mock_cur.__enter__ = lambda self: self
+        mock_cur.__exit__ = MagicMock(return_value=False)
+        mock_conn.cursor.return_value = mock_cur
+        mock_get_conn.return_value = mock_conn
+
+        resp = self.client.post(reverse("parse_job_create"), {
+            "action": "dry_run",
+            "run_tag": "est-test",
+            "priority": "annual,impact",
+            "instance_type": "g6.2xlarge",
+            "max_hours": 24,
+            "batch_size": 500,
+            "workers": 2,
+        }, follow=True)
+        self.assertEqual(resp.status_code, 200)
+        msg_texts = [str(m) for m in resp.context["messages"]]
+        combined = " ".join(msg_texts)
+        self.assertIn("2 workers", combined)
+        self.assertIn("1 worker:", combined)
+        self.assertIn("4 workers:", combined)
+
+    @patch.object(
+        __import__("pipeline.views", fromlist=["ParseJobCreateView"]).ParseJobCreateView,
+        "_get_parse_conn",
+    )
+    def test_dry_run_shows_worker_count_label(self, mock_get_conn):
+        mock_conn = MagicMock()
+        mock_cur = MagicMock()
+        mock_cur.fetchone.return_value = (500,)
+        mock_cur.__enter__ = lambda self: self
+        mock_cur.__exit__ = MagicMock(return_value=False)
+        mock_conn.cursor.return_value = mock_cur
+        mock_get_conn.return_value = mock_conn
+
+        resp = self.client.post(reverse("parse_job_create"), {
+            "action": "dry_run",
+            "run_tag": "w-test",
+            "priority": "annual,impact",
+            "instance_type": "g6.2xlarge",
+            "max_hours": 24,
+            "batch_size": 500,
+            "workers": 3,
+        }, follow=True)
+        self.assertEqual(resp.status_code, 200)
+        msg_texts = [str(m) for m in resp.context["messages"]]
+        combined = " ".join(msg_texts)
+        self.assertIn("[3 workers]", combined)
+
+
+# ---------------------------------------------------------------------------
+# Spec 0055: Multi-Instance Parse — Config allowlist includes workers
+# ---------------------------------------------------------------------------
+
+class TestParseConfigAllowlist(SimpleTestCase):
+    def test_workers_in_parse_allowlist(self):
+        from pipeline.views import _CONFIG_ALLOWLIST
+        self.assertIn("workers", _CONFIG_ALLOWLIST["parse"])

--- a/lavandula/dashboard/pipeline/views.py
+++ b/lavandula/dashboard/pipeline/views.py
@@ -2551,19 +2551,22 @@ class ParseStopView(LoginRequiredMixin, View):
             from django.db import connections
             with connections["default"].cursor() as cur:
                 cur.execute("""
-                    SELECT instance_id FROM lava_parse.parse_runs
+                    SELECT instance_ids, instance_id FROM lava_parse.parse_runs
                     WHERE run_tag = %s AND finished_at IS NULL
                 """, [run_tag])
                 row = cur.fetchone()
-                if row and row[0]:
-                    try:
-                        import boto3
-                        ec2 = boto3.client("ec2", region_name="us-east-1")
-                        ec2.terminate_instances(InstanceIds=[row[0]])
-                    except Exception:
-                        _parse_logger.exception(
-                            "Failed to terminate EC2 instance %s during stop", row[0]
-                        )
+                if row:
+                    ids_to_terminate = row[0] or ([row[1]] if row[1] else [])
+                    if ids_to_terminate:
+                        try:
+                            import boto3
+                            ec2 = boto3.client("ec2", region_name="us-east-1")
+                            ec2.terminate_instances(InstanceIds=ids_to_terminate)
+                        except Exception:
+                            _parse_logger.exception(
+                                "Failed to terminate EC2 instances %s during stop",
+                                ids_to_terminate,
+                            )
 
                 cur.execute("""
                     UPDATE lava_parse.parse_runs

--- a/lavandula/dashboard/pipeline/views.py
+++ b/lavandula/dashboard/pipeline/views.py
@@ -133,7 +133,7 @@ _CONFIG_ALLOWLIST = {
     "compare-classify": ["run_tag", "state"],
     "resolve-disagree": ["run_tag", "backend", "state", "sample", "dry_run"],
     "promote-classify": ["run_tag", "state", "confirm"],
-    "parse": ["run_tag", "ntee", "priority", "instance_type", "max_hours", "no_spot", "ami_id", "start_at"],
+    "parse": ["run_tag", "ntee", "priority", "instance_type", "max_hours", "no_spot", "ami_id", "start_at", "workers"],
 }
 
 
@@ -2322,9 +2322,18 @@ class ParseJobCreateView(LoginRequiredMixin, View):
         use_spot = not config.get("no_spot", False)
         rate = 0.60 if use_spot else 0.98
         est_cost = est_hours * rate
+        workers = config.get("workers", 1)
 
         max_hours = config.get("max_hours", 24)
         capped = est_hours > max_hours
+
+        worker_estimates = ""
+        if count > 0:
+            parts = []
+            for n in (1, 2, 4):
+                wall = est_hours / n
+                parts.append(f"{n} worker{'s' if n > 1 else ''}: ~{wall:.1f}h wall time")
+            worker_estimates = " | " + " | ".join(parts)
 
         messages.info(
             request,
@@ -2332,6 +2341,8 @@ class ParseJobCreateView(LoginRequiredMixin, View):
             f"~{min(est_hours, max_hours):.1f}h GPU time, "
             f"~${min(est_cost, max_hours * rate):.0f} "
             f"({'spot' if use_spot else 'on-demand'})"
+            + (f" [{workers} worker{'s' if workers > 1 else ''}]")
+            + worker_estimates
             + (" — will not complete in one run" if capped else "")
         )
         return redirect("parse")
@@ -2410,6 +2421,7 @@ class ParseProgressPartial(HtmxLoginRequiredMixin, View):
     def get(self, request):
         import json as _json
         from django.db import connections
+        from django.core.cache import cache
 
         active_job = Job.objects.filter(
             phase="parse", status__in=["running", "scheduled", "pending"]
@@ -2421,31 +2433,84 @@ class ParseProgressPartial(HtmxLoginRequiredMixin, View):
         run_tag = (active_job.config_json or {}).get("run_tag")
         parse_run = None
         instance_state = None
+        queue_progress = None
+        worker_stats = None
 
         if run_tag:
             with connections["default"].cursor() as cur:
                 cur.execute("""
-                    SELECT stats_json, instance_id, started_at
+                    SELECT id, stats_json, instance_id, instance_ids, started_at
                     FROM lava_parse.parse_runs WHERE run_tag = %s
                 """, [run_tag])
                 row = cur.fetchone()
                 if row:
-                    stats = row[0] if isinstance(row[0], dict) else _json.loads(row[0] or "{}")
+                    stats = row[1] if isinstance(row[1], dict) else _json.loads(row[1] or "{}")
                     parse_run = {
+                        "id": row[0],
                         "stats": stats,
-                        "instance_id": row[1],
-                        "started_at": row[2],
+                        "instance_id": row[2],
+                        "instance_ids": row[3] or [],
+                        "started_at": row[4],
                     }
 
-            if parse_run and parse_run["instance_id"]:
-                from django.core.cache import cache
-                cache_key = f"ec2_state_{parse_run['instance_id']}"
+            # Query work_queue for aggregate progress and per-worker stats
+            if parse_run:
+                run_id = parse_run["id"]
+                try:
+                    with connections["default"].cursor() as cur:
+                        cur.execute("""
+                            SELECT
+                                COUNT(*) as total,
+                                COUNT(*) FILTER (WHERE claimed_by IS NOT NULL) as claimed,
+                                COUNT(*) FILTER (WHERE completed_at IS NOT NULL AND error IS NULL) as completed,
+                                COUNT(*) FILTER (WHERE completed_at IS NOT NULL AND error IS NOT NULL) as errored
+                            FROM lava_parse.work_queue
+                            WHERE run_id = %s
+                        """, [run_id])
+                        qrow = cur.fetchone()
+                        if qrow and qrow[0] > 0:
+                            queue_progress = {
+                                "total": qrow[0],
+                                "claimed": qrow[1],
+                                "completed": qrow[2],
+                                "errored": qrow[3],
+                            }
+
+                    cache_key = f"parse_worker_stats_{run_id}"
+                    worker_stats = cache.get(cache_key)
+                    if worker_stats is None:
+                        with connections["default"].cursor() as cur:
+                            cur.execute("""
+                                SELECT claimed_by,
+                                       COUNT(*) FILTER (WHERE completed_at IS NOT NULL) as completed,
+                                       COUNT(*) FILTER (WHERE completed_at IS NULL) as in_progress,
+                                       MAX(completed_at) as last_activity,
+                                       EXTRACT(EPOCH FROM MAX(completed_at) - MIN(claimed_at)) as active_seconds
+                                FROM lava_parse.work_queue
+                                WHERE run_id = %s AND claimed_by IS NOT NULL
+                                GROUP BY claimed_by
+                            """, [run_id])
+                            columns = [col[0] for col in cur.description]
+                            worker_stats = [dict(zip(columns, r)) for r in cur.fetchall()]
+                            for ws in worker_stats:
+                                if ws["active_seconds"] and ws["active_seconds"] > 0 and ws["completed"]:
+                                    ws["throughput"] = round(ws["completed"] / ws["active_seconds"] * 3600, 1)
+                                else:
+                                    ws["throughput"] = None
+                        cache.set(cache_key, worker_stats, 10)
+                except Exception:
+                    _parse_logger.exception("Failed to query work_queue progress")
+
+            # Instance state for primary instance (backward compat for single-worker)
+            primary_id = parse_run.get("instance_id") if parse_run else None
+            if primary_id:
+                cache_key = f"ec2_state_{primary_id}"
                 instance_state = cache.get(cache_key)
                 if instance_state is None:
                     try:
                         import boto3
                         ec2 = boto3.client("ec2", region_name="us-east-1")
-                        resp = ec2.describe_instances(InstanceIds=[parse_run["instance_id"]])
+                        resp = ec2.describe_instances(InstanceIds=[primary_id])
                         reservations = resp.get("Reservations", [])
                         if reservations and reservations[0].get("Instances"):
                             inst = reservations[0]["Instances"][0]
@@ -2461,6 +2526,8 @@ class ParseProgressPartial(HtmxLoginRequiredMixin, View):
             "job": active_job,
             "parse_run": parse_run,
             "instance_state": instance_state,
+            "queue_progress": queue_progress,
+            "worker_stats": worker_stats or [],
         }
         return render(request, "pipeline/partials/parse_progress.html", context)
 

--- a/lavandula/migrations/parse/003_work_queue.sql
+++ b/lavandula/migrations/parse/003_work_queue.sql
@@ -1,0 +1,55 @@
+-- Migration 003: Work queue for multi-instance SKIP LOCKED coordination
+-- Spec 0055: Multi-Instance Parse
+--
+-- Prerequisites: 001 (lava_parse schema), 002 (docling_writer role)
+-- Must be run as superuser / table owner on RDS before deploying Spec 0055 code.
+
+-- 1. Create the work queue table
+CREATE TABLE IF NOT EXISTS lava_parse.work_queue (
+    id              BIGSERIAL PRIMARY KEY,
+    run_id          INTEGER NOT NULL REFERENCES lava_parse.parse_runs(id),
+    content_sha256  TEXT NOT NULL,
+    source_org_ein  TEXT NOT NULL,
+    claimed_by      TEXT,
+    claimed_at      TIMESTAMPTZ,
+    completed_at    TIMESTAMPTZ,
+    error           TEXT,
+    UNIQUE (run_id, content_sha256)
+);
+
+-- Partial index for the unclaimed-row query used by SKIP LOCKED fetch
+CREATE INDEX IF NOT EXISTS idx_work_queue_unclaimed
+    ON lava_parse.work_queue (run_id)
+    WHERE claimed_by IS NULL;
+
+-- 2. Add instance_ids array column to parse_runs
+ALTER TABLE lava_parse.parse_runs
+    ADD COLUMN IF NOT EXISTS instance_ids TEXT[];
+
+-- 3. Grants for docling_writer (GPU workers): SELECT + UPDATE only
+GRANT SELECT, UPDATE ON lava_parse.work_queue TO docling_writer;
+
+-- 4. Grants for dashboard_user1 (orchestrator): full access
+GRANT ALL ON lava_parse.work_queue TO dashboard_user1;
+GRANT USAGE, SELECT ON SEQUENCE lava_parse.work_queue_id_seq TO dashboard_user1;
+
+-- 5. Grants for dashboard_reader: SELECT only
+GRANT SELECT ON lava_parse.work_queue TO dashboard_reader;
+
+-- 6. Enable Row-Level Security
+ALTER TABLE lava_parse.work_queue ENABLE ROW LEVEL SECURITY;
+
+-- Workers can only claim unclaimed rows or complete their own claims
+CREATE POLICY worker_claim_policy ON lava_parse.work_queue
+    FOR UPDATE TO docling_writer
+    USING (claimed_by IS NULL OR claimed_by = current_setting('app.worker_id', true));
+
+-- Workers can read all rows (needed for the SKIP LOCKED SELECT)
+CREATE POLICY worker_select_policy ON lava_parse.work_queue
+    FOR SELECT TO docling_writer
+    USING (true);
+
+-- Orchestrator (dashboard_user1) bypasses RLS via permissive policy
+CREATE POLICY orchestrator_full_access ON lava_parse.work_queue
+    FOR ALL TO dashboard_user1
+    USING (true) WITH CHECK (true);

--- a/lavandula/parse/db.py
+++ b/lavandula/parse/db.py
@@ -45,7 +45,7 @@ def get_connection(
     return conn
 
 
-def fetch_work_batch(
+def fetch_work_batch_legacy(
     conn,
     priority_filter: list[str],
     batch_size: int,
@@ -370,3 +370,184 @@ def release_worker_lock(conn) -> None:
         cur.execute(
             "SELECT pg_advisory_unlock(%s)", (DOCLING_PARSE_WORKER,)
         )
+
+
+# ---------------------------------------------------------------------------
+# Work queue functions (Spec 0055: multi-instance SKIP LOCKED)
+# ---------------------------------------------------------------------------
+
+
+def populate_work_queue(
+    conn, run_id: int, priority_filter: list[str], ntee_filter: str | None = None
+) -> int:
+    """Materialize eligible docs into work_queue. Returns count inserted."""
+    ntee_join = (
+        "JOIN lava_corpus.nonprofits_seed ns ON c.source_org_ein = ns.ein"
+        if ntee_filter
+        else ""
+    )
+    ntee_where = "AND ns.ntee_code LIKE %(ntee)s" if ntee_filter else ""
+    with conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                f"""
+                INSERT INTO lava_parse.work_queue (run_id, content_sha256, source_org_ein)
+                SELECT %(run_id)s, c.content_sha256, c.source_org_ein
+                FROM lava_corpus.corpus c
+                {ntee_join}
+                WHERE c.content_sha256 NOT IN (
+                    SELECT content_sha256 FROM lava_parse.documents
+                )
+                  AND c.classification = ANY(%(priority)s)
+                  {ntee_where}
+                ON CONFLICT (run_id, content_sha256) DO NOTHING
+                """,
+                {"run_id": run_id, "priority": priority_filter, "ntee": ntee_filter},
+            )
+            return cur.rowcount
+
+
+def fetch_work_batch(
+    conn, run_id: int, batch_size: int, worker_id: str
+) -> list[dict]:
+    """Claim next batch of unclaimed work items using SKIP LOCKED."""
+    with conn:
+        with conn.cursor(cursor_factory=psycopg2.extras.DictCursor) as cur:
+            cur.execute(
+                """
+                WITH claimed AS (
+                    SELECT id, content_sha256, source_org_ein
+                    FROM lava_parse.work_queue
+                    WHERE run_id = %(run_id)s AND claimed_by IS NULL
+                    ORDER BY id
+                    LIMIT %(limit)s
+                    FOR UPDATE SKIP LOCKED
+                )
+                UPDATE lava_parse.work_queue wq
+                SET claimed_by = %(worker_id)s, claimed_at = NOW()
+                FROM claimed
+                WHERE wq.id = claimed.id
+                RETURNING wq.content_sha256, wq.source_org_ein
+                """,
+                {"run_id": run_id, "limit": batch_size, "worker_id": worker_id},
+            )
+            rows = cur.fetchall()
+    return [dict(r) for r in rows]
+
+
+def complete_work_item(
+    conn, run_id: int, content_sha256: str, error: str | None = None
+) -> None:
+    """Mark a work queue item as completed (or errored)."""
+    if error and len(error) > 200:
+        error = error[:200]
+    with conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                UPDATE lava_parse.work_queue
+                SET completed_at = NOW(), error = %(error)s
+                WHERE run_id = %(run_id)s AND content_sha256 = %(sha)s
+                """,
+                {"run_id": run_id, "sha": content_sha256, "error": error},
+            )
+
+
+def reclaim_stale_claims(conn, run_id: int, worker_id: str) -> int:
+    """Reset claims for a terminated worker so they can be picked up again."""
+    with conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                UPDATE lava_parse.work_queue
+                SET claimed_by = NULL, claimed_at = NULL
+                WHERE run_id = %(run_id)s AND claimed_by = %(worker)s AND completed_at IS NULL
+                """,
+                {"run_id": run_id, "worker": worker_id},
+            )
+            return cur.rowcount
+
+
+def reclaim_all_stale_claims(conn, run_id: int) -> int:
+    """For run resume: reclaim all incomplete claims from previous attempt."""
+    with conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                UPDATE lava_parse.work_queue
+                SET claimed_by = NULL, claimed_at = NULL
+                WHERE run_id = %(run_id)s AND claimed_by IS NOT NULL AND completed_at IS NULL
+                """,
+                {"run_id": run_id},
+            )
+            return cur.rowcount
+
+
+def get_queue_progress(conn, run_id: int) -> dict:
+    """Returns aggregate progress for the orchestrator poll loop."""
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT
+                COUNT(*) as total,
+                COUNT(*) FILTER (WHERE claimed_by IS NOT NULL) as claimed,
+                COUNT(*) FILTER (WHERE completed_at IS NOT NULL AND error IS NULL) as completed,
+                COUNT(*) FILTER (WHERE completed_at IS NOT NULL AND error IS NOT NULL) as errored
+            FROM lava_parse.work_queue
+            WHERE run_id = %(run_id)s
+            """,
+            {"run_id": run_id},
+        )
+        row = cur.fetchone()
+        return {
+            "total": row[0],
+            "claimed": row[1],
+            "completed": row[2],
+            "errored": row[3],
+        }
+
+
+def get_per_worker_stats(conn, run_id: int) -> list[dict]:
+    """Returns per-instance throughput for dashboard display."""
+    with conn.cursor(cursor_factory=psycopg2.extras.DictCursor) as cur:
+        cur.execute(
+            """
+            SELECT claimed_by,
+                   COUNT(*) FILTER (WHERE completed_at IS NOT NULL) as completed,
+                   COUNT(*) FILTER (WHERE completed_at IS NULL) as in_progress,
+                   MAX(completed_at) as last_activity,
+                   EXTRACT(EPOCH FROM MAX(completed_at) - MIN(claimed_at)) as active_seconds
+            FROM lava_parse.work_queue
+            WHERE run_id = %(run_id)s AND claimed_by IS NOT NULL
+            GROUP BY claimed_by
+            """,
+            {"run_id": run_id},
+        )
+        return [dict(r) for r in cur.fetchall()]
+
+
+def cleanup_work_queue(conn, run_id: int) -> int:
+    """Delete queue rows after run completion."""
+    with conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                "DELETE FROM lava_parse.work_queue WHERE run_id = %(run_id)s",
+                {"run_id": run_id},
+            )
+            return cur.rowcount
+
+
+def get_run_status_by_id(conn, run_id: int) -> dict | None:
+    """Get status of a parse run by ID."""
+    with conn.cursor(cursor_factory=psycopg2.extras.DictCursor) as cur:
+        cur.execute(
+            """
+            SELECT id, run_tag, started_at, finished_at, config_json,
+                   stats_json, instance_id
+            FROM lava_parse.parse_runs
+            WHERE id = %s
+            """,
+            (run_id,),
+        )
+        row = cur.fetchone()
+        return dict(row) if row else None

--- a/lavandula/parse/worker.py
+++ b/lavandula/parse/worker.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import argparse
 import json
 import logging
+import re
 import sys
 import tempfile
 import time
@@ -43,20 +44,40 @@ def main() -> None:
     args = parse_args()
     _setup_logging()
 
+    if args.worker_id and not re.match(r"^i-[0-9a-f]+$", args.worker_id):
+        logger.error("invalid worker-id format", extra={"worker_id": args.worker_id})
+        sys.exit(1)
+
+    if not (isinstance(args.run_id, int) and args.run_id > 0):
+        logger.error("invalid run-id: must be a positive integer")
+        sys.exit(1)
+
     logger.info("worker starting", extra={"run_id": args.run_id, "priority": args.priority})
 
     conn = _connect(args)
 
-    if not db.acquire_worker_lock(conn):
-        logger.error("another worker is already running (advisory lock held)")
-        sys.exit(1)
+    if args.worker_id:
+        with conn.cursor() as cur:
+            cur.execute("SET app.worker_id = %s", (args.worker_id,))
 
-    try:
-        _run_loop(conn, args)
-    finally:
-        db.release_worker_lock(conn)
-        conn.close()
+        status = db.get_run_status_by_id(conn, args.run_id)
+        if status is None:
+            logger.error("run_id does not exist in parse_runs", extra={"run_id": args.run_id})
+            conn.close()
+            sys.exit(1)
 
+        _run_loop_queue(conn, args)
+    else:
+        if not db.acquire_worker_lock(conn):
+            logger.error("another worker is already running (advisory lock held)")
+            conn.close()
+            sys.exit(1)
+        try:
+            _run_loop(conn, args)
+        finally:
+            db.release_worker_lock(conn)
+
+    conn.close()
     logger.info("worker finished")
 
 
@@ -81,7 +102,7 @@ def _run_loop(conn, args) -> None:
             logger.info("reached max-docs limit", extra={"max_docs": max_docs})
             break
 
-        batch = db.fetch_work_batch(conn, priority, args.batch_size, ntee_filter=args.ntee)
+        batch = db.fetch_work_batch_legacy(conn, priority, args.batch_size, ntee_filter=args.ntee)
         if not batch:
             logger.info("no more eligible documents")
             break
@@ -141,6 +162,88 @@ def _run_loop(conn, args) -> None:
     stats["end_time"] = time.time()
     stats["duration_seconds"] = stats["end_time"] - stats["start_time"]
     db.finish_run(conn, args.run_id, stats)
+
+
+def _run_loop_queue(conn, args) -> None:
+    """Queue mode: claim work via SKIP LOCKED, complete items individually."""
+    import boto3
+
+    s3 = boto3.client("s3")
+
+    stats = {
+        "total": 0,
+        "succeeded": 0,
+        "failed": 0,
+        "skipped": 0,
+        "start_time": time.time(),
+    }
+
+    max_docs = args.max_docs
+
+    while True:
+        if max_docs is not None and stats["total"] >= max_docs:
+            logger.info("reached max-docs limit", extra={"max_docs": max_docs})
+            break
+
+        batch = db.fetch_work_batch(conn, args.run_id, args.batch_size, args.worker_id)
+        if not batch:
+            logger.info("no more unclaimed work items")
+            break
+
+        with tempfile.TemporaryDirectory(prefix="docling-work-") as tmp_dir:
+            tmp_path = Path(tmp_dir)
+            pdf_paths = _download_batch(s3, batch, tmp_path)
+
+            for item in batch:
+                sha = item["content_sha256"]
+
+                if not config.validate_sha256(sha):
+                    logger.warning("invalid sha256 in work queue", extra={"sha": sha[:20]})
+                    db.complete_work_item(conn, args.run_id, sha, error="invalid_sha256")
+                    stats["skipped"] += 1
+                    stats["total"] += 1
+                    continue
+
+                pdf_path = pdf_paths.get(sha)
+
+                if pdf_path is None:
+                    logger.warning("download failed after retries, skipping", extra={"sha": sha[:16]})
+                    stats["transient_skipped"] = stats.get("transient_skipped", 0) + 1
+                    stats["total"] += 1
+                    continue
+
+                try:
+                    result = _process_one(pdf_path, item)
+                    db.insert_document(conn, result)
+                    _generate_thumbnail(s3, pdf_path, sha)
+                    db.complete_work_item(conn, args.run_id, sha)
+                    stats["succeeded"] += 1
+                except TransientError as e:
+                    logger.warning("transient error, skipping", extra={"sha": sha[:16], "err": str(e)[:100]})
+                    stats["transient_skipped"] = stats.get("transient_skipped", 0) + 1
+                except PermanentError as e:
+                    error_label = str(e)[:200] if str(e) else "unknown_error"
+                    _record_error(conn, item, e)
+                    db.complete_work_item(conn, args.run_id, sha, error=error_label)
+                    stats["failed"] += 1
+                finally:
+                    stats["total"] += 1
+                    if pdf_path and pdf_path.exists():
+                        pdf_path.unlink()
+
+                if stats["total"] % config.STATS_UPDATE_INTERVAL == 0:
+                    db.update_run_stats(conn, args.run_id, stats)
+
+                if _spot_termination_pending():
+                    logger.warning("spot termination notice received, exiting gracefully")
+                    break
+
+        if _spot_termination_pending():
+            break
+
+    stats["end_time"] = time.time()
+    stats["duration_seconds"] = stats["end_time"] - stats["start_time"]
+    db.update_run_stats(conn, args.run_id, stats)
 
 
 def _process_one(pdf_path: Path, item: dict) -> dict:
@@ -347,6 +450,8 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
                         help="Stop after processing this many documents (required for safety)")
     parser.add_argument("--ntee", default=None,
                         help="NTEE prefix filter (e.g. 'P2%%' for Human Services)")
+    parser.add_argument("--worker-id", default=None,
+                        help="EC2 instance ID (enables SKIP LOCKED queue mode)")
     return parser.parse_args(argv)
 
 


### PR DESCRIPTION
## Summary

- Enable 1-4 concurrent GPU workers for Docling parsing via `--workers N` flag
- Workers self-coordinate via PostgreSQL `FOR UPDATE SKIP LOCKED` on a new `lava_parse.work_queue` table — no double-processing, no advisory locks between instances
- Orchestrator manages N EC2 instances in a slot-based model with per-slot relaunch on spot termination (max 3 relaunches per slot)
- Dashboard shows aggregate progress from work_queue and per-worker throughput cards
- `--workers 1` is backward-compatible with existing single-instance behavior

## Changed files

| File | What |
|------|------|
| `lavandula/parse/db.py` | 10 new work queue functions (populate, SKIP LOCKED fetch, complete, reclaim, progress, cleanup) |
| `lavandula/parse/worker.py` | `--worker-id` flag, queue-mode run loop with RLS session variable |
| `parse_documents.py` | `--workers` flag, slot-based multi-instance management, stale worker detection |
| `orchestrator.py` | `workers` param in COMMAND_MAP |
| `forms.py` | Workers field (1-4) on ParseRunForm |
| `views.py` | Aggregate progress from work_queue, per-worker stats with 10s cache |
| `parse_progress.html` | Multi-worker fleet display with per-instance cards |
| `test_parse.py` | 25 new tests + updated existing tests for workers field |
| `003_work_queue.sql` | Migration DDL: CREATE TABLE, RLS policies, grants, instance_ids column |
| `0011_parse_runs_instance_ids.py` | Django no-op stub for migration sequence |

## Migration required

Operator must apply `lavandula/migrations/parse/003_work_queue.sql` on RDS **before** deploying this code.

## Test plan

- [x] All 76 tests pass (`DJANGO_SETTINGS_MODULE=dashboard.test_settings python3 manage.py test pipeline.tests.test_parse`)
- [ ] Apply migration DDL on RDS
- [ ] Launch single-worker run (`--workers 1`) — verify backward compatibility
- [ ] Launch multi-worker run (`--workers 2`) — verify SKIP LOCKED no-overlap
- [ ] Verify spot termination triggers stale reclaim + relaunch
- [ ] Verify dashboard shows per-worker cards and aggregate progress

🤖 Generated with [Claude Code](https://claude.com/claude-code)