### PR TITLE
[Spec 0060] Parse fidelity verification & pdftotext repair

### DIFF
--- a/lavandula/dashboard/pipeline/management/commands/extract_pdftotext.py
+++ b/lavandula/dashboard/pipeline/management/commands/extract_pdftotext.py
@@ -1,0 +1,247 @@
+"""Extract pdftotext from S3-archived PDFs and compute fidelity scores (Spec 0060).
+
+Usage:
+    python3 manage.py extract_pdftotext
+    python3 manage.py extract_pdftotext --limit 100
+    python3 manage.py extract_pdftotext --sha abc123...
+    python3 manage.py extract_pdftotext --force
+    python3 manage.py extract_pdftotext --force --version-mismatch
+    python3 manage.py extract_pdftotext --run-tag p20-v1
+"""
+from __future__ import annotations
+
+import logging
+import re
+import tempfile
+import time
+
+from django.core.management.base import BaseCommand
+from sqlalchemy import text as sa_text
+
+from lavandula.common.db import make_app_engine
+from lavandula.faithfulness.fidelity import classify_text_source, score_fidelity
+from lavandula.faithfulness.pdftotext_extract import (
+    ExtractResult,
+    extract_text,
+    get_pdftotext_version,
+)
+from lavandula.reports.s3_archive import S3Archive
+
+log = logging.getLogger(__name__)
+
+_BUCKET = "lavandula-nonprofit-collaterals"
+_PREFIX = "pdfs"
+_SHA_RE = re.compile(r"^[a-f0-9]{64}$")
+
+
+class Command(BaseCommand):
+    help = "Extract pdftotext text from S3-archived PDFs, compute fidelity scores (Spec 0060)"
+
+    def add_arguments(self, parser):
+        parser.add_argument("--run-tag", type=str, default=None,
+                            help="Filter to documents from a specific extraction run")
+        parser.add_argument("--limit", type=int, default=None,
+                            help="Max documents to process")
+        parser.add_argument("--sha", type=str, default=None,
+                            help="Process a single document by SHA-256")
+        parser.add_argument("--force", action="store_true",
+                            help="Re-extract even if pdftotext row exists")
+        parser.add_argument("--version-mismatch", action="store_true",
+                            help="With --force: only re-extract where stored version differs")
+
+    def handle(self, *args, **options):
+        sha_filter = options["sha"]
+        if sha_filter and not _SHA_RE.match(sha_filter):
+            self.stderr.write("Invalid SHA-256: must be 64 hex characters")
+            raise SystemExit(1)
+
+        try:
+            version = get_pdftotext_version()
+        except FileNotFoundError as exc:
+            self.stderr.write(str(exc))
+            raise SystemExit(1)
+
+        self.stdout.write(f"pdftotext version: {version}")
+
+        engine = make_app_engine()
+        archive = S3Archive(_BUCKET, _PREFIX)
+
+        shas = self._get_target_shas(
+            engine, options, sha_filter, version,
+        )
+
+        if not shas:
+            self.stdout.write("No documents to process.")
+            return
+
+        self.stdout.write(f"Processing {len(shas)} documents...")
+
+        stats = {"processed": 0, "extracted": 0, "scanned": 0, "failed": 0, "skipped": 0}
+        t0 = time.monotonic()
+
+        for i, sha in enumerate(shas):
+            try:
+                self._process_one(engine, archive, sha, version, stats)
+            except Exception:
+                log.exception("Unexpected error processing %s", sha[:16])
+                stats["failed"] += 1
+
+            if (i + 1) % 100 == 0:
+                elapsed = time.monotonic() - t0
+                self.stdout.write(
+                    f"  Progress: {i + 1}/{len(shas)} docs, "
+                    f"{stats['extracted']} extracted, {stats['scanned']} scanned, "
+                    f"{stats['failed']} failed ({elapsed:.0f}s)"
+                )
+
+        elapsed = time.monotonic() - t0
+        self.stdout.write(
+            f"\nComplete ({elapsed:.1f}s): {stats['processed']} processed, "
+            f"{stats['extracted']} text-native, {stats['scanned']} scanned, "
+            f"{stats['failed']} failed, {stats['skipped']} skipped"
+        )
+
+    def _get_target_shas(self, engine, options, sha_filter, version):
+        force = options["force"]
+        version_mismatch = options["version_mismatch"]
+        run_tag = options["run_tag"]
+        limit = options["limit"]
+
+        if sha_filter:
+            return [sha_filter]
+
+        with engine.connect() as conn:
+            if force and version_mismatch:
+                rows = conn.execute(sa_text("""
+                    SELECT d.content_sha256
+                    FROM lava_parse.documents d
+                    JOIN lava_parse.pdftotext p ON d.content_sha256 = p.content_sha256
+                    WHERE p.pdftotext_version != :version
+                    ORDER BY d.content_sha256
+                    LIMIT :lim
+                """), {"version": version, "lim": limit or 999999999}).fetchall()
+            elif force:
+                if run_tag:
+                    rows = conn.execute(sa_text("""
+                        SELECT d.content_sha256
+                        FROM lava_parse.documents d
+                        JOIN lava_parse.parse_runs r ON r.run_tag = :tag
+                        WHERE d.metadata_json->>'run_tag' = :tag
+                           OR d.parsed_at >= r.started_at
+                        ORDER BY d.content_sha256
+                        LIMIT :lim
+                    """), {"tag": run_tag, "lim": limit or 999999999}).fetchall()
+                else:
+                    rows = conn.execute(sa_text("""
+                        SELECT content_sha256
+                        FROM lava_parse.documents
+                        ORDER BY content_sha256
+                        LIMIT :lim
+                    """), {"lim": limit or 999999999}).fetchall()
+            else:
+                if run_tag:
+                    rows = conn.execute(sa_text("""
+                        SELECT d.content_sha256
+                        FROM lava_parse.documents d
+                        LEFT JOIN lava_parse.pdftotext p ON d.content_sha256 = p.content_sha256
+                        JOIN lava_parse.parse_runs r ON r.run_tag = :tag
+                        WHERE p.content_sha256 IS NULL
+                          AND (d.metadata_json->>'run_tag' = :tag
+                               OR d.parsed_at >= r.started_at)
+                        ORDER BY d.content_sha256
+                        LIMIT :lim
+                    """), {"tag": run_tag, "lim": limit or 999999999}).fetchall()
+                else:
+                    rows = conn.execute(sa_text("""
+                        SELECT d.content_sha256
+                        FROM lava_parse.documents d
+                        LEFT JOIN lava_parse.pdftotext p ON d.content_sha256 = p.content_sha256
+                        WHERE p.content_sha256 IS NULL
+                        ORDER BY d.content_sha256
+                        LIMIT :lim
+                    """), {"lim": limit or 999999999}).fetchall()
+
+        return [r[0] for r in rows]
+
+    def _process_one(self, engine, archive, sha, version, stats):
+        pdf_bytes = self._download_pdf(archive, sha)
+        if pdf_bytes is None:
+            stats["failed"] += 1
+            return
+
+        result = extract_text(pdf_bytes)
+
+        docling_text = self._get_docling_text(engine, sha)
+        fidelity = None
+        if docling_text and not result.failed and not result.is_scanned:
+            fidelity = score_fidelity(docling_text, result.text)
+
+        text_source = classify_text_source(result, fidelity)
+
+        with engine.begin() as conn:
+            conn.execute(sa_text("""
+                INSERT INTO lava_parse.pdftotext
+                    (content_sha256, pdftotext_version, full_text, char_count)
+                VALUES (:sha, :version, :text, :chars)
+                ON CONFLICT (content_sha256) DO UPDATE SET
+                    pdftotext_version = EXCLUDED.pdftotext_version,
+                    full_text = EXCLUDED.full_text,
+                    char_count = EXCLUDED.char_count,
+                    extracted_at = now()
+            """), {
+                "sha": sha,
+                "version": version,
+                "text": result.text,
+                "chars": result.char_count,
+            })
+
+            conn.execute(sa_text("""
+                UPDATE lava_parse.documents
+                SET pdftotext_coverage = :fwd,
+                    pdftotext_reverse = :rev,
+                    text_source = :src
+                WHERE content_sha256 = :sha
+            """), {
+                "sha": sha,
+                "fwd": fidelity.forward if fidelity else None,
+                "rev": fidelity.reverse if fidelity else None,
+                "src": text_source,
+            })
+
+        stats["processed"] += 1
+        if text_source == "text_native":
+            stats["extracted"] += 1
+        elif text_source == "scanned":
+            stats["scanned"] += 1
+        else:
+            stats["failed"] += 1
+
+    def _download_pdf(self, archive, sha):
+        try:
+            return archive.get(sha)
+        except Exception:
+            log.warning("S3 download failed for %s, retrying", sha[:16])
+            try:
+                return archive.get(sha)
+            except Exception:
+                log.warning("S3 download failed on retry for %s", sha[:16])
+                return None
+
+    def _get_docling_text(self, engine, sha):
+        with engine.connect() as conn:
+            rows = conn.execute(sa_text("""
+                SELECT heading, body_text
+                FROM lava_parse.sections
+                WHERE content_sha256 = :sha
+                ORDER BY section_index
+            """), {"sha": sha}).fetchall()
+
+        if not rows:
+            return None
+
+        parts = []
+        for heading, body in rows:
+            if heading:
+                parts.append(heading)
+            parts.append(body)
+        return "\n\n".join(parts)

--- a/lavandula/dashboard/pipeline/templates/pipeline/base.html
+++ b/lavandula/dashboard/pipeline/templates/pipeline/base.html
@@ -29,6 +29,9 @@
         <li><a href="{% url 'enrich_index' %}" class="block px-4 py-2 hover:bg-gray-800 hover:text-white {% if 'enrich_index' in request.resolver_match.url_name %}bg-gray-800 text-white{% endif %}">990 Index</a></li>
         <li><a href="{% url 'enrich_parse' %}" class="block px-4 py-2 hover:bg-gray-800 hover:text-white {% if 'enrich_parse' in request.resolver_match.url_name %}bg-gray-800 text-white{% endif %}">990 Parse</a></li>
         <li><a href="{% url 'phone_enrich' %}" class="block px-4 py-2 hover:bg-gray-800 hover:text-white {% if 'phone_enrich' in request.resolver_match.url_name %}bg-gray-800 text-white{% endif %}">Phone Enrich</a></li>
+        <li class="pt-3 px-4 text-xs font-semibold text-gray-500 uppercase tracking-wider">Quality</li>
+        <li><a href="{% url 'llm_extract' %}" class="block px-4 py-2 hover:bg-gray-800 hover:text-white {% if request.resolver_match.url_name == 'llm_extract' %}bg-gray-800 text-white{% endif %}">LLM Extraction</a></li>
+        <li><a href="{% url 'faithfulness' %}" class="block px-4 py-2 hover:bg-gray-800 hover:text-white {% if 'faithfulness' in request.resolver_match.url_name %}bg-gray-800 text-white{% endif %}">Faithfulness Gate</a></li>
         <li class="pt-3 px-4 text-xs font-semibold text-gray-500 uppercase tracking-wider">Operations</li>
         <li><a href="{% url 'job_list' %}" class="block px-4 py-2 hover:bg-gray-800 hover:text-white {% if 'job' in request.resolver_match.url_name and 'worker' not in request.resolver_match.url_name %}bg-gray-800 text-white{% endif %}">Jobs</a></li>
         <li><a href="{% url 'worker_list' %}" class="block px-4 py-2 hover:bg-gray-800 hover:text-white {% if 'worker' in request.resolver_match.url_name %}bg-gray-800 text-white{% endif %}">Workers</a></li>

--- a/lavandula/dashboard/pipeline/templates/pipeline/faithfulness.html
+++ b/lavandula/dashboard/pipeline/templates/pipeline/faithfulness.html
@@ -55,9 +55,19 @@
           {% empty %}
           <option disabled>No unverified runs</option>
           {% endfor %}
+          {% for run in verified_runs %}
+          <option value="{{ run.id }}">{{ run.run_tag }} (re-verify) — {{ run.total_metrics }} metrics</option>
+          {% endfor %}
         </select>
       </div>
-      <button type="submit" class="w-full bg-blue-600 text-white py-2 rounded text-sm hover:bg-blue-700" {% if active_verification or not unverified_runs %}disabled{% endif %}>
+      <div class="mb-3">
+        <label class="block text-xs font-medium text-gray-600 mb-1">Source Provider</label>
+        <select name="source_provider" class="w-full border border-gray-300 rounded px-3 py-2 text-sm">
+          <option value="docling">Docling (default)</option>
+          <option value="pdftotext">pdftotext-repaired (0060)</option>
+        </select>
+      </div>
+      <button type="submit" class="w-full bg-blue-600 text-white py-2 rounded text-sm hover:bg-blue-700" {% if active_verification %}disabled{% endif %}>
         Run Verification Gate
       </button>
     </form>
@@ -100,6 +110,78 @@
     <p class="text-gray-500 text-sm">No verified runs yet. Run the gate on an extraction run to see results.</p>
     {% endif %}
   </div>
+</div>
+
+<!-- pdftotext Extraction (Spec 0060) -->
+<div class="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-6">
+  <div class="bg-white rounded-lg shadow p-5">
+    <h2 class="text-sm font-semibold text-gray-500 uppercase mb-3">pdftotext Extraction</h2>
+    {% if pdftotext_stats %}
+    <div class="grid grid-cols-2 gap-3 text-sm mb-3">
+      <div><span class="text-gray-500">Extracted:</span> <span class="font-mono font-medium">{{ pdftotext_stats.total_extracted }}</span> / {{ pdftotext_stats.total_parsed }}</div>
+      <div><span class="text-gray-500">Coverage:</span> <span class="font-mono">{{ pdftotext_stats.pct }}%</span></div>
+      <div><span class="text-green-600">Text-native:</span> <span class="font-mono">{{ pdftotext_stats.text_native }}</span></div>
+      <div><span class="text-yellow-600">Scanned:</span> <span class="font-mono">{{ pdftotext_stats.scanned }}</span></div>
+      <div><span class="text-red-600">Failed:</span> <span class="font-mono">{{ pdftotext_stats.failed }}</span></div>
+      <div><span class="text-gray-400">Pending:</span> <span class="font-mono">{{ pdftotext_stats.pending }}</span></div>
+    </div>
+    {% if pdftotext_stats.total_parsed > 0 %}
+    <div class="mb-3">
+      <div class="flex justify-between text-xs text-gray-500 mb-1">
+        <span>Extraction Progress</span>
+        <span>{{ pdftotext_stats.pct }}%</span>
+      </div>
+      <div class="w-full bg-gray-200 rounded-full h-2">
+        <div class="bg-blue-500 h-2 rounded-full" style="width: {{ pdftotext_stats.pct }}%"></div>
+      </div>
+    </div>
+    {% endif %}
+    {% else %}
+    <p class="text-gray-500 text-sm mb-3">pdftotext table not yet created. Run the migration first.</p>
+    {% endif %}
+    <form method="post" action="{% url 'pdftotext_backfill' %}">
+      {% csrf_token %}
+      <button type="submit" class="w-full bg-indigo-600 text-white py-2 rounded text-sm hover:bg-indigo-700" {% if active_pdftotext %}disabled{% endif %}>
+        Run pdftotext Backfill
+      </button>
+    </form>
+  </div>
+
+  {% if active_pdftotext %}
+  <div class="bg-indigo-50 border border-indigo-200 rounded-lg p-4" id="active-pdftotext">
+    <div class="flex items-center gap-2 mb-2">
+      <span class="w-2 h-2 rounded-full bg-green-500 animate-pulse"></span>
+      <span class="font-semibold text-indigo-900">pdftotext Backfill Running</span>
+    </div>
+    <div class="grid grid-cols-2 md:grid-cols-3 gap-3 text-sm" id="pt-stats">
+      <div><span class="text-gray-500">Progress:</span> <span class="font-mono" id="pt-processed">{{ active_pdftotext.processed }}</span>/<span class="font-mono" id="pt-total">{{ active_pdftotext.total }}</span></div>
+      <div><span class="text-green-600">Extracted:</span> <span class="font-mono" id="pt-extracted">{{ active_pdftotext.extracted }}</span></div>
+      <div><span class="text-yellow-600">Scanned:</span> <span class="font-mono" id="pt-scanned">{{ active_pdftotext.scanned }}</span></div>
+      <div><span class="text-red-600">Failed:</span> <span class="font-mono" id="pt-failed">{{ active_pdftotext.failed }}</span></div>
+      <div><span class="text-gray-500">Elapsed:</span> <span class="font-mono" id="pt-elapsed">{{ active_pdftotext.elapsed_s }}s</span></div>
+    </div>
+  </div>
+  <script>
+  (function() {
+    function pollPt() {
+      fetch("{% url 'pdftotext_backfill_status' %}")
+        .then(r => r.json())
+        .then(d => {
+          if (d.done) { location.reload(); return; }
+          document.getElementById("pt-processed").textContent = d.processed || 0;
+          document.getElementById("pt-total").textContent = d.total || 0;
+          document.getElementById("pt-extracted").textContent = d.extracted || 0;
+          document.getElementById("pt-scanned").textContent = d.scanned || 0;
+          document.getElementById("pt-failed").textContent = d.failed || 0;
+          document.getElementById("pt-elapsed").textContent = (d.elapsed_s || 0).toFixed(0) + "s";
+          setTimeout(pollPt, 3000);
+        })
+        .catch(() => setTimeout(pollPt, 5000));
+    }
+    setTimeout(pollPt, 3000);
+  })();
+  </script>
+  {% endif %}
 </div>
 
 <!-- Run History -->

--- a/lavandula/dashboard/pipeline/templates/pipeline/faithfulness.html
+++ b/lavandula/dashboard/pipeline/templates/pipeline/faithfulness.html
@@ -1,0 +1,158 @@
+{% extends "pipeline/base.html" %}
+{% block title %}Faithfulness Gate — Lavandula Pipeline{% endblock %}
+{% block content %}
+<h1 class="text-2xl font-bold text-gray-900 mb-2">Faithfulness Verification Gate</h1>
+<p class="text-sm text-gray-500 mb-6">Verify LLM-extracted metrics and stories are grounded in source document text. Assigns verification tiers (A/B/C) and quarantines ungrounded facts.</p>
+
+{% if active_verification %}
+<div class="bg-blue-50 border border-blue-200 rounded-lg p-4 mb-6" id="active-verify">
+  <div class="flex items-center justify-between mb-2">
+    <div class="flex items-center gap-2">
+      <span class="w-2 h-2 rounded-full bg-green-500 animate-pulse"></span>
+      <span class="font-semibold text-blue-900">Verifying: {{ active_verification.run_tag }}</span>
+    </div>
+  </div>
+  <div class="grid grid-cols-2 md:grid-cols-4 gap-3 text-sm" id="verify-stats">
+    <div><span class="text-gray-500">Docs:</span> <span class="font-mono" id="vstat-docs">{{ active_verification.docs_processed }}</span></div>
+    <div><span class="text-gray-500">Metrics verified:</span> <span class="font-mono" id="vstat-mverified">{{ active_verification.metrics_verified }}</span>/<span class="font-mono" id="vstat-mtotal">{{ active_verification.total_metrics }}</span></div>
+    <div><span class="text-gray-500">Stories verified:</span> <span class="font-mono" id="vstat-sverified">{{ active_verification.stories_verified }}</span>/<span class="font-mono" id="vstat-stotal">{{ active_verification.total_stories }}</span></div>
+    <div><span class="text-gray-500">Elapsed:</span> <span class="font-mono" id="vstat-elapsed">{{ active_verification.elapsed_s }}s</span></div>
+  </div>
+</div>
+<script>
+(function() {
+  function poll() {
+    fetch("{% url 'faithfulness_status' %}?run_id={{ active_verification.run_id }}")
+      .then(r => r.json())
+      .then(d => {
+        if (d.done) { location.reload(); return; }
+        document.getElementById("vstat-docs").textContent = d.docs_processed || 0;
+        document.getElementById("vstat-mverified").textContent = d.metrics_verified || 0;
+        document.getElementById("vstat-mtotal").textContent = d.total_metrics || 0;
+        document.getElementById("vstat-sverified").textContent = d.stories_verified || 0;
+        document.getElementById("vstat-stotal").textContent = d.total_stories || 0;
+        document.getElementById("vstat-elapsed").textContent = (d.elapsed_s || 0).toFixed(0) + "s";
+        setTimeout(poll, 3000);
+      })
+      .catch(() => setTimeout(poll, 5000));
+  }
+  setTimeout(poll, 3000);
+})();
+</script>
+{% endif %}
+
+<div class="grid grid-cols-1 lg:grid-cols-3 gap-6 mb-6">
+  <!-- Verify a Run -->
+  <div class="bg-white rounded-lg shadow p-5">
+    <h2 class="text-sm font-semibold text-gray-500 uppercase mb-3">Verify Extraction Run</h2>
+    <form method="post" action="{% url 'faithfulness_verify' %}">
+      {% csrf_token %}
+      <div class="mb-3">
+        <label class="block text-xs font-medium text-gray-600 mb-1">Extraction Run</label>
+        <select name="run_id" required class="w-full border border-gray-300 rounded px-3 py-2 text-sm">
+          {% for run in unverified_runs %}
+          <option value="{{ run.id }}">{{ run.run_tag }} — {{ run.metric_count }} metrics, {{ run.story_count }} stories</option>
+          {% empty %}
+          <option disabled>No unverified runs</option>
+          {% endfor %}
+        </select>
+      </div>
+      <button type="submit" class="w-full bg-blue-600 text-white py-2 rounded text-sm hover:bg-blue-700" {% if active_verification or not unverified_runs %}disabled{% endif %}>
+        Run Verification Gate
+      </button>
+    </form>
+  </div>
+
+  <!-- Summary Stats -->
+  <div class="lg:col-span-2 bg-white rounded-lg shadow p-5">
+    <h2 class="text-sm font-semibold text-gray-500 uppercase mb-3">Corpus Faithfulness</h2>
+    {% if corpus_stats %}
+    <div class="grid grid-cols-2 md:grid-cols-4 gap-4 text-center">
+      <div>
+        <div class="text-2xl font-bold text-green-600">{{ corpus_stats.verified|default:"—" }}</div>
+        <div class="text-xs text-gray-500">Tier A (Verified)</div>
+      </div>
+      <div>
+        <div class="text-2xl font-bold text-yellow-600">{{ corpus_stats.ocr|default:"0" }}</div>
+        <div class="text-xs text-gray-500">Tier B (OCR)</div>
+      </div>
+      <div>
+        <div class="text-2xl font-bold text-red-600">{{ corpus_stats.quarantined|default:"0" }}</div>
+        <div class="text-xs text-gray-500">Tier C (Quarantine)</div>
+      </div>
+      <div>
+        <div class="text-2xl font-bold text-gray-400">{{ corpus_stats.legacy|default:"0" }}</div>
+        <div class="text-xs text-gray-500">Unverified Legacy</div>
+      </div>
+    </div>
+    {% if corpus_stats.grounding_rate %}
+    <div class="mt-4">
+      <div class="flex justify-between text-xs text-gray-500 mb-1">
+        <span>Grounding Rate (Metrics)</span>
+        <span>{{ corpus_stats.grounding_rate }}%</span>
+      </div>
+      <div class="w-full bg-gray-200 rounded-full h-2">
+        <div class="bg-green-500 h-2 rounded-full" style="width: {{ corpus_stats.grounding_rate }}%"></div>
+      </div>
+    </div>
+    {% endif %}
+    {% else %}
+    <p class="text-gray-500 text-sm">No verified runs yet. Run the gate on an extraction run to see results.</p>
+    {% endif %}
+  </div>
+</div>
+
+<!-- Run History -->
+<div class="bg-white rounded-lg shadow p-5">
+  <h2 class="text-sm font-semibold text-gray-500 uppercase mb-3">Verification History</h2>
+  {% if runs %}
+  <div class="overflow-x-auto">
+    <table class="w-full text-sm">
+      <thead><tr class="text-left text-gray-500 border-b">
+        <th class="pb-2">Run Tag</th>
+        <th class="pb-2">Verified</th>
+        <th class="pb-2 text-right">Metrics</th>
+        <th class="pb-2 text-right">Tier A</th>
+        <th class="pb-2 text-right">Tier B</th>
+        <th class="pb-2 text-right">Tier C</th>
+        <th class="pb-2 text-right">Rate</th>
+        <th class="pb-2 text-right">Stories</th>
+        <th class="pb-2 text-right">Duration</th>
+      </tr></thead>
+      <tbody>
+        {% for run in runs %}
+        <tr class="border-b hover:bg-gray-50">
+          <td class="py-2 font-mono text-xs">{{ run.run_tag }}</td>
+          <td class="py-2 text-xs text-gray-500">{{ run.verified_at|default:"—" }}</td>
+          <td class="py-2 text-right">{{ run.total_metrics }}</td>
+          <td class="py-2 text-right text-green-600 font-medium">{{ run.metrics_verified }}</td>
+          <td class="py-2 text-right text-yellow-600">{{ run.metrics_ocr }}</td>
+          <td class="py-2 text-right text-red-600">{{ run.metrics_quarantined }}</td>
+          <td class="py-2 text-right font-mono">
+            {% if run.metrics_grounding_rate is not None %}
+            <span class="{% if run.metrics_grounding_rate >= 0.95 %}text-green-600{% elif run.metrics_grounding_rate >= 0.80 %}text-yellow-600{% else %}text-red-600{% endif %}">
+              {{ run.metrics_grounding_rate_pct }}%
+            </span>
+            {% else %}—{% endif %}
+          </td>
+          <td class="py-2 text-right">{{ run.total_stories }} <span class="text-gray-400">({{ run.stories_verified }}✓)</span></td>
+          <td class="py-2 text-right text-gray-500">{{ run.elapsed_s|default:"—" }}</td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+  {% else %}
+  <p class="text-gray-500 text-sm">No verification runs yet.</p>
+  {% endif %}
+</div>
+
+<!-- Tier Legend -->
+<div class="mt-4 bg-gray-50 rounded-lg p-4 text-xs text-gray-600">
+  <span class="font-semibold">Tier Legend:</span>
+  <span class="ml-2 text-green-600">A — Verified</span> (snippet grounded in source, publishable) ·
+  <span class="text-yellow-600">B — OCR</span> (grounded but OCR source, publishable with label) ·
+  <span class="text-red-600">C — Quarantine</span> (not grounded, never published) ·
+  <span class="text-gray-400">Legacy</span> (not yet verified)
+</div>
+{% endblock %}

--- a/lavandula/dashboard/pipeline/urls.py
+++ b/lavandula/dashboard/pipeline/urls.py
@@ -85,6 +85,10 @@ urlpatterns = [
     path("faithfulness/verify/", views.FaithfulnessVerifyView.as_view(), name="faithfulness_verify"),
     path("faithfulness/status/", views.FaithfulnessStatusPartial.as_view(), name="faithfulness_status"),
 
+    # pdftotext Backfill & Re-verify (Spec 0060)
+    path("faithfulness/pdftotext-backfill/", views.PdftextBackfillView.as_view(), name="pdftotext_backfill"),
+    path("faithfulness/pdftotext-status/", views.PdftextBackfillStatusPartial.as_view(), name="pdftotext_backfill_status"),
+
     # Control Panel
     path("control/", views.ControlPanelView.as_view(), name="control_panel"),
     path("control/queue/pause/", views.QueuePauseView.as_view(), name="queue_pause"),

--- a/lavandula/dashboard/pipeline/urls.py
+++ b/lavandula/dashboard/pipeline/urls.py
@@ -80,6 +80,11 @@ urlpatterns = [
     path("llm-extract/status/", views.LlmExtractStatusPartial.as_view(), name="llm_extract_status"),
     path("llm-extract/stop/", views.LlmExtractStopView.as_view(), name="llm_extract_stop"),
 
+    # Faithfulness Verification Gate (Spec 0057)
+    path("faithfulness/", views.FaithfulnessView.as_view(), name="faithfulness"),
+    path("faithfulness/verify/", views.FaithfulnessVerifyView.as_view(), name="faithfulness_verify"),
+    path("faithfulness/status/", views.FaithfulnessStatusPartial.as_view(), name="faithfulness_status"),
+
     # Control Panel
     path("control/", views.ControlPanelView.as_view(), name="control_panel"),
     path("control/queue/pause/", views.QueuePauseView.as_view(), name="queue_pause"),

--- a/lavandula/dashboard/pipeline/views.py
+++ b/lavandula/dashboard/pipeline/views.py
@@ -3051,10 +3051,42 @@ class FaithfulnessView(LoginRequiredMixin, TemplateView):
 
         ctx["runs"] = all_runs
         ctx["unverified_runs"] = unverified_runs
+        ctx["verified_runs"] = all_runs
 
         with _VERIFY_LOCK:
             active = {k: v for k, v in _VERIFY_PROGRESS.items() if not v.get("done")}
         ctx["active_verification"] = list(active.values())[0] if active else None
+
+        # 0060: pdftotext backfill stats
+        try:
+            with connections["default"].cursor() as cur:
+                cur.execute("SELECT COUNT(*) FROM lava_parse.documents")
+                total_parsed = cur.fetchone()[0]
+                cur.execute("SELECT COUNT(*) FROM lava_parse.pdftotext")
+                total_pdftotext = cur.fetchone()[0]
+                cur.execute("""
+                    SELECT text_source, COUNT(*)
+                    FROM lava_parse.documents
+                    WHERE text_source IS NOT NULL
+                    GROUP BY text_source
+                """)
+                text_source_counts = dict(cur.fetchall())
+            ctx["pdftotext_stats"] = {
+                "total_parsed": total_parsed,
+                "total_extracted": total_pdftotext,
+                "text_native": text_source_counts.get("text_native", 0),
+                "scanned": text_source_counts.get("scanned", 0),
+                "failed": text_source_counts.get("pdftotext_failed", 0),
+                "pending": total_parsed - sum(text_source_counts.values()) if text_source_counts else total_parsed,
+                "pct": f"{total_pdftotext / total_parsed * 100:.1f}" if total_parsed > 0 else "0",
+            }
+        except Exception:
+            ctx["pdftotext_stats"] = None
+
+        # 0060: active pdftotext backfill
+        with _PDFTOTEXT_LOCK:
+            pt_active = {k: v for k, v in _PDFTOTEXT_PROGRESS.items() if not v.get("done")}
+        ctx["active_pdftotext"] = list(pt_active.values())[0] if pt_active else None
 
         # Corpus-wide stats
         with connections["default"].cursor() as cur:
@@ -3114,16 +3146,18 @@ class FaithfulnessVerifyView(LoginRequiredMixin, View):
                 "total_stories": 0, "stories_verified": 0, "elapsed_s": 0, "done": False,
             }
 
+        use_pdftotext = request.POST.get("source_provider") == "pdftotext"
+
         def _run_verification():
             from lavandula.common.db import make_app_engine
             from lavandula.faithfulness.gate_runner import verify_run
-            from lavandula.faithfulness.source_provider import DoclingSourceProvider
+            from lavandula.faithfulness.source_provider import DoclingSourceProvider, PdftextSourceProvider
             import logging
             log = logging.getLogger("faithfulness.dashboard")
 
             try:
                 engine = make_app_engine()
-                provider = DoclingSourceProvider(engine)
+                provider = PdftextSourceProvider(engine) if use_pdftotext else DoclingSourceProvider(engine)
 
                 def on_progress(stats):
                     with _VERIFY_LOCK:
@@ -3170,4 +3204,154 @@ class FaithfulnessStatusPartial(HtmxLoginRequiredMixin, View):
         with _VERIFY_LOCK:
             progress = _VERIFY_PROGRESS.get(progress_key, {})
 
+        return HttpResponse(_json.dumps(progress), content_type="application/json")
+
+
+# ---------------------------------------------------------------------------
+# pdftotext Backfill (Spec 0060)
+# ---------------------------------------------------------------------------
+
+_PDFTOTEXT_PROGRESS = {}
+_PDFTOTEXT_LOCK = threading.Lock()
+
+
+class PdftextBackfillView(LoginRequiredMixin, View):
+    def post(self, request):
+        with _PDFTOTEXT_LOCK:
+            active = {k: v for k, v in _PDFTOTEXT_PROGRESS.items() if not v.get("done")}
+            if active:
+                messages.error(request, "A pdftotext backfill is already running")
+                return redirect("faithfulness")
+
+        progress_key = "pdftotext_backfill"
+        with _PDFTOTEXT_LOCK:
+            _PDFTOTEXT_PROGRESS[progress_key] = {
+                "processed": 0, "extracted": 0, "scanned": 0,
+                "failed": 0, "total": 0, "elapsed_s": 0, "done": False,
+            }
+
+        def _run_backfill():
+            import logging
+            import time
+            from lavandula.common.db import make_app_engine
+            from lavandula.faithfulness.pdftotext_extract import extract_text, get_pdftotext_version
+            from lavandula.faithfulness.fidelity import score_fidelity, classify_text_source
+            from lavandula.reports.s3_archive import S3Archive
+            from sqlalchemy import text as sa_text
+
+            _log = logging.getLogger("pdftotext.dashboard")
+
+            try:
+                engine = make_app_engine()
+                archive = S3Archive("lavandula-nonprofit-collaterals", "pdfs")
+                version = get_pdftotext_version()
+
+                with engine.connect() as conn:
+                    rows = conn.execute(sa_text("""
+                        SELECT d.content_sha256
+                        FROM lava_parse.documents d
+                        LEFT JOIN lava_parse.pdftotext p ON d.content_sha256 = p.content_sha256
+                        WHERE p.content_sha256 IS NULL
+                        ORDER BY d.content_sha256
+                    """)).fetchall()
+
+                shas = [r[0] for r in rows]
+                with _PDFTOTEXT_LOCK:
+                    _PDFTOTEXT_PROGRESS[progress_key]["total"] = len(shas)
+
+                t0 = time.monotonic()
+                for i, sha in enumerate(shas):
+                    try:
+                        pdf_bytes = archive.get(sha)
+                        result = extract_text(pdf_bytes)
+
+                        docling_text = None
+                        with engine.connect() as conn:
+                            sec_rows = conn.execute(sa_text("""
+                                SELECT heading, body_text
+                                FROM lava_parse.sections
+                                WHERE content_sha256 = :sha
+                                ORDER BY section_index
+                            """), {"sha": sha}).fetchall()
+                        if sec_rows:
+                            parts = []
+                            for heading, body in sec_rows:
+                                if heading:
+                                    parts.append(heading)
+                                parts.append(body)
+                            docling_text = "\n\n".join(parts)
+
+                        fidelity = None
+                        if docling_text and not result.failed and not result.is_scanned:
+                            fidelity = score_fidelity(docling_text, result.text)
+
+                        text_source = classify_text_source(result, fidelity)
+
+                        with engine.begin() as conn:
+                            conn.execute(sa_text("""
+                                INSERT INTO lava_parse.pdftotext
+                                    (content_sha256, pdftotext_version, full_text, char_count)
+                                VALUES (:sha, :version, :text, :chars)
+                                ON CONFLICT (content_sha256) DO UPDATE SET
+                                    pdftotext_version = EXCLUDED.pdftotext_version,
+                                    full_text = EXCLUDED.full_text,
+                                    char_count = EXCLUDED.char_count,
+                                    extracted_at = now()
+                            """), {
+                                "sha": sha, "version": version,
+                                "text": result.text, "chars": result.char_count,
+                            })
+                            conn.execute(sa_text("""
+                                UPDATE lava_parse.documents
+                                SET pdftotext_coverage = :fwd,
+                                    pdftotext_reverse = :rev,
+                                    text_source = :src
+                                WHERE content_sha256 = :sha
+                            """), {
+                                "sha": sha,
+                                "fwd": fidelity.forward if fidelity else None,
+                                "rev": fidelity.reverse if fidelity else None,
+                                "src": text_source,
+                            })
+
+                        with _PDFTOTEXT_LOCK:
+                            p = _PDFTOTEXT_PROGRESS[progress_key]
+                            p["processed"] = i + 1
+                            if text_source == "text_native":
+                                p["extracted"] += 1
+                            elif text_source == "scanned":
+                                p["scanned"] += 1
+                            else:
+                                p["failed"] += 1
+                            p["elapsed_s"] = time.monotonic() - t0
+
+                    except Exception:
+                        _log.exception("pdftotext backfill error sha=%s", sha[:16])
+                        with _PDFTOTEXT_LOCK:
+                            _PDFTOTEXT_PROGRESS[progress_key]["failed"] += 1
+                            _PDFTOTEXT_PROGRESS[progress_key]["processed"] = i + 1
+
+                with _PDFTOTEXT_LOCK:
+                    _PDFTOTEXT_PROGRESS[progress_key]["done"] = True
+                    _PDFTOTEXT_PROGRESS[progress_key]["elapsed_s"] = time.monotonic() - t0
+                _log.info("pdftotext backfill complete: %s", _PDFTOTEXT_PROGRESS[progress_key])
+
+            except Exception:
+                _log.exception("pdftotext backfill failed")
+                with _PDFTOTEXT_LOCK:
+                    _PDFTOTEXT_PROGRESS[progress_key]["done"] = True
+
+        t = threading.Thread(target=_run_backfill, daemon=True)
+        t.start()
+
+        _log_audit(request, "pdftotext_backfill", "faithfulness", {})
+        messages.success(request, "pdftotext backfill started")
+        return redirect("faithfulness")
+
+
+class PdftextBackfillStatusPartial(HtmxLoginRequiredMixin, View):
+    def get(self, request):
+        import json as _json
+        with _PDFTOTEXT_LOCK:
+            progress = _PDFTOTEXT_PROGRESS.get("pdftotext_backfill", {})
         return HttpResponse(_json.dumps(progress), content_type="application/json")

--- a/lavandula/dashboard/pipeline/views.py
+++ b/lavandula/dashboard/pipeline/views.py
@@ -3156,7 +3156,7 @@ class FaithfulnessVerifyView(LoginRequiredMixin, View):
         t = threading.Thread(target=_run_verification, daemon=True)
         t.start()
 
-        _log_audit(request, "faithfulness_verify_start", "faithfulness", {"run_id": run_id, "run_tag": run_tag})
+        _log_audit(request, "faith_verify", "faithfulness", {"run_id": run_id, "run_tag": run_tag})
         messages.success(request, f"Verification started for run: {run_tag}")
         return redirect("faithfulness")
 

--- a/lavandula/dashboard/pipeline/views.py
+++ b/lavandula/dashboard/pipeline/views.py
@@ -2995,3 +2995,179 @@ class OrgExtractionQARedirectView(LoginRequiredMixin, View):
             raise Http404("No extracted documents for this org")
 
         return redirect(reverse("extraction_qa", kwargs={"sha": docs[0][0]}) + f"?run_id={run_id}")
+
+
+# ---------------------------------------------------------------------------
+# Faithfulness Verification Gate (Spec 0057) — dashboard integration
+# ---------------------------------------------------------------------------
+
+import threading
+
+_VERIFY_PROGRESS = {}
+_VERIFY_LOCK = threading.Lock()
+
+
+class FaithfulnessView(LoginRequiredMixin, TemplateView):
+    template_name = "pipeline/faithfulness.html"
+
+    def get_context_data(self, **kwargs):
+        import json as _json
+        ctx = super().get_context_data(**kwargs)
+        from django.db import connections
+
+        with connections["default"].cursor() as cur:
+            cur.execute("""
+                SELECT r.id, r.run_tag, r.started_at, r.stats_json,
+                    (SELECT COUNT(*) FROM lava_vocab.llm_metrics WHERE run_id = r.id) AS metric_count,
+                    (SELECT COUNT(*) FROM lava_vocab.llm_stories WHERE run_id = r.id) AS story_count
+                FROM lava_vocab.extraction_runs r
+                ORDER BY r.id DESC
+            """)
+            all_runs = []
+            unverified_runs = []
+            for row in cur.fetchall():
+                stats = row[3] if isinstance(row[3], dict) else _json.loads(row[3] or "{}")
+                faith = stats.get("faithfulness", {})
+                run = {
+                    "id": row[0], "run_tag": row[1], "started_at": row[2],
+                    "metric_count": row[4], "story_count": row[5],
+                    "total_metrics": faith.get("total_metrics", 0),
+                    "total_stories": faith.get("total_stories", 0),
+                    "metrics_verified": faith.get("metrics_verified", 0),
+                    "metrics_ocr": faith.get("metrics_ocr", 0),
+                    "metrics_pending": faith.get("metrics_pending", 0),
+                    "metrics_quarantined": faith.get("metrics_quarantined", 0),
+                    "stories_verified": faith.get("stories_verified", 0),
+                    "metrics_grounding_rate": faith.get("metrics_grounding_rate"),
+                    "metrics_grounding_rate_pct": f"{faith.get('metrics_grounding_rate', 0) * 100:.1f}" if faith.get("metrics_grounding_rate") is not None else None,
+                    "elapsed_s": f"{faith.get('elapsed_s', 0):.0f}s" if faith.get("elapsed_s") else None,
+                    "verified_at": row[2],
+                    "has_faithfulness": bool(faith),
+                }
+                if run["has_faithfulness"]:
+                    all_runs.append(run)
+                if not run["has_faithfulness"] and (row[4] > 0 or row[5] > 0):
+                    unverified_runs.append(run)
+
+        ctx["runs"] = all_runs
+        ctx["unverified_runs"] = unverified_runs
+
+        with _VERIFY_LOCK:
+            active = {k: v for k, v in _VERIFY_PROGRESS.items() if not v.get("done")}
+        ctx["active_verification"] = list(active.values())[0] if active else None
+
+        # Corpus-wide stats
+        with connections["default"].cursor() as cur:
+            cur.execute("""
+                SELECT verification_tier, COUNT(*)
+                FROM lava_vocab.llm_metrics
+                WHERE verification_tier IS NOT NULL
+                GROUP BY verification_tier
+            """)
+            tier_counts = dict(cur.fetchall())
+
+        total_verified = tier_counts.get("verified", 0)
+        total_all = sum(tier_counts.values()) if tier_counts else 0
+        ctx["corpus_stats"] = {
+            "verified": total_verified,
+            "ocr": tier_counts.get("unverified_ocr", 0),
+            "quarantined": tier_counts.get("quarantine", 0),
+            "legacy": tier_counts.get("unverified_legacy", 0),
+            "pending": tier_counts.get("unverified_pending", 0),
+            "grounding_rate": f"{total_verified / total_all * 100:.1f}" if total_all > 0 else None,
+        } if tier_counts else None
+
+        return ctx
+
+
+class FaithfulnessVerifyView(LoginRequiredMixin, View):
+    def post(self, request):
+        import json as _json
+        run_id = request.POST.get("run_id", "").strip()
+        if not run_id or not run_id.isdigit():
+            messages.error(request, "Invalid run ID")
+            return redirect("faithfulness")
+
+        run_id = int(run_id)
+
+        from django.db import connections
+        with connections["default"].cursor() as cur:
+            cur.execute("SELECT run_tag FROM lava_vocab.extraction_runs WHERE id = %s", [run_id])
+            row = cur.fetchone()
+        if not row:
+            messages.error(request, "Extraction run not found")
+            return redirect("faithfulness")
+
+        run_tag = row[0]
+
+        with _VERIFY_LOCK:
+            active = {k: v for k, v in _VERIFY_PROGRESS.items() if not v.get("done")}
+            if active:
+                messages.error(request, "A verification is already running")
+                return redirect("faithfulness")
+
+        progress_key = f"verify_{run_id}"
+        with _VERIFY_LOCK:
+            _VERIFY_PROGRESS[progress_key] = {
+                "run_id": run_id, "run_tag": run_tag,
+                "docs_processed": 0, "total_metrics": 0, "metrics_verified": 0,
+                "total_stories": 0, "stories_verified": 0, "elapsed_s": 0, "done": False,
+            }
+
+        def _run_verification():
+            from lavandula.common.db import make_app_engine
+            from lavandula.faithfulness.gate_runner import verify_run
+            from lavandula.faithfulness.source_provider import DoclingSourceProvider
+            import logging
+            log = logging.getLogger("faithfulness.dashboard")
+
+            try:
+                engine = make_app_engine()
+                provider = DoclingSourceProvider(engine)
+
+                def on_progress(stats):
+                    with _VERIFY_LOCK:
+                        _VERIFY_PROGRESS[progress_key].update({
+                            "docs_processed": stats.docs_processed,
+                            "total_metrics": stats.total_metrics,
+                            "metrics_verified": stats.metrics_verified,
+                            "total_stories": stats.total_stories,
+                            "stories_verified": stats.stories_verified,
+                            "elapsed_s": stats.elapsed_s,
+                        })
+
+                stats = verify_run(engine, provider, run_id, progress_callback=on_progress)
+                with _VERIFY_LOCK:
+                    _VERIFY_PROGRESS[progress_key].update({
+                        "done": True,
+                        "docs_processed": stats.docs_processed,
+                        "total_metrics": stats.total_metrics,
+                        "metrics_verified": stats.metrics_verified,
+                        "total_stories": stats.total_stories,
+                        "stories_verified": stats.stories_verified,
+                        "elapsed_s": stats.elapsed_s,
+                    })
+                log.info("Verification complete for run %s: %s", run_tag, stats.to_dict())
+            except Exception:
+                log.exception("Verification failed for run %s", run_tag)
+                with _VERIFY_LOCK:
+                    _VERIFY_PROGRESS[progress_key]["done"] = True
+
+        t = threading.Thread(target=_run_verification, daemon=True)
+        t.start()
+
+        _log_audit(request, "faithfulness_verify_start", "faithfulness", {"run_id": run_id, "run_tag": run_tag})
+        messages.success(request, f"Verification started for run: {run_tag}")
+        return redirect("faithfulness")
+
+
+class FaithfulnessStatusPartial(HtmxLoginRequiredMixin, View):
+    def get(self, request):
+        import json as _json
+        run_id = request.GET.get("run_id", "").strip()
+        progress_key = f"verify_{run_id}"
+
+        with _VERIFY_LOCK:
+            progress = _VERIFY_PROGRESS.get(progress_key, {})
+
+        return HttpResponse(_json.dumps(progress), content_type="application/json")

--- a/lavandula/faithfulness/fidelity.py
+++ b/lavandula/faithfulness/fidelity.py
@@ -1,0 +1,74 @@
+"""Fidelity scoring module (Spec 0060 Phase 2).
+
+Pure module — computes bidirectional word-set coverage between Docling text
+and pdftotext text. No DB dependency.
+
+Word-set tokenization: lowercase → Unicode NFC → collapse whitespace → split
+on whitespace → discard tokens ≤ 1 char. Coverage = |A ∩ B| / |A|.
+"""
+from __future__ import annotations
+
+import re
+import unicodedata
+from dataclasses import dataclass
+
+from lavandula.faithfulness.pdftotext_extract import ExtractResult
+
+_WS_RE = re.compile(r"\s+")
+
+COVERAGE_FLOOR = 0.50
+
+
+@dataclass(frozen=True)
+class FidelityScore:
+    forward: float   # Docling → pdftotext (catches Docling invention)
+    reverse: float   # pdftotext → Docling (catches Docling omission)
+
+
+def word_set(text: str) -> set[str]:
+    """Normalize and tokenize text into a word set for coverage comparison."""
+    if not text:
+        return set()
+    text = text.lower()
+    text = unicodedata.normalize("NFC", text)
+    text = _WS_RE.sub(" ", text).strip()
+    return {tok for tok in text.split(" ") if len(tok) > 1}
+
+
+def coverage(source: set[str], target: set[str]) -> float:
+    """Fraction of source words present in target. 0.0 if source is empty."""
+    if not source:
+        return 0.0
+    return len(source & target) / len(source)
+
+
+def score_fidelity(docling_text: str, pdftotext_text: str) -> FidelityScore:
+    """Compute bidirectional word-set coverage between Docling and pdftotext."""
+    docling_ws = word_set(docling_text)
+    pdftotext_ws = word_set(pdftotext_text)
+    return FidelityScore(
+        forward=coverage(docling_ws, pdftotext_ws),
+        reverse=coverage(pdftotext_ws, docling_ws),
+    )
+
+
+def classify_text_source(
+    extract_result: ExtractResult,
+    fidelity_score: FidelityScore | None,
+) -> str:
+    """Classify a document's text source type.
+
+    Returns 'text_native', 'scanned', or 'pdftotext_failed'.
+    """
+    if extract_result.failed:
+        return "pdftotext_failed"
+
+    if extract_result.is_scanned:
+        return "scanned"
+
+    if fidelity_score is not None:
+        if (fidelity_score.forward < COVERAGE_FLOOR
+                and fidelity_score.reverse < COVERAGE_FLOOR):
+            return "pdftotext_failed"
+
+    return "text_native"

--- a/lavandula/faithfulness/gate_runner.py
+++ b/lavandula/faithfulness/gate_runner.py
@@ -88,6 +88,7 @@ def _assign_tier(
     """Assign verification tier based on verdict and source provenance.
 
     Fail-safe: absence of source or certification never yields 'verified'.
+    When the provider sets tier_hint, that overrides the default mapping.
     """
     if source is None:
         return TIER_QUARANTINE
@@ -95,8 +96,8 @@ def _assign_tier(
     if not verdict.grounded:
         return TIER_QUARANTINE
 
-    if source.source == "pdftotext-repaired":
-        return TIER_UNVERIFIED_OCR
+    if source.tier_hint is not None:
+        return source.tier_hint
 
     return TIER_VERIFIED
 

--- a/lavandula/faithfulness/pdftotext_extract.py
+++ b/lavandula/faithfulness/pdftotext_extract.py
@@ -1,0 +1,136 @@
+"""pdftotext extraction module (Spec 0060 Phase 1).
+
+Pure module — runs /usr/bin/pdftotext as a subprocess, captures output with
+bounded memory, strips NUL bytes, classifies scanned vs text-native.
+No DB dependency.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import subprocess
+from dataclasses import dataclass
+
+log = logging.getLogger(__name__)
+
+PDFTOTEXT_BIN = "/usr/bin/pdftotext"
+MAX_OUTPUT_BYTES = 10 * 1024 * 1024  # 10 MB
+TIMEOUT_SECONDS = 30
+SCANNED_CHAR_THRESHOLD = 50
+
+_cached_version: str | None = None
+
+
+@dataclass(frozen=True)
+class ExtractResult:
+    text: str
+    version: str
+    char_count: int
+    is_scanned: bool
+    failed: bool = False
+    error: str | None = None
+
+
+def get_pdftotext_version() -> str:
+    global _cached_version
+    if _cached_version is not None:
+        return _cached_version
+
+    if not os.path.isfile(PDFTOTEXT_BIN):
+        raise FileNotFoundError(
+            f"{PDFTOTEXT_BIN} not found — install poppler-utils"
+        )
+
+    result = subprocess.run(
+        [PDFTOTEXT_BIN, "-v"],
+        capture_output=True, text=True, timeout=10,
+    )
+    version_text = (result.stderr or result.stdout).strip()
+    for line in version_text.splitlines():
+        if "version" in line.lower():
+            _cached_version = line.strip()
+            return _cached_version
+
+    _cached_version = version_text.splitlines()[0] if version_text else "unknown"
+    return _cached_version
+
+
+def extract_text(pdf_input: bytes) -> ExtractResult:
+    """Extract text from PDF bytes via pdftotext.
+
+    Uses Popen with bounded stdout read to enforce the 10MB output cap.
+    Input is fed via stdin (no temp file needed).
+    """
+    version = get_pdftotext_version()
+
+    try:
+        proc = subprocess.Popen(
+            [PDFTOTEXT_BIN, "-layout", "-", "-"],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            env={**os.environ, "TMPDIR": _ensure_tmpdir()},
+        )
+    except OSError as exc:
+        return ExtractResult(
+            text="", version=version, char_count=0,
+            is_scanned=False, failed=True, error=str(exc),
+        )
+
+    try:
+        proc.stdin.write(pdf_input)
+        proc.stdin.close()
+
+        raw_output = proc.stdout.read(MAX_OUTPUT_BYTES + 1)
+
+        if len(raw_output) > MAX_OUTPUT_BYTES:
+            proc.kill()
+            proc.wait()
+            log.warning("pdftotext output exceeded %d bytes, killed", MAX_OUTPUT_BYTES)
+            return ExtractResult(
+                text="", version=version, char_count=0,
+                is_scanned=False, failed=True,
+                error="output_exceeded_10mb",
+            )
+
+        proc.stdout.close()
+        proc.wait(timeout=TIMEOUT_SECONDS)
+
+        stderr_out = proc.stderr.read(4096)
+        proc.stderr.close()
+        if stderr_out:
+            log.debug("pdftotext stderr: %s", stderr_out[:500])
+
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        proc.wait()
+        return ExtractResult(
+            text="", version=version, char_count=0,
+            is_scanned=False, failed=True, error="timeout",
+        )
+    except OSError as exc:
+        proc.kill()
+        proc.wait()
+        return ExtractResult(
+            text="", version=version, char_count=0,
+            is_scanned=False, failed=True, error=str(exc),
+        )
+
+    text = raw_output.decode("utf-8", errors="replace")
+    text = text.replace("\x00", "")
+    text_stripped = text.strip()
+
+    is_scanned = len(text_stripped) < SCANNED_CHAR_THRESHOLD
+
+    return ExtractResult(
+        text=text,
+        version=version,
+        char_count=len(text_stripped),
+        is_scanned=is_scanned,
+    )
+
+
+def _ensure_tmpdir() -> str:
+    d = "/tmp/pdftotext-0060"
+    os.makedirs(d, exist_ok=True)
+    return d

--- a/lavandula/faithfulness/source_provider.py
+++ b/lavandula/faithfulness/source_provider.py
@@ -25,6 +25,7 @@ class SourceText:
     section_text: str
     tables: list[list[TableRow]]
     source: str  # "docling" | "pdftotext-repaired"
+    tier_hint: str | None = None  # provider-set tier override for gate_runner
 
 
 class SourceTextProvider(Protocol):
@@ -98,3 +99,97 @@ def _parse_table(data_json, markdown: str | None) -> list[TableRow]:
         return rows
 
     return []
+
+
+# ============================================================
+# 0060: PdftextSourceProvider — pdftotext-repaired text + certification
+# ============================================================
+
+CERTIFICATION_COVERAGE_FLOOR = 0.50
+
+
+class PdftextSourceProvider:
+    """V2 provider: returns certified pdftotext text when available,
+    falls back to Docling text otherwise. Tables always from Docling."""
+
+    def __init__(self, engine: Engine) -> None:
+        self._engine = engine
+        self._docling = DoclingSourceProvider(engine)
+
+    def get(self, content_sha256: str) -> SourceText | None:
+        doc_row, pdftotext_row, tables = self._load(content_sha256)
+
+        if pdftotext_row is None:
+            return self._fallback_docling(content_sha256, "unverified_pending")
+
+        text_source = doc_row["text_source"] if doc_row else None
+        fwd = doc_row["pdftotext_coverage"] if doc_row else None
+        rev = doc_row["pdftotext_reverse"] if doc_row else None
+
+        if text_source == "scanned":
+            return self._fallback_docling(content_sha256, "unverified_ocr")
+
+        if text_source == "pdftotext_failed":
+            return self._fallback_docling(content_sha256, "unverified_pending")
+
+        if not self._is_certified(text_source, fwd, rev):
+            return self._fallback_docling(content_sha256, "unverified_pending")
+
+        return SourceText(
+            section_text=pdftotext_row["full_text"],
+            tables=tables,
+            source="pdftotext-repaired",
+        )
+
+    def _load(self, sha: str):
+        with self._engine.connect() as conn:
+            doc_row = conn.execute(text("""
+                SELECT text_source, pdftotext_coverage, pdftotext_reverse
+                FROM lava_parse.documents
+                WHERE content_sha256 = :sha
+            """), {"sha": sha}).mappings().fetchone()
+
+            pdftotext_row = conn.execute(text("""
+                SELECT full_text, char_count
+                FROM lava_parse.pdftotext
+                WHERE content_sha256 = :sha
+            """), {"sha": sha}).mappings().fetchone()
+
+            table_rows = conn.execute(text("""
+                SELECT data_json, markdown
+                FROM lava_parse.tables
+                WHERE content_sha256 = :sha
+                ORDER BY table_index
+            """), {"sha": sha}).fetchall()
+
+        tables: list[list[TableRow]] = []
+        for data_json, markdown in table_rows:
+            rows = _parse_table(data_json, markdown)
+            if rows:
+                tables.append(rows)
+
+        return doc_row, pdftotext_row, tables
+
+    def _fallback_docling(self, sha: str, tier_hint: str) -> SourceText | None:
+        source = self._docling.get(sha)
+        if source is None:
+            return None
+        return SourceText(
+            section_text=source.section_text,
+            tables=source.tables,
+            source=source.source,
+            tier_hint=tier_hint,
+        )
+
+    @staticmethod
+    def _is_certified(
+        text_source: str | None,
+        forward_coverage: float | None,
+        reverse_coverage: float | None,
+    ) -> bool:
+        if text_source != "text_native":
+            return False
+        if forward_coverage is None or reverse_coverage is None:
+            return False
+        return (float(forward_coverage) >= CERTIFICATION_COVERAGE_FLOOR
+                and float(reverse_coverage) >= CERTIFICATION_COVERAGE_FLOOR)

--- a/lavandula/faithfulness/tests/test_fidelity.py
+++ b/lavandula/faithfulness/tests/test_fidelity.py
@@ -1,0 +1,167 @@
+"""Tests for fidelity scoring module (Spec 0060 Phase 2)."""
+from __future__ import annotations
+
+import pytest
+
+from lavandula.faithfulness.fidelity import (
+    COVERAGE_FLOOR,
+    FidelityScore,
+    classify_text_source,
+    coverage,
+    score_fidelity,
+    word_set,
+)
+from lavandula.faithfulness.pdftotext_extract import ExtractResult
+
+
+# ============================================================
+# word_set
+# ============================================================
+
+class TestWordSet:
+    def test_basic_tokenization(self):
+        ws = word_set("Hello World from Python")
+        assert ws == {"hello", "world", "from", "python"}
+
+    def test_single_char_tokens_discarded(self):
+        ws = word_set("I am a data scientist")
+        assert "i" not in ws
+        assert "a" not in ws
+        assert "am" in ws
+        assert "data" in ws
+        assert "scientist" in ws
+
+    def test_unicode_nfc(self):
+        ws1 = word_set("café")
+        ws2 = word_set("café")
+        assert ws1 == ws2
+
+    def test_empty_input(self):
+        assert word_set("") == set()
+        assert word_set("   ") == set()
+
+    def test_punctuation_kept_with_words(self):
+        ws = word_set("$5,000 served 100%")
+        assert "$5,000" in ws
+        assert "served" in ws
+        assert "100%" in ws
+
+    def test_whitespace_collapse(self):
+        ws = word_set("hello    world\n\ttab")
+        assert ws == {"hello", "world", "tab"}
+
+
+# ============================================================
+# coverage
+# ============================================================
+
+class TestCoverage:
+    def test_identical_sets(self):
+        s = {"hello", "world"}
+        assert coverage(s, s) == 1.0
+
+    def test_disjoint_sets(self):
+        assert coverage({"hello", "world"}, {"foo", "bar"}) == 0.0
+
+    def test_partial_overlap(self):
+        assert coverage({"hello", "world"}, {"hello", "bar"}) == 0.5
+
+    def test_empty_source(self):
+        assert coverage(set(), {"hello"}) == 0.0
+
+    def test_empty_target(self):
+        assert coverage({"hello"}, set()) == 0.0
+
+    def test_superset_target(self):
+        assert coverage({"hello"}, {"hello", "world"}) == 1.0
+
+
+# ============================================================
+# score_fidelity
+# ============================================================
+
+class TestScoreFidelity:
+    def test_identical_texts(self):
+        text = "We served 1,514 cancer patients and caregivers last year."
+        score = score_fidelity(text, text)
+        assert score.forward == 1.0
+        assert score.reverse == 1.0
+
+    def test_docling_drops_content(self):
+        docling = "We served patients last year."
+        pdftotext = "We served 1,514 cancer patients and caregivers last year."
+        score = score_fidelity(docling, pdftotext)
+        assert score.forward == 1.0  # all docling words in pdftotext
+        assert score.reverse < 1.0   # pdftotext has words docling dropped
+
+    def test_docling_invents_content(self):
+        docling = "We served 1,514 cancer patients and caregivers last year. Extra invented words here."
+        pdftotext = "We served 1,514 cancer patients and caregivers last year."
+        score = score_fidelity(docling, pdftotext)
+        assert score.forward < 1.0   # docling has words not in pdftotext
+        assert score.reverse == 1.0  # all pdftotext words in docling
+
+    def test_empty_texts(self):
+        score = score_fidelity("", "")
+        assert score.forward == 0.0
+        assert score.reverse == 0.0
+
+    def test_known_fixture(self):
+        docling = "Annual Report 2023 Total revenue $5,000,000 Programs served 1,200 families"
+        pdftotext = "Annual Report 2023 Total revenue $5,000,000 Programs served 1,200 families in the community"
+        score = score_fidelity(docling, pdftotext)
+        docling_ws = word_set(docling)
+        pdftotext_ws = word_set(pdftotext)
+        expected_fwd = len(docling_ws & pdftotext_ws) / len(docling_ws)
+        expected_rev = len(pdftotext_ws & docling_ws) / len(pdftotext_ws)
+        assert abs(score.forward - expected_fwd) < 0.001
+        assert abs(score.reverse - expected_rev) < 0.001
+
+
+# ============================================================
+# classify_text_source
+# ============================================================
+
+class TestClassifyTextSource:
+    def _make_extract(self, *, failed=False, is_scanned=False, char_count=1000):
+        return ExtractResult(
+            text="x" * char_count, version="test", char_count=char_count,
+            is_scanned=is_scanned, failed=failed,
+        )
+
+    def test_failed_extraction(self):
+        result = self._make_extract(failed=True)
+        assert classify_text_source(result, None) == "pdftotext_failed"
+
+    def test_scanned_document(self):
+        result = self._make_extract(is_scanned=True, char_count=10)
+        assert classify_text_source(result, None) == "scanned"
+
+    def test_text_native_no_fidelity(self):
+        result = self._make_extract()
+        assert classify_text_source(result, None) == "text_native"
+
+    def test_text_native_good_fidelity(self):
+        result = self._make_extract()
+        fidelity = FidelityScore(forward=0.95, reverse=0.98)
+        assert classify_text_source(result, fidelity) == "text_native"
+
+    def test_low_fidelity_both_directions(self):
+        result = self._make_extract()
+        fidelity = FidelityScore(forward=0.30, reverse=0.40)
+        assert classify_text_source(result, fidelity) == "pdftotext_failed"
+
+    def test_low_forward_high_reverse(self):
+        result = self._make_extract()
+        fidelity = FidelityScore(forward=0.30, reverse=0.90)
+        assert classify_text_source(result, fidelity) == "text_native"
+
+    def test_boundary_coverage(self):
+        result = self._make_extract()
+        fidelity = FidelityScore(forward=COVERAGE_FLOOR, reverse=COVERAGE_FLOOR)
+        assert classify_text_source(result, fidelity) == "text_native"
+
+    def test_just_below_boundary(self):
+        result = self._make_extract()
+        fidelity = FidelityScore(forward=COVERAGE_FLOOR - 0.01, reverse=COVERAGE_FLOOR - 0.01)
+        assert classify_text_source(result, fidelity) == "pdftotext_failed"

--- a/lavandula/faithfulness/tests/test_gate_runner.py
+++ b/lavandula/faithfulness/tests/test_gate_runner.py
@@ -29,9 +29,16 @@ class TestAssignTier:
         source = SourceText(section_text="x", tables=[], source="docling")
         assert _assign_tier(verdict, source) == TIER_VERIFIED
 
-    def test_grounded_pdftotext_is_ocr(self):
+    def test_grounded_pdftotext_certified_is_verified(self):
+        """0060: certified pdftotext source (no tier_hint) → Tier A."""
         verdict = Verdict(grounded=True, rule="R1", offsets=[(0, 10)])
         source = SourceText(section_text="x", tables=[], source="pdftotext-repaired")
+        assert _assign_tier(verdict, source) == TIER_VERIFIED
+
+    def test_grounded_pdftotext_scanned_is_ocr(self):
+        """0060: scanned fallback (tier_hint=unverified_ocr) → Tier B."""
+        verdict = Verdict(grounded=True, rule="R1", offsets=[(0, 10)])
+        source = SourceText(section_text="x", tables=[], source="docling", tier_hint=TIER_UNVERIFIED_OCR)
         assert _assign_tier(verdict, source) == TIER_UNVERIFIED_OCR
 
     def test_ungrounded_is_quarantine(self):
@@ -94,13 +101,19 @@ class TestStoryTierAssignment:
 # ============================================================
 
 class TestTrustBoundary:
-    def test_uncertified_source_never_verified(self):
-        """Un-certified source → never 'verified', even if grounded."""
+    def test_tier_hint_unverified_pending(self):
+        """0060: provider-set unverified_pending → never 'verified'."""
         verdict = Verdict(grounded=True, rule="R1", offsets=[(0, 10)])
-        source = SourceText(section_text="x", tables=[], source="pdftotext-repaired")
+        source = SourceText(section_text="x", tables=[], source="docling", tier_hint=TIER_UNVERIFIED_PENDING)
         tier = _assign_tier(verdict, source)
         assert tier != TIER_VERIFIED
-        assert tier == TIER_UNVERIFIED_OCR
+        assert tier == TIER_UNVERIFIED_PENDING
+
+    def test_tier_hint_quarantine(self):
+        """0060: provider-set quarantine is respected."""
+        verdict = Verdict(grounded=True, rule="R1", offsets=[(0, 10)])
+        source = SourceText(section_text="x", tables=[], source="docling", tier_hint=TIER_QUARANTINE)
+        assert _assign_tier(verdict, source) == TIER_QUARANTINE
 
 
 # ============================================================
@@ -152,9 +165,18 @@ class TestMixedFixture:
         tier = _assign_tier(verdict, source)
         assert tier == TIER_QUARANTINE
 
-    def test_ocr_grounded_metric(self):
+    def test_pdftotext_certified_metric(self):
+        """0060: certified pdftotext grounded metric → Tier A."""
         source_text = "Total revenue was $5,000,000 for the fiscal year."
         source = SourceText(section_text=source_text, tables=[], source="pdftotext-repaired")
+        verdict = check("Total revenue was $5,000,000", source_text, [])
+        tier = _assign_tier(verdict, source)
+        assert tier == TIER_VERIFIED
+
+    def test_scanned_fallback_metric(self):
+        """0060: scanned doc falls back to Docling → Tier B."""
+        source_text = "Total revenue was $5,000,000 for the fiscal year."
+        source = SourceText(section_text=source_text, tables=[], source="docling", tier_hint=TIER_UNVERIFIED_OCR)
         verdict = check("Total revenue was $5,000,000", source_text, [])
         tier = _assign_tier(verdict, source)
         assert tier == TIER_UNVERIFIED_OCR

--- a/lavandula/faithfulness/tests/test_pdftotext_extract.py
+++ b/lavandula/faithfulness/tests/test_pdftotext_extract.py
@@ -1,0 +1,146 @@
+"""Tests for pdftotext extraction module (Spec 0060 Phase 1)."""
+from __future__ import annotations
+
+import subprocess
+import unittest.mock as mock
+
+import pytest
+
+from lavandula.faithfulness.pdftotext_extract import (
+    ExtractResult,
+    MAX_OUTPUT_BYTES,
+    PDFTOTEXT_BIN,
+    SCANNED_CHAR_THRESHOLD,
+    extract_text,
+    get_pdftotext_version,
+)
+
+
+# ============================================================
+# Version detection
+# ============================================================
+
+class TestGetVersion:
+    def test_parses_version_string(self):
+        version = get_pdftotext_version()
+        assert "pdftotext" in version.lower() or "version" in version.lower() or version != ""
+
+    def test_version_is_cached(self):
+        v1 = get_pdftotext_version()
+        v2 = get_pdftotext_version()
+        assert v1 == v2
+
+    def test_missing_binary_raises(self):
+        import lavandula.faithfulness.pdftotext_extract as mod
+        old_bin = mod.PDFTOTEXT_BIN
+        old_cached = mod._cached_version
+        try:
+            mod.PDFTOTEXT_BIN = "/nonexistent/pdftotext"
+            mod._cached_version = None
+            with pytest.raises(FileNotFoundError, match="poppler-utils"):
+                get_pdftotext_version()
+        finally:
+            mod.PDFTOTEXT_BIN = old_bin
+            mod._cached_version = old_cached
+
+
+# ============================================================
+# Text extraction
+# ============================================================
+
+class TestExtractText:
+    def _make_minimal_pdf(self, text_content: str = "Hello World") -> bytes:
+        """Create a minimal valid PDF with embedded text."""
+        content = (
+            f"1 0 obj<</Type/Catalog/Pages 2 0 R>>endobj "
+            f"2 0 obj<</Type/Pages/Kids[3 0 R]/Count 1>>endobj "
+            f"3 0 obj<</Type/Page/Parent 2 0 R/MediaBox[0 0 612 792]"
+            f"/Contents 4 0 R/Resources<</Font<</F1 5 0 R>>>>>>endobj "
+            f"4 0 obj<</Length {len(text_content) + 30}>>stream\n"
+            f"BT /F1 12 Tf 100 700 Td ({text_content}) Tj ET\n"
+            f"endstream endobj "
+            f"5 0 obj<</Type/Font/Subtype/Type1/BaseFont/Helvetica>>endobj "
+        )
+        xref_offset = len(b"%PDF-1.4\n") + len(content.encode())
+        pdf = (
+            f"%PDF-1.4\n{content}"
+            f"xref\n0 6\n"
+            f"0000000000 65535 f \n"
+            f"0000000009 00000 n \n"
+            f"0000000058 00000 n \n"
+            f"0000000115 00000 n \n"
+            f"0000000266 00000 n \n"
+            f"0000000{len(content) + 9:03d} 00000 n \n"
+            f"trailer<</Size 6/Root 1 0 R>>\n"
+            f"startxref\n{xref_offset}\n%%EOF"
+        )
+        return pdf.encode("latin-1")
+
+    def test_text_native_pdf(self):
+        pdf = self._make_minimal_pdf("This is a test document with enough text to pass threshold")
+        result = extract_text(pdf)
+        assert not result.failed
+        assert not result.is_scanned
+        assert result.char_count > 0
+        assert result.version != ""
+
+    def test_empty_pdf_is_scanned(self):
+        pdf = self._make_minimal_pdf("")
+        result = extract_text(pdf)
+        assert not result.failed
+        assert result.is_scanned
+        assert result.char_count < SCANNED_CHAR_THRESHOLD
+
+    def test_nul_bytes_stripped(self):
+        pdf = self._make_minimal_pdf("Hello\x00World test content with enough chars to pass threshold")
+        result = extract_text(pdf)
+        assert "\x00" not in result.text
+
+    def test_timeout_handling(self):
+        with mock.patch("lavandula.faithfulness.pdftotext_extract.subprocess.Popen") as mock_popen:
+            proc_mock = mock.MagicMock()
+            proc_mock.stdin = mock.MagicMock()
+            proc_mock.stdout.read.return_value = b"some output"
+            proc_mock.stdout.close = mock.MagicMock()
+            proc_mock.stderr.read.return_value = b""
+            proc_mock.stderr.close = mock.MagicMock()
+            proc_mock.wait.side_effect = [
+                subprocess.TimeoutExpired(cmd="pdftotext", timeout=30),
+                None,  # second call in except handler returns normally
+            ]
+            mock_popen.return_value = proc_mock
+
+            result = extract_text(b"%PDF-1.4 test")
+            assert result.failed
+            assert result.error == "timeout"
+            proc_mock.kill.assert_called_once()
+
+    def test_oversized_output_killed(self):
+        with mock.patch("lavandula.faithfulness.pdftotext_extract.subprocess.Popen") as mock_popen:
+            proc_mock = mock.MagicMock()
+            proc_mock.stdin = mock.MagicMock()
+            proc_mock.stdout.read.return_value = b"x" * (MAX_OUTPUT_BYTES + 1)
+            proc_mock.stderr.read.return_value = b""
+            mock_popen.return_value = proc_mock
+
+            result = extract_text(b"%PDF-1.4 test")
+            assert result.failed
+            assert result.error == "output_exceeded_10mb"
+            proc_mock.kill.assert_called_once()
+
+    def test_failed_result_fields(self):
+        result = ExtractResult(
+            text="", version="test", char_count=0,
+            is_scanned=False, failed=True, error="test_error",
+        )
+        assert result.failed
+        assert result.error == "test_error"
+
+    def test_scanned_threshold(self):
+        short_text = "x" * (SCANNED_CHAR_THRESHOLD - 1)
+        r1 = ExtractResult(text=short_text, version="v", char_count=len(short_text), is_scanned=True)
+        assert r1.is_scanned
+
+        long_text = "x" * SCANNED_CHAR_THRESHOLD
+        r2 = ExtractResult(text=long_text, version="v", char_count=len(long_text), is_scanned=False)
+        assert not r2.is_scanned

--- a/lavandula/faithfulness/tests/test_pdftotext_provider.py
+++ b/lavandula/faithfulness/tests/test_pdftotext_provider.py
@@ -1,0 +1,184 @@
+"""Tests for PdftextSourceProvider (Spec 0060 Phase 4).
+
+Tests the provider's decision table from spec §4.3 — all 7 rows plus
+borderline cases.
+"""
+from __future__ import annotations
+
+import pytest
+
+from lavandula.faithfulness.gate_runner import (
+    TIER_QUARANTINE,
+    TIER_UNVERIFIED_OCR,
+    TIER_UNVERIFIED_PENDING,
+    TIER_VERIFIED,
+    _assign_tier,
+)
+from lavandula.faithfulness.grounding import Verdict
+from lavandula.faithfulness.source_provider import (
+    CERTIFICATION_COVERAGE_FLOOR,
+    PdftextSourceProvider,
+    SourceText,
+)
+
+
+# ============================================================
+# Certification logic (pure, no DB)
+# ============================================================
+
+class TestCertification:
+    def test_certified_text_native_above_floor(self):
+        assert PdftextSourceProvider._is_certified("text_native", 0.80, 0.90)
+
+    def test_certified_at_exact_floor(self):
+        assert PdftextSourceProvider._is_certified(
+            "text_native", CERTIFICATION_COVERAGE_FLOOR, CERTIFICATION_COVERAGE_FLOOR
+        )
+
+    def test_not_certified_below_floor(self):
+        assert not PdftextSourceProvider._is_certified("text_native", 0.49, 0.99)
+
+    def test_not_certified_scanned(self):
+        assert not PdftextSourceProvider._is_certified("scanned", 0.99, 0.99)
+
+    def test_not_certified_failed(self):
+        assert not PdftextSourceProvider._is_certified("pdftotext_failed", 0.99, 0.99)
+
+    def test_not_certified_null_source(self):
+        assert not PdftextSourceProvider._is_certified(None, 0.99, 0.99)
+
+    def test_not_certified_null_coverage(self):
+        assert not PdftextSourceProvider._is_certified("text_native", None, 0.99)
+        assert not PdftextSourceProvider._is_certified("text_native", 0.99, None)
+
+    def test_decimal_coverage_from_db(self):
+        from decimal import Decimal
+        assert PdftextSourceProvider._is_certified(
+            "text_native", Decimal("0.95"), Decimal("0.98")
+        )
+
+    def test_decimal_below_floor(self):
+        from decimal import Decimal
+        assert not PdftextSourceProvider._is_certified(
+            "text_native", Decimal("0.49"), Decimal("0.49")
+        )
+
+
+# ============================================================
+# Decision table (spec §4.3) — tier assignment end-to-end
+# ============================================================
+
+class TestDecisionTable:
+    """Each test corresponds to one row in the spec's decision table."""
+
+    def test_row1_certified_pdftotext(self):
+        """pdftotext exists + text_native + coverage ≥ 0.50 → pdftotext-repaired, Tier A."""
+        source = SourceText(
+            section_text="pdftotext full text here",
+            tables=[],
+            source="pdftotext-repaired",
+        )
+        verdict = Verdict(grounded=True, rule="R1", offsets=[(0, 10)])
+        assert _assign_tier(verdict, source) == TIER_VERIFIED
+
+    def test_row2_uncertified_low_coverage(self):
+        """pdftotext exists + text_native + coverage < 0.50 → Docling, unverified_pending."""
+        source = SourceText(
+            section_text="docling fallback text",
+            tables=[],
+            source="docling",
+            tier_hint=TIER_UNVERIFIED_PENDING,
+        )
+        verdict = Verdict(grounded=True, rule="R1", offsets=[(0, 10)])
+        assert _assign_tier(verdict, source) == TIER_UNVERIFIED_PENDING
+
+    def test_row3_scanned(self):
+        """pdftotext exists + scanned → Docling, Tier B (OCR label)."""
+        source = SourceText(
+            section_text="docling text from scanned doc",
+            tables=[],
+            source="docling",
+            tier_hint=TIER_UNVERIFIED_OCR,
+        )
+        verdict = Verdict(grounded=True, rule="R1", offsets=[(0, 10)])
+        assert _assign_tier(verdict, source) == TIER_UNVERIFIED_OCR
+
+    def test_row4_scanned_no_docling(self):
+        """pdftotext exists + scanned + missing Docling → None → quarantine."""
+        verdict = Verdict(grounded=True, rule="R1", offsets=[(0, 10)])
+        assert _assign_tier(verdict, None) == TIER_QUARANTINE
+
+    def test_row5_pdftotext_failed(self):
+        """pdftotext exists + pdftotext_failed → Docling, unverified_pending."""
+        source = SourceText(
+            section_text="docling fallback",
+            tables=[],
+            source="docling",
+            tier_hint=TIER_UNVERIFIED_PENDING,
+        )
+        verdict = Verdict(grounded=True, rule="R1", offsets=[(0, 10)])
+        assert _assign_tier(verdict, source) == TIER_UNVERIFIED_PENDING
+
+    def test_row6_no_pdftotext_row(self):
+        """No pdftotext row + Docling exists → Docling, unverified_pending."""
+        source = SourceText(
+            section_text="docling text",
+            tables=[],
+            source="docling",
+            tier_hint=TIER_UNVERIFIED_PENDING,
+        )
+        verdict = Verdict(grounded=True, rule="R1", offsets=[(0, 10)])
+        assert _assign_tier(verdict, source) == TIER_UNVERIFIED_PENDING
+
+    def test_row7_no_pdftotext_no_docling(self):
+        """No pdftotext row + no Docling → None → quarantine."""
+        verdict = Verdict(grounded=True, rule="R1", offsets=[(0, 10)])
+        assert _assign_tier(verdict, None) == TIER_QUARANTINE
+
+
+# ============================================================
+# Tier hint mechanics
+# ============================================================
+
+class TestTierHint:
+    def test_no_tier_hint_defaults_to_verified(self):
+        source = SourceText(section_text="x", tables=[], source="docling")
+        verdict = Verdict(grounded=True, rule="R1", offsets=[(0, 5)])
+        assert _assign_tier(verdict, source) == TIER_VERIFIED
+
+    def test_tier_hint_overrides_default(self):
+        source = SourceText(
+            section_text="x", tables=[], source="docling",
+            tier_hint=TIER_UNVERIFIED_OCR,
+        )
+        verdict = Verdict(grounded=True, rule="R1", offsets=[(0, 5)])
+        assert _assign_tier(verdict, source) == TIER_UNVERIFIED_OCR
+
+    def test_ungrounded_overrides_tier_hint(self):
+        source = SourceText(
+            section_text="x", tables=[], source="docling",
+            tier_hint=TIER_VERIFIED,
+        )
+        verdict = Verdict(grounded=False, rule="none")
+        assert _assign_tier(verdict, source) == TIER_QUARANTINE
+
+    def test_none_source_overrides_tier_hint(self):
+        verdict = Verdict(grounded=True, rule="R1", offsets=[(0, 5)])
+        assert _assign_tier(verdict, None) == TIER_QUARANTINE
+
+
+# ============================================================
+# Backward compatibility
+# ============================================================
+
+class TestBackwardCompat:
+    def test_docling_provider_unchanged(self):
+        """DoclingSourceProvider returns source='docling', no tier_hint → VERIFIED."""
+        source = SourceText(section_text="text", tables=[], source="docling")
+        assert source.tier_hint is None
+        verdict = Verdict(grounded=True, rule="R1", offsets=[(0, 5)])
+        assert _assign_tier(verdict, source) == TIER_VERIFIED
+
+    def test_source_text_default_tier_hint(self):
+        source = SourceText(section_text="x", tables=[], source="docling")
+        assert source.tier_hint is None

--- a/lavandula/faithfulness/tests/test_regression_fixtures.py
+++ b/lavandula/faithfulness/tests/test_regression_fixtures.py
@@ -241,10 +241,18 @@ class TestTierRegressionFixtures:
         source = SourceText(section_text=source_text, tables=[], source="docling")
         assert _assign_tier(verdict, source) == TIER_QUARANTINE
 
-    def test_ocr_metric_gets_tier_b(self):
+    def test_certified_pdftotext_gets_tier_a(self):
+        """0060: certified pdftotext-repaired → Tier A (verified)."""
         source_text = "Total revenue was $5,000,000."
         verdict = check("Total revenue was $5,000,000", source_text, [])
         source = SourceText(section_text=source_text, tables=[], source="pdftotext-repaired")
+        assert _assign_tier(verdict, source) == TIER_VERIFIED
+
+    def test_scanned_fallback_gets_tier_b(self):
+        """0060: scanned doc with tier_hint → Tier B."""
+        source_text = "Total revenue was $5,000,000."
+        verdict = check("Total revenue was $5,000,000", source_text, [])
+        source = SourceText(section_text=source_text, tables=[], source="docling", tier_hint=TIER_UNVERIFIED_OCR)
         assert _assign_tier(verdict, source) == TIER_UNVERIFIED_OCR
 
     def test_missing_source_gets_tier_c(self):

--- a/lavandula/migrations/parse/0060_pdftotext.sql
+++ b/lavandula/migrations/parse/0060_pdftotext.sql
@@ -1,0 +1,47 @@
+-- Spec 0060: Parse Fidelity Verification & pdftotext Repair
+-- Operator-run migration. Apply on RDS via psql.
+--
+-- New table: lava_parse.pdftotext — stores pdftotext-extracted text per document
+-- New columns on lava_parse.documents — fidelity scores and text source classification
+
+BEGIN;
+
+-- New table for pdftotext output
+CREATE TABLE IF NOT EXISTS lava_parse.pdftotext (
+    content_sha256    TEXT PRIMARY KEY,
+    pdftotext_version TEXT NOT NULL,
+    full_text         TEXT NOT NULL,
+    char_count        INTEGER NOT NULL,
+    extracted_at      TIMESTAMPTZ DEFAULT now()
+);
+
+-- Fidelity scoring and classification columns on documents
+ALTER TABLE lava_parse.documents
+    ADD COLUMN IF NOT EXISTS pdftotext_coverage  NUMERIC,
+    ADD COLUMN IF NOT EXISTS pdftotext_reverse   NUMERIC,
+    ADD COLUMN IF NOT EXISTS text_source         TEXT;
+
+-- Index for batch runner queries (find docs not yet extracted)
+CREATE INDEX IF NOT EXISTS idx_pdftotext_sha
+    ON lava_parse.pdftotext (content_sha256);
+
+-- Index for filtering by text_source classification
+CREATE INDEX IF NOT EXISTS idx_documents_text_source
+    ON lava_parse.documents (text_source)
+    WHERE text_source IS NOT NULL;
+
+-- Grants for application user
+GRANT SELECT, INSERT, UPDATE ON lava_parse.pdftotext TO research_app;
+
+COMMIT;
+
+-- ============================================================
+-- ROLLBACK (run manually if needed)
+-- ============================================================
+-- BEGIN;
+-- DROP TABLE IF EXISTS lava_parse.pdftotext;
+-- ALTER TABLE lava_parse.documents
+--     DROP COLUMN IF EXISTS pdftotext_coverage,
+--     DROP COLUMN IF EXISTS pdftotext_reverse,
+--     DROP COLUMN IF EXISTS text_source;
+-- COMMIT;

--- a/lavandula/reports/async_crawler.py
+++ b/lavandula/reports/async_crawler.py
@@ -418,6 +418,28 @@ async def _download_worker(
             download_queue.task_done()
 
 
+def _run_pdftotext_inline(engine, sha: str, body: bytes) -> None:
+    """Sync helper for inline pdftotext extraction (Spec 0060)."""
+    from lavandula.faithfulness.pdftotext_extract import extract_text
+    from sqlalchemy import text as sa_text
+
+    result = extract_text(body)
+    if result.failed:
+        return
+    with engine.begin() as conn:
+        conn.execute(sa_text("""
+            INSERT INTO lava_parse.pdftotext
+                (content_sha256, pdftotext_version, full_text, char_count)
+            VALUES (:sha, :version, :text, :chars)
+            ON CONFLICT (content_sha256) DO NOTHING
+        """), {
+            "sha": sha,
+            "version": result.version,
+            "text": result.text,
+            "chars": result.char_count,
+        })
+
+
 async def _process_download(
     *,
     ein: str,
@@ -493,6 +515,17 @@ async def _process_download(
     except Exception as exc:  # noqa: BLE001
         extract_status = "server_error"
         extract_note = sanitize(str(exc))
+
+    # 0060: inline pdftotext extraction — best-effort, never blocks crawl
+    try:
+        loop = asyncio.get_running_loop()
+        await loop.run_in_executor(
+            pdf_thread_pool,
+            _run_pdftotext_inline, db_actor._engine, outcome.content_sha256, outcome.body,
+        )
+    except Exception:  # noqa: BLE001
+        _log.debug("pdftotext inline failed sha=%s, backfill will catch it",
+                   outcome.content_sha256[:16] if outcome.content_sha256 else "?")
 
     import datetime
     archive_metadata = {

--- a/lavandula/reports/crawler.py
+++ b/lavandula/reports/crawler.py
@@ -222,6 +222,22 @@ def _close_thread_clients() -> None:
         _thread_clients.clear()
 
 
+def _store_pdftotext_inline(engine: Engine, sha: str, result) -> None:
+    """Best-effort store of pdftotext result during crawl (Spec 0060)."""
+    with engine.begin() as conn:
+        conn.execute(text("""
+            INSERT INTO lava_parse.pdftotext
+                (content_sha256, pdftotext_version, full_text, char_count)
+            VALUES (:sha, :version, :text, :chars)
+            ON CONFLICT (content_sha256) DO NOTHING
+        """), {
+            "sha": sha,
+            "version": result.version,
+            "text": result.text,
+            "chars": result.char_count,
+        })
+
+
 def process_org(
     *,
     ein: str,
@@ -368,6 +384,16 @@ def process_org(
         except Exception as exc:  # noqa: BLE001
             extract_status = "server_error"
             extract_note = sanitize(str(exc))
+
+        # 0060: inline pdftotext extraction — best-effort, never blocks crawl
+        try:
+            from lavandula.faithfulness.pdftotext_extract import extract_text as _extract_pdftotext
+            _pt_result = _extract_pdftotext(outcome.body)
+            if not _pt_result.failed:
+                _store_pdftotext_inline(engine, outcome.content_sha256, _pt_result)
+        except Exception:  # noqa: BLE001
+            log.debug("pdftotext inline failed sha=%s, backfill will catch it",
+                      outcome.content_sha256[:16] if outcome.content_sha256 else "?")
 
         archive_metadata = {
             "source-url": outcome.final_url or cand.url,

--- a/locard/operations/0057-failure-catalog.md
+++ b/locard/operations/0057-failure-catalog.md
@@ -1,0 +1,123 @@
+# 0057 Failure Catalog — Faithfulness Verification (p20-v1)
+
+**Run:** p20-v1 (run 10) · **Date:** 2026-05-30 · **Elapsed:** 1,419s (~24 min)
+**Docs:** 3,242 processed, 8 missing source
+
+## Summary
+
+| | Total | Tier A (Verified) | Tier C (Quarantine) |
+|---|---|---|---|
+| **Metrics** | 68,772 | 56,385 (82.0%) | 12,387 (18.0%) |
+| **Stories** | 10,697 | 7,632 (71.4%) | 3,065 (28.6%) |
+
+**2,164 docs** have at least one quarantined metric. 8 docs had no parsed source at all (151 metrics).
+
+## Quarantined Metric Categories (n=300 sample → projected)
+
+| Category | Sample % | Projected Count | Fix | Owner |
+|---|---|---|---|---|
+| **Near-contiguous (≥80%)** | 48.5% | ~6,010 | Docling fragmentation — snippet is faithful but parser split layout | 0060 pdftotext repair |
+| **Partial match (40-80%)** | 49.0% | ~6,070 | Mix of fragmentation + minor LLM reformatting | 0060 + prompt tune |
+| **Low match (<40%)** | 2.0% | ~248 | Heavily rewritten, table dumps, or missing source | Prompt tune |
+| **Missing source** | — | 151 | Doc never parsed (stalled run 30 queue) | Resume parse |
+
+### Key finding
+
+**True LLM fabrication/paraphrase is rare (~2%).** The dominant failure mode is Docling splitting designed-layout hero stats into separate sections. The LLM correctly reassembled what was on the page — the snippet IS faithful to the document — but our verifier can't confirm it because the parsed text is fragmented.
+
+## Category Details + Examples
+
+### 1. Near-Contiguous (≥80% longest run) — ~6,010 metrics
+
+The snippet is almost entirely present as a contiguous span in the source text, but a small prefix or suffix breaks the match. Typically: a **number or label** that Docling placed in a different section from the rest of the sentence.
+
+```
+snippet: "66 Tons, or 132,843 pounds, of EPS (block Styrofoam) recycled"
+matched: "tons, or 132,843 pounds, of eps (block styrofoam) recycled"
+missing: "66" (number in a separate designed callout)
+
+snippet: "85% of clients in our Career Development Services demonstrated improvement..."
+matched: "of clients in our career development services demonstrated improvement..."
+missing: "85%" (hero stat number separated from body text)
+
+snippet: "Have been determined by a health care professional to be up-to-date on all immunizations [220 Children]"
+matched: "have been determined by a health care professional to be up-to-date on all immunizations"
+missing: "[220 Children]" (count in a separate layout element)
+```
+
+**Pattern:** The number or bracket-label lives in a designed callout that Docling parses as its own section. The descriptive text is in a body paragraph. The LLM correctly paired them.
+
+**Fix:** 0060 pdftotext repair reads the page in visual order, preserving these pairings. Once 0060 provides the source text, these will verify as Tier A.
+
+### 2. Partial Match (40-80%) — ~6,070 metrics
+
+Significant chunks match, but larger fragments are split or lightly reformatted. Often the number AND some context words are separated.
+
+```
+snippet: "More than 3,600 meals were served to food-insecure children."
+matched: "meals were served to food-insecure children."
+missing: "More than 3,600" (hero stat headline)
+
+snippet: "43 CHILDREN SERVED"
+matched: "43 children"
+missing: "served" (label split into a different section/heading)
+
+snippet: "$18,601.75 WORTH OF TOYS AND ESSENTIAL ITEMS RAISED FROM OUR AMAZON PRIME DAY CAMPAIGN"
+matched: "items raised from our amazon prime day campaign"
+missing: "$18,601.75 worth of toys and essential" (designed callout text)
+```
+
+**Pattern:** Same root cause as near-contiguous, but the designed layout fragmented more aggressively (number + descriptor in separate elements). Some cases include minor LLM word additions ("More than").
+
+**Fix:** Primarily 0060 pdftotext repair. After that, residual cases where the LLM added words ("More than") will be caught by prompt tuning to enforce verbatim-only spans.
+
+### 3. Low Match (<40%) — ~248 metrics
+
+Genuinely rewritten, table dumps, or content not found in the parsed source at all.
+
+```
+snippet: "Salaries $5,428,348 Fringe $1,964,129 Travel $60,918 Supplies $529,184..."
+analysis: LLM dumped an entire expense table as a single run-on snippet. Only the first item matches.
+
+snippet: "$645,221 from 995 donors"
+analysis: 0% match — content may be in a designed infographic that Docling garbled entirely.
+
+snippet: "6,891 Patients in our Care"  
+analysis: 0% match — likely a hero stat in a custom font that Docling rendered as mojibake (the Make-A-Wish pattern from 0060 spike).
+```
+
+**Fix:** Table dumps → prompt tune (extract individual table metrics, not row dumps). Zero-match/garbled → 0060 pdftotext repair.
+
+### 4. Missing Source — 151 metrics (8 docs)
+
+Documents queued in parse run 30 (which stalled at 23 docs) but never completed. The LLM extraction ran from `classification_context` (first 5 pages), not the full Docling parse.
+
+**Fix:** Resume parse run for these 8 docs. They're still in the work queue.
+
+## Story Failures (n=200 sample)
+
+| Category | Sample % | Projected Count |
+|---|---|---|
+| Fragmented | 35.5% | ~1,080 |
+| Numeric reformat | 64.5% | ~1,975 |
+| Missing source | — | 24 |
+
+Stories have the same root cause: the `source_snippet` field references text that Docling fragmented. The higher quarantine rate (28.6% vs 18.0%) is because story snippets tend to be longer and span more layout elements.
+
+## Projected Impact of Fixes
+
+| Fix | Metrics Rescued | New Rate | Dependency |
+|---|---|---|---|
+| **0060 pdftotext repair** | ~10,000-11,000 | ~96-98% | Spec 0060 |
+| **Prompt tune (verbatim-only)** | ~500-1,000 | +1-2% | Extractor fix |
+| **Resume parse (8 docs)** | ~151 | +0.2% | Parse run |
+| **Combined** | ~12,000+ | **≥99%** | 0060 + prompt tune |
+
+## Conclusion
+
+The 99% Tier-A target in the acceptance criteria **IS reachable**, but it requires 0060 (pdftotext repair) as the primary fix. Prompt tuning alone gets us from 82% to ~84%. The good news: true LLM fabrication/hallucination is extremely rare (~2% of quarantined = ~0.4% of total metrics). The pipeline is faithful — the verifier's parser-fragmented source is the bottleneck.
+
+**Priority order:**
+1. **0060** (parse fidelity / pdftotext repair) — rescues ~80% of quarantined
+2. **Prompt tune** (verbatim-only extraction) — catches the remaining reformat/composition
+3. **Resume parse** (8 docs) — trivial cleanup

--- a/locard/plans/0060-parse-fidelity-verification.md
+++ b/locard/plans/0060-parse-fidelity-verification.md
@@ -1,7 +1,7 @@
 # Plan 0060 — Parse Fidelity Verification & pdftotext Repair
 
 - **Project:** 0060   **Spec:** `locard/specs/0060-parse-fidelity-verification.md` (specified)
-- **Status:** conceived (plan-review incorporated)
+- **Status:** conceived (plan-review + red-team incorporated)
 - **Author:** Architect, 2026-05-30
 
 > Builder-executable plan. pdftotext extraction + fidelity scoring + PdftextSourceProvider + crawler inline hook + backfill batch runner + dashboard integration.
@@ -18,14 +18,16 @@
 ## Phase 1 — pdftotext extractor module (pure, no DB)
 
 `lavandula/faithfulness/pdftotext_extract.py`:
-- `extract_text(pdf_bytes: bytes) -> ExtractResult` — runs `/usr/bin/pdftotext -layout - -` via subprocess, timeout 30s, stdout cap 10MB, strips NUL bytes, returns `ExtractResult(text, version, char_count, is_scanned)`.
+- `extract_text(pdf_bytes: bytes) -> ExtractResult` — runs `/usr/bin/pdftotext -layout - -` via `subprocess.Popen`, timeout 30s, strips NUL bytes, returns `ExtractResult(text, version, char_count, is_scanned)`.
+- **Bounded output read (red-team CRITICAL — Codex):** uses `Popen` + manual `stdout.read(MAX_OUTPUT + 1)` instead of `subprocess.run(stdout=PIPE)` to enforce the 10MB cap without buffering unbounded output in memory. If output exceeds 10MB, the process is killed and the doc is marked `pdftotext_failed`.
 - `is_scanned` = True when output is empty or <50 chars after whitespace strip.
 - `get_pdftotext_version() -> str` — runs `pdftotext -v`, caches result.
 - Fails fast if `/usr/bin/pdftotext` doesn't exist.
+- **SQL injection prevention (red-team CRITICAL — Gemini):** all DB writes use parameterized queries (SQLAlchemy `text()` with `:param` bindings), never string interpolation. pdftotext output is untrusted text treated as a data parameter, never as SQL.
 
-**Tests:** empty PDF → scanned; text-native PDF → non-empty text; timeout on hung subprocess; NUL byte stripped; version string parsed.
+**Tests:** empty PDF → scanned; text-native PDF → non-empty text; timeout on hung subprocess; NUL byte stripped; version string parsed; oversized output (>10MB) → killed + pdftotext_failed.
 
-**Acceptance:** pure module, no DB deps, handles all error cases from spec §8.
+**Acceptance:** pure module, no DB deps, handles all error cases from spec §8. Bounded memory usage.
 
 ## Phase 2 — Fidelity scoring module (pure, no DB)
 
@@ -149,3 +151,5 @@ Phase 1 (extractor) → Phase 2 (fidelity) → Phase 3 (migration, hand to opera
 - Do NOT replace Docling tables — always use Docling tables for R2.
 - The inline crawl hook must be fire-and-forget — never block the crawl on a pdftotext failure.
 - pdftotext stdin mode (`-layout - -`) must be verified to work with poppler 24.02.0 on cloud2.
+- All DB writes of pdftotext output use parameterized queries — never interpolate untrusted text into SQL.
+- Dashboard batch trigger uses POST + CSRF token (Django middleware) + `_log_audit()` — same pattern as all other pipeline controls.

--- a/locard/plans/0060-parse-fidelity-verification.md
+++ b/locard/plans/0060-parse-fidelity-verification.md
@@ -1,7 +1,7 @@
 # Plan 0060 — Parse Fidelity Verification & pdftotext Repair
 
 - **Project:** 0060   **Spec:** `locard/specs/0060-parse-fidelity-verification.md` (specified)
-- **Status:** conceived (plan-review + red-team incorporated)
+- **Status:** planned (plan-review + red-team incorporated; human-approved 2026-05-30)
 - **Author:** Architect, 2026-05-30
 
 > Builder-executable plan. pdftotext extraction + fidelity scoring + PdftextSourceProvider + crawler inline hook + backfill batch runner + dashboard integration.

--- a/locard/plans/0060-parse-fidelity-verification.md
+++ b/locard/plans/0060-parse-fidelity-verification.md
@@ -1,0 +1,139 @@
+# Plan 0060 — Parse Fidelity Verification & pdftotext Repair
+
+- **Project:** 0060   **Spec:** `locard/specs/0060-parse-fidelity-verification.md` (specified)
+- **Status:** conceived (initial draft)
+- **Author:** Architect, 2026-05-30
+
+> Builder-executable plan. pdftotext extraction + fidelity scoring + PdftextSourceProvider + crawler inline hook + backfill batch runner + dashboard integration.
+
+## Key decisions
+
+1. **pdftotext reads from stdin** — `subprocess.run(["/usr/bin/pdftotext", "-layout", "-", "-"], input=pdf_bytes, ...)`. No temp file needed for the inline crawl path. Backfill path uses `NamedTemporaryFile` for S3 downloads.
+2. **Inline crawl hook location:** inject in both `crawler.py` (sync) and `async_crawler.py` (async) right after `fetch_pdf.download()` succeeds, before `archive.put()`. The PDF bytes are already in `outcome.body`.
+3. **Fidelity scoring is a separate step** from extraction — it requires both pdftotext AND Docling sections to exist. The batch runner computes it for docs that have both; the inline path stores pdftotext text only (Docling hasn't run yet at crawl time).
+4. **Word-set tokenizer** reuses 0057's `normalize()` (lowercase → NFC → collapse whitespace) then splits on whitespace, discarding tokens ≤ 1 char. Pure function, shared module.
+5. **Dashboard integration** goes on the existing Faithfulness Gate page — a "pdftotext Backfill" section with a run button and progress, plus a "Re-verify with pdftotext" option on the verify form.
+6. **DDL is operator-run.** Same pattern as 0057.
+
+## Phase 1 — pdftotext extractor module (pure, no DB)
+
+`lavandula/faithfulness/pdftotext_extract.py`:
+- `extract_text(pdf_bytes: bytes) -> ExtractResult` — runs `/usr/bin/pdftotext -layout - -` via subprocess, timeout 30s, stdout cap 10MB, strips NUL bytes, returns `ExtractResult(text, version, char_count, is_scanned)`.
+- `is_scanned` = True when output is empty or <50 chars after whitespace strip.
+- `get_pdftotext_version() -> str` — runs `pdftotext -v`, caches result.
+- Fails fast if `/usr/bin/pdftotext` doesn't exist.
+
+**Tests:** empty PDF → scanned; text-native PDF → non-empty text; timeout on hung subprocess; NUL byte stripped; version string parsed.
+
+**Acceptance:** pure module, no DB deps, handles all error cases from spec §8.
+
+## Phase 2 — Fidelity scoring module (pure, no DB)
+
+`lavandula/faithfulness/fidelity.py`:
+- `word_set(text: str) -> set[str]` — normalize (lowercase → NFC → collapse ws) → split → discard ≤1 char tokens.
+- `coverage(source: set[str], target: set[str]) -> float` — |source ∩ target| / |source|, returns 0.0 if source is empty.
+- `score_fidelity(docling_text: str, pdftotext_text: str) -> FidelityScore` — returns `FidelityScore(forward, reverse)`.
+- `classify_text_source(extract_result, fidelity_score) -> str` — returns `text_native | scanned | pdftotext_failed` per spec §4.3 rules.
+
+**Tests:** known fixture with pre-computed coverage; empty input → 0.0; identical input → 1.0; scanned classification; pdftotext_failed on low coverage (<0.50 both directions).
+
+**Acceptance:** pure, deterministic, no DB deps.
+
+## Phase 3 — Data model migration (operator-run)
+
+`lavandula/migrations/lava_parse/0060_pdftotext.sql`:
+- CREATE TABLE `lava_parse.pdftotext` (content_sha256 TEXT PK, pdftotext_version TEXT NOT NULL, full_text TEXT NOT NULL, char_count INTEGER NOT NULL, extracted_at TIMESTAMPTZ DEFAULT now())
+- ALTER TABLE `lava_parse.documents` ADD COLUMN pdftotext_coverage NUMERIC, ADD COLUMN pdftotext_reverse NUMERIC, ADD COLUMN text_source TEXT
+- GRANT SELECT, INSERT, UPDATE on new table/columns to `research_app`
+- Rollback script included.
+
+**Acceptance:** columns present, existing rows unaffected, backward compatible.
+
+## Phase 4 — PdftextSourceProvider
+
+`lavandula/faithfulness/source_provider.py` — add `PdftextSourceProvider` class alongside existing `DoclingSourceProvider`:
+- Implements `SourceTextProvider` protocol (same interface).
+- Per-document fallback per the spec's decision table (§4.3).
+- Returns pdftotext `full_text` as `section_text`, Docling tables from `lava_parse.tables`, `source = "pdftotext-repaired"`.
+- Falls back to `DoclingSourceProvider` when no pdftotext row or not text_native.
+
+**Tests:** all 10 decision-table rows from spec §4.3; certified doc returns pdftotext text; scanned doc falls back to Docling with Tier B; missing pdftotext falls back to Docling; borderline coverage falls back.
+
+**Acceptance:** provider passes the spec's decision table exhaustively.
+
+## Phase 5 — Backfill batch runner
+
+`lavandula/dashboard/pipeline/management/commands/extract_pdftotext.py`:
+- Args: `[--run-tag TAG] [--limit N] [--sha SHA] [--force] [--force --version-mismatch]`
+- Query docs in `lava_parse.documents` not yet in `lava_parse.pdftotext` (or all with `--force`).
+- For each: download PDF from S3 → `extract_text()` → INSERT into `lava_parse.pdftotext` → if Docling sections exist, `score_fidelity()` → UPDATE `lava_parse.documents` with coverage + text_source.
+- Atomic per-document (single transaction per doc).
+- Progress every 100 docs. Resumable. Failures logged and skipped.
+- `--force` overwrites existing rows. `--version-mismatch` only re-extracts where stored version ≠ current.
+- Isolated TMPDIR (`/tmp/pdftotext-0060/`) for subprocess temp files.
+
+**Tests:** resumable (skip existing); force overwrites; version-mismatch filter; S3 failure skipped; progress callback fires.
+
+**Acceptance:** backfill runner processes all target docs, atomic per-doc, handles all failure modes.
+
+## Phase 6 — Crawler inline hook
+
+Inject pdftotext extraction into both crawlers, right after `fetch_pdf.download()` succeeds:
+
+**`lavandula/reports/crawler.py`** (sync, ~line 350):
+```python
+# After outcome = fetch_pdf.download(...)
+if outcome.status == "ok" and outcome.body:
+    from lavandula.faithfulness.pdftotext_extract import extract_text
+    extract_result = extract_text(outcome.body)
+    # Store in lava_parse.pdftotext (fire-and-forget, don't block crawl on DB failure)
+```
+
+**`lavandula/reports/async_crawler.py`** (async, ~line 440):
+```python
+# Same, wrapped in loop.run_in_executor() for the subprocess call
+```
+
+pdftotext stdin accepts bytes directly — no temp file. The DB write is best-effort (log and continue if it fails, backfill catches it later).
+
+**Tests:** mock subprocess, verify extract called during crawl; DB failure doesn't block crawl.
+
+**Acceptance:** new crawled docs get pdftotext text stored automatically.
+
+## Phase 7 — Dashboard integration
+
+Add to the existing Faithfulness Gate page (`faithfulness.html` + `views.py`):
+- **Backfill section:** "pdftotext Extraction" card with doc count (extracted / total parsed), "Run Backfill" button, progress display.
+- **Re-verify option:** dropdown or toggle on the verify form to select `PdftextSourceProvider` instead of `DoclingSourceProvider`.
+- Status partial endpoint for backfill progress polling.
+
+**Tests:** view renders, backfill button triggers runner, re-verify with pdftotext option works.
+
+**Acceptance:** operator can trigger backfill and re-verify from the dashboard without CLI.
+
+## Phase 8 — End-to-end validation on p20-v1
+
+1. Run backfill over the 3,242 p20-v1 docs.
+2. Run `verify_faithfulness` with `PdftextSourceProvider`.
+3. Compare results to the Docling-source run (82% Tier A).
+4. Verify ≥ 95% Tier A. Verify no regressions (Docling-verified metrics stay verified).
+5. Document results in `locard/operations/0060-validation.md`.
+
+**Acceptance:** spec AC #5 (≥ 95% Tier A) and AC #6 (no regressions) met.
+
+## Build sequence
+
+Phase 1 (extractor) → Phase 2 (fidelity) → Phase 3 (migration, hand to operator) → Phase 4 (provider) → Phase 5 (backfill runner) → Phase 6 (crawler hook) → Phase 7 (dashboard) → Phase 8 (validation). Phases 1 and 2 can proceed in parallel.
+
+## Dependencies & handoffs
+
+- **0057 (faithfulness gate):** already shipped. 0060 plugs in via `SourceTextProvider`.
+- **Operator:** applies Phase 3 migration SQL.
+- **Crawler modification (Phase 6):** touches `crawler.py` and `async_crawler.py` — coordinate if a crawl is running.
+
+## Risks / traps
+
+- Do NOT use sequence alignment for fidelity scoring.
+- Do NOT replace Docling tables — always use Docling tables for R2.
+- The inline crawl hook must be fire-and-forget — never block the crawl on a pdftotext failure.
+- pdftotext stdin mode (`-layout - -`) must be verified to work with poppler 24.02.0 on cloud2.

--- a/locard/plans/0060-parse-fidelity-verification.md
+++ b/locard/plans/0060-parse-fidelity-verification.md
@@ -1,7 +1,7 @@
 # Plan 0060 — Parse Fidelity Verification & pdftotext Repair
 
 - **Project:** 0060   **Spec:** `locard/specs/0060-parse-fidelity-verification.md` (specified)
-- **Status:** conceived (initial draft)
+- **Status:** conceived (plan-review incorporated)
 - **Author:** Architect, 2026-05-30
 
 > Builder-executable plan. pdftotext extraction + fidelity scoring + PdftextSourceProvider + crawler inline hook + backfill batch runner + dashboard integration.
@@ -49,17 +49,23 @@
 
 **Acceptance:** columns present, existing rows unaffected, backward compatible.
 
-## Phase 4 — PdftextSourceProvider
+## Phase 4 — PdftextSourceProvider (with certification logic)
 
 `lavandula/faithfulness/source_provider.py` — add `PdftextSourceProvider` class alongside existing `DoclingSourceProvider`:
 - Implements `SourceTextProvider` protocol (same interface).
-- Per-document fallback per the spec's decision table (§4.3).
-- Returns pdftotext `full_text` as `section_text`, Docling tables from `lava_parse.tables`, `source = "pdftotext-repaired"`.
-- Falls back to `DoclingSourceProvider` when no pdftotext row or not text_native.
+- **Certification logic is first-class** (not just a fallback — it drives the tier decision):
+  - `_is_certified(text_source, forward_coverage, reverse_coverage) -> bool` — returns True only when `text_source = 'text_native'` AND both coverage ≥ 0.50.
+  - `_get_tier_eligibility(text_source, certified) -> str` — returns `"tier_a" | "tier_b" | "unverified_pending" | "quarantine"` per the spec's decision table.
+- Per-document logic per the spec's decision table (§4.3):
+  - Certified → returns pdftotext `full_text` as `section_text`, `source = "pdftotext-repaired"`
+  - Scanned → falls back to Docling, signals Tier B
+  - Uncertified / missing → falls back to Docling, signals `unverified_pending`
+- Tables always come from `lava_parse.tables` (Docling structured data).
+- Low-coverage borderline cases (< 0.50) → deterministically fall back to Docling AND set `text_source = 'pdftotext_failed'` so they're flagged for manual review.
 
-**Tests:** all 10 decision-table rows from spec §4.3; certified doc returns pdftotext text; scanned doc falls back to Docling with Tier B; missing pdftotext falls back to Docling; borderline coverage falls back.
+**Tests:** all 7 decision-table rows from spec §4.3 as parametrized tests; certification function edge cases (exactly 0.50, below 0.50, NULL coverage); tier eligibility mapping exhaustive.
 
-**Acceptance:** provider passes the spec's decision table exhaustively.
+**Acceptance:** provider passes the spec's decision table exhaustively. Certification logic is explicit, testable, and deterministic.
 
 ## Phase 5 — Backfill batch runner
 
@@ -80,25 +86,31 @@
 
 Inject pdftotext extraction into both crawlers, right after `fetch_pdf.download()` succeeds:
 
+**Spec alignment note (Codex review):** the spec says "run pdftotext on the local file before S3 upload." In the current codebase, the S3 archive path never writes a local file — `outcome.body` is bytes in memory streamed directly to S3 via `put_object()`. The `LocalArchive` path does write a temp file, but that's only used in non-S3 mode. Therefore the inline hook uses **stdin mode** (`input=outcome.body`), which is functionally equivalent to "on the local file" and avoids an unnecessary temp file write. The spec's intent (extract before archive, using the same bytes, no re-download) is preserved.
+
 **`lavandula/reports/crawler.py`** (sync, ~line 350):
 ```python
-# After outcome = fetch_pdf.download(...)
+# After outcome = fetch_pdf.download(...), before archive.put()
 if outcome.status == "ok" and outcome.body:
     from lavandula.faithfulness.pdftotext_extract import extract_text
     extract_result = extract_text(outcome.body)
-    # Store in lava_parse.pdftotext (fire-and-forget, don't block crawl on DB failure)
+    # Store in lava_parse.pdftotext — best-effort, don't block crawl on DB failure
+    try:
+        _store_pdftotext(engine, outcome.content_sha256, extract_result)
+    except Exception:
+        log.warning("pdftotext store failed for %s, backfill will catch it", sha[:16])
 ```
 
 **`lavandula/reports/async_crawler.py`** (async, ~line 440):
 ```python
-# Same, wrapped in loop.run_in_executor() for the subprocess call
+# Same logic, subprocess wrapped in loop.run_in_executor()
 ```
 
-pdftotext stdin accepts bytes directly — no temp file. The DB write is best-effort (log and continue if it fails, backfill catches it later).
+pdftotext stdin accepts bytes directly — no temp file needed. The DB write is best-effort: if it fails, the backfill runner (Phase 5) catches it on the next run. The crawl pipeline is never blocked by a pdftotext failure.
 
-**Tests:** mock subprocess, verify extract called during crawl; DB failure doesn't block crawl.
+**Tests:** mock subprocess, verify extract called during crawl; DB failure doesn't block crawl; verify extraction happens before `archive.put()`.
 
-**Acceptance:** new crawled docs get pdftotext text stored automatically.
+**Acceptance:** new crawled docs get pdftotext text stored automatically. Crawl throughput is not degraded (pdftotext adds ~0.1s/doc).
 
 ## Phase 7 — Dashboard integration
 

--- a/locard/projectlist.md
+++ b/locard/projectlist.md
@@ -891,11 +891,11 @@ projects:
   - id: "0060"
     title: "Parse Fidelity Verification & pdftotext Repair"
     summary: "Verify the extracted text is true to the source PDF — don't trust the parser, check it. Cross-check Docling output against the PDF's embedded text layer via an independent deterministic extractor (pdftotext/poppler, present on cloud2): coverage (Docling dropped nothing) + inverse (Docling invented nothing). The foundation link beneath 0057 — together they form an unbroken PDF->text->snippet->published chain of custody."
-    status: specified
+    status: implementing
     priority: high
     files:
-      spec: null
-      plan: null
+      spec: locard/specs/0060-parse-fidelity-verification.md
+      plan: locard/plans/0060-parse-fidelity-verification.md
       review: null
     dependencies: []
     tags: [pipeline, parse, quality, verification, integrity]

--- a/locard/projectlist.md
+++ b/locard/projectlist.md
@@ -852,7 +852,7 @@ projects:
   - id: "0057"
     title: "LLM Extraction Faithfulness Verification (Snippet Grounding)"
     summary: "Verification pass that runs after the LLM metric/story extraction. Confirms every source_snippet — and the metric value/unit tied to it — appears verbatim (character-for-character) in the parsed source document text, so we can prove zero hallucination/fabrication. Quarantines or flags any LLM output not grounded in the source."
-    status: implementing
+    status: committed
     priority: high
     files:
       spec: locard/specs/0057-llm-faithfulness-verification.md

--- a/locard/projectlist.md
+++ b/locard/projectlist.md
@@ -889,9 +889,9 @@ projects:
     notes: "Added 2026-05-29. Use MAINTAIN protocol. CANDIDATES (UNVERIFIED — confirm nothing still reads each before dropping): (1) lava_vocab.metric_observations — the statistical/market-basket 'first attempt' per-doc extractor (extract_metrics.py); produced ~750 noisy observations for ONE Think New Mexico doc (a Library of Congress photo-catalog number became 5 'metrics'); superseded by llm_metrics. (2) fixture extraction_runs (run 8 fixture-bgcsm2, run 11 fixture-cancare-split) + their rows. (3) stale TestFetchWorkBatch tests (assert a removed fetch_work_batch API: retry_errors/reparse/min_version params). (4) legacy non-queue worker path in worker.py (advisory-lock _run_loop) if single-instance mode is retired. KEEP (do NOT deprecate): the statistical DISCOVERY pipeline (extract_terms / discover_archetypes / keyness) — still the right tool for vocabulary/archetype discovery per the discovery-vs-extraction lesson; only the stat EXTRACTION (metric_observations) is dead. DISCIPLINE: read-only inventory first (what writes/reads each artifact); nothing deleted without verification + operator confirmation; table drops are operator-run migrations (Claude cannot apply DDL)."
 
   - id: "0060"
-    title: "Parse Fidelity Verification (Docling output vs source PDF)"
+    title: "Parse Fidelity Verification & pdftotext Repair"
     summary: "Verify the extracted text is true to the source PDF — don't trust the parser, check it. Cross-check Docling output against the PDF's embedded text layer via an independent deterministic extractor (pdftotext/poppler, present on cloud2): coverage (Docling dropped nothing) + inverse (Docling invented nothing). The foundation link beneath 0057 — together they form an unbroken PDF->text->snippet->published chain of custody."
-    status: conceived
+    status: specified
     priority: high
     files:
       spec: null

--- a/locard/specs/0060-parse-fidelity-verification.md
+++ b/locard/specs/0060-parse-fidelity-verification.md
@@ -1,7 +1,7 @@
 # Spec 0060 — Parse Fidelity Verification & pdftotext Repair
 
 - **Project:** 0060
-- **Status:** conceived (multi-agent review + red-team incorporated)
+- **Status:** specified (multi-agent review + red-team incorporated; human-approved 2026-05-30)
 - **Depends on:** none (0057 consumes 0060's output via SourceTextProvider)
 - **Author:** Architect, 2026-05-30
 

--- a/locard/specs/0060-parse-fidelity-verification.md
+++ b/locard/specs/0060-parse-fidelity-verification.md
@@ -1,0 +1,170 @@
+# Spec 0060 — Parse Fidelity Verification & pdftotext Repair
+
+- **Project:** 0060
+- **Status:** conceived (initial draft)
+- **Depends on:** none (0057 consumes 0060's output via SourceTextProvider)
+- **Author:** Architect, 2026-05-30
+
+> Link 1 of the integrity chain: verify the parsed text is true to the source PDF. Together with 0057 (link 2: snippet grounded in parsed text), forms an unbroken PDF → text → snippet → published chain of custody.
+
+---
+
+## 1. Problem & Motivation
+
+Docling produces structured text (sections + tables) from PDF documents. We trust this text as ground truth for all downstream extraction and verification. But Docling has two failure modes discovered in spikes:
+
+1. **Layout fragmentation** — designed-layout hero stats (the highest-value content on impact reports) get split across sections. "5,330 Served at the Y in 2022" becomes "5,330" in one section and "Served at the Y in 2022" in another. This is the **primary cause of 0057 quarantine** (97% of the 12,387 quarantined metrics in the p20-v1 failure catalog).
+
+2. **Font garble** — custom/subsetted display fonts render as mojibake (e.g., "o;u ƐƏķƕƏƏ wishes sin1e ƐƖѶƒ" = "over 10,700 wishes since 1983"). pdftotext reads these correctly by applying the font's ToUnicode map. Garbled hero stats are silently dropped by the LLM (incomplete, not wrong) — a recall loss on the most valuable content.
+
+**Evidence:**
+- n=1,500 sample: 99.3% text-native (verifiable), 0.3% scanned (Tier B), 0.3% pdftotext-suspect
+- Word-set coverage (Docling vs pdftotext): mean 0.938, median 0.964, but a left tail — 15.6% of docs < 0.90, 2.3% < 0.70
+- Reverse coverage: mean 0.988 — Docling rarely invents content; it drops
+- 0057 failure catalog: 82% metrics verified, 18% quarantined. Of quarantined, ~97% are Docling fragmentation/garble. True LLM fabrication is ~0.4% of total metrics
+- **Projected impact:** 0060 pdftotext repair rescues ~10,000 of 12,387 quarantined metrics, pushing the verified rate from 82% toward 96-98%
+
+## 2. Scope
+
+**0060 delivers:**
+1. **pdftotext extraction** — run pdftotext against S3-archived PDFs, store the raw text in a new `lava_parse.pdftotext` table
+2. **Fidelity scoring** — bidirectional word-set coverage (Docling vs pdftotext) per document, stored in `lava_parse.documents`
+3. **PdftextSourceProvider** — a new `SourceTextProvider` implementation that returns pdftotext text instead of Docling sections, plugging into 0057's existing interface
+4. **Text-native / scanned classification** — flag each document as text-native (has embedded text layer) or scanned (OCR-only), feeding 0057's Tier A vs Tier B decision
+5. **Batch runner** — management command to run pdftotext extraction + fidelity scoring over the corpus
+
+**Non-goals:**
+- Replacing Docling entirely (Docling's section structure + tables are valuable; pdftotext provides flat text)
+- OCR cross-checking for scanned documents (residual-risk minority, <1% of corpus)
+- Modifying the 0057 verifier logic (0060 swaps the source text; 0057's grounding rules are unchanged)
+
+## 3. The Integrity Chain (updated)
+
+```
+PDF ─[0060: pdftotext fidelity check]→ certified text ─[0057: deterministic grounding]→ metric/story ─[disclosure]→ published
+```
+
+0060 certifies link 1 by providing **two things to 0057:**
+- The pdftotext text (a more faithful rendering of the PDF for grounding)
+- A certification flag (text-native vs scanned) that determines Tier A vs Tier B
+
+## 4. Requirements
+
+### 4.1 pdftotext extraction
+
+For each document in the corpus (by `content_sha256`):
+1. Download the PDF from S3 (`s3://lavandula-nonprofit-collaterals/pdfs/{sha}.pdf`)
+2. Run `pdftotext -layout {pdf_path} -` to extract the embedded text layer
+3. Store the full text in `lava_parse.pdftotext` keyed by `content_sha256`
+4. If pdftotext produces zero or near-zero output (<50 chars) on a PDF with pages, classify as **scanned** (no embedded text layer)
+
+**pdftotext is deterministic:** same PDF + same pdftotext version → identical output. No AI, no model, no randomness.
+
+### 4.2 Fidelity scoring
+
+For each text-native document, compute:
+- **Forward coverage** (Docling → pdftotext): fraction of Docling word-set present in pdftotext output. Catches Docling **invention** (words Docling produced that aren't in the PDF).
+- **Reverse coverage** (pdftotext → Docling): fraction of pdftotext word-set present in Docling output. Catches Docling **omission** (content in the PDF that Docling dropped).
+
+Both metrics use **word-set membership** (lowercased, whitespace-collapsed), NOT sequence alignment. Sequence alignment conflates benign reading-order differences with real content divergence (proven: docs with identical content scored align=0.20 from order alone).
+
+Store per-document scores in `lava_parse.documents`:
+- `pdftotext_coverage` — forward coverage (Docling fidelity to source)
+- `pdftotext_reverse` — reverse coverage (source completeness in Docling)
+- `text_source` enum — `text_native | scanned | pdftotext_failed`
+
+### 4.3 PdftextSourceProvider
+
+A new `SourceTextProvider` implementation for 0057's faithfulness gate:
+- Returns pdftotext text (from `lava_parse.pdftotext`) as the `section_text`
+- Returns Docling tables (from `lava_parse.tables`) as-is — pdftotext doesn't produce structured tables
+- Sets `source = "pdftotext-repaired"` so 0057 records which text it grounded against
+- Falls back to `DoclingSourceProvider` if no pdftotext text exists
+
+**Certification rule:** a document is **certified** (eligible for Tier A in 0057) when:
+- `text_source = 'text_native'`
+- pdftotext text exists and is non-empty
+- Forward AND reverse coverage are both ≥ 0.50 (both parsers produced meaningful output)
+
+Uncertified documents (scanned, failed, or extremely low coverage) get `unverified_pending` in 0057 until manually reviewed or OCR cross-checked.
+
+### 4.4 Data model additions
+
+**New table: `lava_parse.pdftotext`**
+```sql
+content_sha256  TEXT PRIMARY KEY,
+pdftotext_version TEXT NOT NULL,
+full_text       TEXT NOT NULL,
+char_count      INTEGER NOT NULL,
+extracted_at    TIMESTAMPTZ DEFAULT now()
+```
+
+**New columns on `lava_parse.documents`:**
+```sql
+pdftotext_coverage  NUMERIC,     -- forward word-set coverage
+pdftotext_reverse   NUMERIC,     -- reverse word-set coverage
+text_source         TEXT,        -- 'text_native' | 'scanned' | 'pdftotext_failed'
+```
+
+### 4.5 Batch runner
+
+Management command: `python3 manage.py extract_pdftotext [--run-tag TAG] [--limit N] [--sha SHA]`
+
+1. Query corpus for documents not yet in `lava_parse.pdftotext`
+2. For each: download PDF from S3 → run pdftotext → store text → compute fidelity scores → update `documents`
+3. Progress reporting (every 100 docs)
+4. Resumable (skips already-extracted documents)
+5. Dashboard integration: button on the Faithfulness Gate page to trigger a batch run
+
+**Performance:** pdftotext is fast (~0.1s/doc). The bottleneck is S3 download. For 3,242 docs in p20-v1, expect ~10-15 minutes. For full corpus (~100K), a few hours with parallel downloads.
+
+## 5. Integration with 0057
+
+After 0060 runs:
+1. The Faithfulness Gate page shows a "Re-verify with pdftotext" button
+2. Re-running `verify_faithfulness` uses `PdftextSourceProvider` instead of `DoclingSourceProvider`
+3. Previously-quarantined metrics that were quarantined due to Docling fragmentation now verify as Tier A against the pdftotext text
+4. The `grounding_source` field records `"pdftotext-repaired"` so the provenance is clear
+
+**The swap is a config change**, not a code change — 0057's `SourceTextProvider` protocol was designed for this.
+
+## 6. Acceptance Criteria
+
+1. pdftotext text extracted and stored for **100%** of text-native documents in the target run
+2. Fidelity scores computed for all extracted documents
+3. Text-native / scanned classification assigned to all documents
+4. `PdftextSourceProvider` passes the same 102 verifier tests as `DoclingSourceProvider`
+5. Re-running `verify_faithfulness` with `PdftextSourceProvider` on p20-v1 produces **≥ 95% Tier A** metrics (up from 82%)
+6. No regressions: metrics that were Tier A with Docling source remain Tier A with pdftotext source
+7. Per-document fidelity scores available in `lava_parse.documents` for downstream use
+8. Scanned documents correctly classified and routed to `unverified_pending` (not `verified`)
+9. Batch runner is resumable, reports progress, and handles S3 download failures gracefully
+
+## 7. Security & Abuse Considerations
+
+- **PDF input is untrusted**: pdftotext runs on externally-sourced PDFs. Use subprocess with timeout (30s per doc), bounded output size (10MB text cap), and no shell=True.
+- **S3 download**: validate SHA format before constructing S3 key. Stream to temp file, don't hold in memory.
+- **Stored text**: same NUL-byte stripping as the parse worker (PostgreSQL rejects 0x00 in TEXT columns).
+- **No new external access**: pdftotext is a local binary, S3 access uses existing IAM role.
+
+## 8. Failure & Error Scenarios
+
+- **pdftotext crashes/hangs on a PDF** → timeout after 30s, mark `text_source = 'pdftotext_failed'`, continue batch
+- **S3 download fails** → retry once, then skip with error logged, continue batch
+- **pdftotext produces empty output on a multi-page PDF** → classify as `scanned`, not `pdftotext_failed`
+- **Extremely low fidelity score** (< 0.30 both directions) → flag for manual review but don't block
+- **NUL bytes in output** → strip before INSERT (known issue from parse worker)
+
+## 9. Traps to Avoid
+
+- **Do NOT use sequence alignment** for fidelity scoring — it conflates reading-order with content (proven in spike: identical content scored 0.20 alignment from order alone). Use word-set coverage.
+- **Do NOT replace Docling tables** — pdftotext produces flat text with no table structure. Docling tables feed R2 matching in 0057 and must be preserved.
+- **Do NOT treat pdftotext as infallible** — 0.3% of corpus has broken-font issues where pdftotext ALSO fails. The `pdftotext_suspect` category exists.
+- **Do NOT run pdftotext on GPU instances** — it's CPU-only, runs on cloud2.
+
+## 10. Open Questions (plan phase)
+
+- **Parallel S3 downloads** — how many concurrent downloads? (S3 rate limits, memory)
+- **Dashboard UX** — separate page or fold into the existing Faithfulness Gate page?
+- **Coverage threshold for certification** — 0.50 proposed; tune after seeing corpus-wide distribution
+- **Re-extraction trigger** — when Docling is upgraded, should pdftotext re-run? (Probably not — pdftotext is independent of Docling)

--- a/locard/specs/0060-parse-fidelity-verification.md
+++ b/locard/specs/0060-parse-fidelity-verification.md
@@ -41,10 +41,14 @@ Docling produces structured text (sections + tables) from PDF documents. We trus
 ## 3. The Integrity Chain (updated)
 
 ```
-PDF ─[0060: pdftotext fidelity check]→ certified text ─[0057: deterministic grounding]→ metric/story ─[disclosure]→ published
+Crawl ─[0060 inline: pdftotext at archive time]→ certified text in DB
+                                                         ↓
+PDF ─[Docling parse]→ structured sections/tables          ↓
+                                                         ↓
+                              ─[0057: deterministic grounding against pdftotext text]→ metric/story ─[disclosure]→ published
 ```
 
-0060 certifies link 1 by providing **two things to 0057:**
+pdftotext runs at crawl time (no Docling dependency). Fidelity scoring runs after both pdftotext and Docling exist. 0060 provides **two things to 0057:**
 - The pdftotext text (a more faithful rendering of the PDF for grounding)
 - A certification flag (text-native vs scanned) that determines Tier A vs Tier B
 
@@ -52,11 +56,16 @@ PDF ─[0060: pdftotext fidelity check]→ certified text ─[0057: deterministi
 
 ### 4.1 pdftotext extraction
 
-For each document in the corpus (by `content_sha256`):
-1. Download the PDF from S3 (`s3://lavandula-nonprofit-collaterals/pdfs/{sha}.pdf`)
-2. Run `pdftotext -layout {pdf_path} -` to extract the embedded text layer
-3. Store the full text in `lava_parse.pdftotext` keyed by `content_sha256`
-4. If pdftotext produces zero or near-zero output (<50 chars) on a PDF with pages, classify as **scanned** (no embedded text layer)
+**Two paths — inline at crawl time (primary) + backfill for existing corpus:**
+
+**Primary (inline at crawl):** During the crawl pipeline, the PDF bytes are already on disk before S3 upload. Run `pdftotext -layout {pdf_path} -` on the local file at that point — adds ~0.1s per doc, zero S3 download needed. Store the text in `lava_parse.pdftotext` alongside the S3 archive step. All future crawled docs get pdftotext text captured for free.
+
+**Backfill (one-time batch):** For the ~16K+ documents already crawled and archived in S3, a batch runner downloads from S3 and runs pdftotext. This is a one-time catch-up; once complete, the inline path handles all new docs.
+
+In both paths:
+1. Run `pdftotext -layout {pdf_path} -` to extract the embedded text layer
+2. Store the full text in `lava_parse.pdftotext` keyed by `content_sha256`
+3. If pdftotext produces zero or near-zero output (<50 chars) on a PDF with pages, classify as **scanned** (no embedded text layer)
 
 **pdftotext is deterministic:** same PDF + same pdftotext version → identical output. No AI, no model, no randomness.
 
@@ -154,7 +163,7 @@ Located in `lavandula/dashboard/pipeline/management/commands/extract_pdftotext.p
 
 **Resource limits:** per-document subprocess timeout (30s), output capture capped at 10MB, temp file in `/tmp` (not accumulating).
 
-**Performance:** pdftotext is fast (~0.1s/doc). The bottleneck is S3 download. For 3,242 docs in p20-v1, expect ~10-15 minutes. For full corpus (~100K), a few hours with parallel downloads.
+**Performance:** pdftotext is fast (~0.1s/doc). For the inline path, it adds negligible time to the crawl pipeline. For the backfill path, S3 download is the bottleneck: ~16K docs in ~1-2 hours, full corpus (~333K) in ~6-8 hours single-threaded.
 
 ## 5. Integration with 0057
 

--- a/locard/specs/0060-parse-fidelity-verification.md
+++ b/locard/specs/0060-parse-fidelity-verification.md
@@ -1,7 +1,7 @@
 # Spec 0060 — Parse Fidelity Verification & pdftotext Repair
 
 - **Project:** 0060
-- **Status:** conceived (initial draft)
+- **Status:** conceived (multi-agent review incorporated)
 - **Depends on:** none (0057 consumes 0060's output via SourceTextProvider)
 - **Author:** Architect, 2026-05-30
 
@@ -31,7 +31,7 @@ Docling produces structured text (sections + tables) from PDF documents. We trus
 2. **Fidelity scoring** — bidirectional word-set coverage (Docling vs pdftotext) per document, stored in `lava_parse.documents`
 3. **PdftextSourceProvider** — a new `SourceTextProvider` implementation that returns pdftotext text instead of Docling sections, plugging into 0057's existing interface
 4. **Text-native / scanned classification** — flag each document as text-native (has embedded text layer) or scanned (OCR-only), feeding 0057's Tier A vs Tier B decision
-5. **Batch runner** — management command to run pdftotext extraction + fidelity scoring over the corpus
+5. **Batch runner** — management command + dashboard button to run pdftotext extraction + fidelity scoring over the corpus
 
 **Non-goals:**
 - Replacing Docling entirely (Docling's section structure + tables are valuable; pdftotext provides flat text)
@@ -60,13 +60,17 @@ For each document in the corpus (by `content_sha256`):
 
 **pdftotext is deterministic:** same PDF + same pdftotext version → identical output. No AI, no model, no randomness.
 
+**Dependency management:** pdftotext is provided by the `poppler-utils` system package (already installed on cloud2: `pdftotext version 24.02.0`). The extracted `pdftotext_version` column records the binary version per row for reproducibility. No additional installation is needed. If a future environment lacks it, `apt install poppler-utils` is the only prerequisite.
+
 ### 4.2 Fidelity scoring
 
 For each text-native document, compute:
 - **Forward coverage** (Docling → pdftotext): fraction of Docling word-set present in pdftotext output. Catches Docling **invention** (words Docling produced that aren't in the PDF).
 - **Reverse coverage** (pdftotext → Docling): fraction of pdftotext word-set present in Docling output. Catches Docling **omission** (content in the PDF that Docling dropped).
 
-Both metrics use **word-set membership** (lowercased, whitespace-collapsed), NOT sequence alignment. Sequence alignment conflates benign reading-order differences with real content divergence (proven: docs with identical content scored align=0.20 from order alone).
+**Word-set tokenization (precise definition):** lowercase → Unicode NFC → collapse all whitespace to single space → strip → split on whitespace → discard tokens ≤ 1 character. This matches the normalization in 0057's `grounding.normalize()` minus the quote/dash folding (not needed for coverage — we're comparing two machine-produced texts, not human vs machine). Punctuation attached to words is kept (e.g., "$5,000" is one token). Coverage = |A ∩ B| / |A| where A and B are word-sets.
+
+Both metrics use **word-set membership**, NOT sequence alignment. Sequence alignment conflates benign reading-order differences with real content divergence (proven: docs with identical content scored align=0.20 from order alone).
 
 Store per-document scores in `lava_parse.documents`:
 - `pdftotext_coverage` — forward coverage (Docling fidelity to source)
@@ -75,53 +79,75 @@ Store per-document scores in `lava_parse.documents`:
 
 ### 4.3 PdftextSourceProvider
 
-A new `SourceTextProvider` implementation for 0057's faithfulness gate:
-- Returns pdftotext text (from `lava_parse.pdftotext`) as the `section_text`
-- Returns Docling tables (from `lava_parse.tables`) as-is — pdftotext doesn't produce structured tables
-- Sets `source = "pdftotext-repaired"` so 0057 records which text it grounded against
-- Falls back to `DoclingSourceProvider` if no pdftotext text exists
+A new `SourceTextProvider` implementation for 0057's faithfulness gate.
+
+**Fallback logic (per-document, not per-section):**
+1. Look up `lava_parse.pdftotext` for the document's `content_sha256`
+2. If a row exists AND `text_source = 'text_native'` in `lava_parse.documents` → return pdftotext text with `source = "pdftotext-repaired"`
+3. If no pdftotext row exists OR `text_source` is not `text_native` → fall back to `DoclingSourceProvider` (returns Docling text with `source = "docling"`)
+
+**In all cases:** tables come from `lava_parse.tables` (Docling's structured table data). pdftotext produces flat text with no table structure, so Docling tables are always used for R2 matching.
+
+**No mixed-source documents:** a document is either fully pdftotext-sourced or fully Docling-sourced. The `grounding_source` field on each verified fact records which provider was used.
 
 **Certification rule:** a document is **certified** (eligible for Tier A in 0057) when:
 - `text_source = 'text_native'`
 - pdftotext text exists and is non-empty
-- Forward AND reverse coverage are both ≥ 0.50 (both parsers produced meaningful output)
+- Forward AND reverse coverage are both ≥ 0.50 (both parsers produced meaningful output — the threshold is deliberately low to avoid rejecting docs where Docling dropped significant content, which is the exact scenario we want pdftotext to rescue)
 
-Uncertified documents (scanned, failed, or extremely low coverage) get `unverified_pending` in 0057 until manually reviewed or OCR cross-checked.
+**Scanned documents route to Tier B in 0057** (published with OCR label), not `unverified_pending`. This matches the 0057 spec §4.3: Tier B = scanned/image source, published WITH a label. `unverified_pending` is reserved for docs where 0060 hasn't run yet (pdftotext not extracted).
+
+**Borderline cases:**
+- pdftotext exists but coverage < 0.50 in either direction → treat as `pdftotext_failed` (both parsers disagree so severely that neither is trustworthy alone); fall back to Docling; flag for manual review
+- pdftotext exists but Docling sections are missing → use pdftotext text directly; this document was never fully parsed by Docling but has a text layer
+- Docling exists but pdftotext row is missing → use Docling (0060 hasn't processed this doc yet); set `unverified_pending` until 0060 runs
 
 ### 4.4 Data model additions
 
 **New table: `lava_parse.pdftotext`**
 ```sql
-content_sha256  TEXT PRIMARY KEY,
+content_sha256    TEXT PRIMARY KEY,
 pdftotext_version TEXT NOT NULL,
-full_text       TEXT NOT NULL,
-char_count      INTEGER NOT NULL,
-extracted_at    TIMESTAMPTZ DEFAULT now()
+full_text         TEXT NOT NULL,
+char_count        INTEGER NOT NULL,
+extracted_at      TIMESTAMPTZ DEFAULT now()
 ```
 
-**New columns on `lava_parse.documents`:**
+**New columns on `lava_parse.documents` (all nullable, backfilled by the batch runner):**
 ```sql
 pdftotext_coverage  NUMERIC,     -- forward word-set coverage
 pdftotext_reverse   NUMERIC,     -- reverse word-set coverage
 text_source         TEXT,        -- 'text_native' | 'scanned' | 'pdftotext_failed'
 ```
 
+Existing rows remain `NULL` until the batch runner processes them. The `PdftextSourceProvider` treats `NULL text_source` as "not yet processed" and falls back to Docling.
+
+**Migration:** operator-run DDL (same pattern as 0057). Claude produces the SQL; operator applies it. Single-operator DB, no zero-downtime needed.
+
 ### 4.5 Batch runner
 
 Management command: `python3 manage.py extract_pdftotext [--run-tag TAG] [--limit N] [--sha SHA]`
 
-1. Query corpus for documents not yet in `lava_parse.pdftotext`
+Located in `lavandula/dashboard/pipeline/management/commands/extract_pdftotext.py`.
+
+1. Query `lava_parse.documents` for documents not yet in `lava_parse.pdftotext`
 2. For each: download PDF from S3 → run pdftotext → store text → compute fidelity scores → update `documents`
 3. Progress reporting (every 100 docs)
-4. Resumable (skips already-extracted documents)
-5. Dashboard integration: button on the Faithfulness Gate page to trigger a batch run
+4. **Resumable:** skips documents already in `lava_parse.pdftotext` (idempotent at row level)
+5. **Atomic per-document:** each document's pdftotext row + fidelity scores + text_source classification are written in a single transaction. No partial state.
+6. **Partial-failure recovery:** S3 download failures or pdftotext crashes are logged and skipped; the batch continues. Failed documents can be retried with `--sha`.
+7. Dashboard integration: button on the Faithfulness Gate page to trigger a batch run
+
+**Temp file cleanup:** PDF downloads use `tempfile.NamedTemporaryFile(delete=True)` so cleanup is automatic, including on crash. The temp file is created, pdftotext reads it, and it's deleted — no accumulation.
+
+**Resource limits:** per-document subprocess timeout (30s), output capture capped at 10MB, temp file in `/tmp` (not accumulating).
 
 **Performance:** pdftotext is fast (~0.1s/doc). The bottleneck is S3 download. For 3,242 docs in p20-v1, expect ~10-15 minutes. For full corpus (~100K), a few hours with parallel downloads.
 
 ## 5. Integration with 0057
 
 After 0060 runs:
-1. The Faithfulness Gate page shows a "Re-verify with pdftotext" button
+1. The Faithfulness Gate dashboard page shows a "Re-verify with pdftotext" option
 2. Re-running `verify_faithfulness` uses `PdftextSourceProvider` instead of `DoclingSourceProvider`
 3. Previously-quarantined metrics that were quarantined due to Docling fragmentation now verify as Tier A against the pdftotext text
 4. The `grounding_source` field records `"pdftotext-repaired"` so the provenance is clear
@@ -133,27 +159,43 @@ After 0060 runs:
 1. pdftotext text extracted and stored for **100%** of text-native documents in the target run
 2. Fidelity scores computed for all extracted documents
 3. Text-native / scanned classification assigned to all documents
-4. `PdftextSourceProvider` passes the same 102 verifier tests as `DoclingSourceProvider`
+4. `PdftextSourceProvider` returns correct `SourceText` objects (pdftotext text + Docling tables + correct `source` tag)
 5. Re-running `verify_faithfulness` with `PdftextSourceProvider` on p20-v1 produces **≥ 95% Tier A** metrics (up from 82%)
-6. No regressions: metrics that were Tier A with Docling source remain Tier A with pdftotext source
+6. **No regressions:** metrics that were Tier A with Docling source remain Tier A with pdftotext source
 7. Per-document fidelity scores available in `lava_parse.documents` for downstream use
-8. Scanned documents correctly classified and routed to `unverified_pending` (not `verified`)
-9. Batch runner is resumable, reports progress, and handles S3 download failures gracefully
+8. Scanned documents correctly classified and routed to Tier B (not `verified`)
+9. Batch runner is resumable, atomic per-document, reports progress, and handles failures gracefully
+
+**Required test cases:**
+- scanned-vs-text-native classification (empty pdftotext output → scanned; non-empty → text-native)
+- near-empty pdftotext output (<50 chars on multi-page PDF → scanned)
+- pdftotext timeout handling (subprocess killed after 30s → `pdftotext_failed`)
+- NUL-byte stripping (0x00 in pdftotext output stripped before INSERT)
+- word-set coverage correctness on known fixture (pre-computed expected coverage)
+- provider fallback: no pdftotext row → returns Docling text with `source = "docling"`
+- provider certified: pdftotext row exists + text_native → returns pdftotext text with `source = "pdftotext-repaired"`
+- end-to-end rescue: a metric quarantined under Docling source verifies as Tier A under pdftotext source
+- end-to-end no-regression: a metric verified under Docling source remains verified under pdftotext source
+- borderline coverage (<0.50) → falls back to Docling, not pdftotext
 
 ## 7. Security & Abuse Considerations
 
-- **PDF input is untrusted**: pdftotext runs on externally-sourced PDFs. Use subprocess with timeout (30s per doc), bounded output size (10MB text cap), and no shell=True.
-- **S3 download**: validate SHA format before constructing S3 key. Stream to temp file, don't hold in memory.
-- **Stored text**: same NUL-byte stripping as the parse worker (PostgreSQL rejects 0x00 in TEXT columns).
-- **No new external access**: pdftotext is a local binary, S3 access uses existing IAM role.
+- **PDF input is untrusted**: pdftotext runs on externally-sourced PDFs. Use `subprocess.run()` with `timeout=30`, `shell=False`, bounded `stdout` capture (10MB cap via `subprocess.PIPE` + length check). No `shell=True`.
+- **Malformed PDFs causing runaway CPU/disk:** the 30s timeout covers CPU; the 10MB stdout cap covers memory; temp files use `delete=True` for disk. If a PDF causes pdftotext to write excessive temp files internally, the subprocess timeout kills it.
+- **S3 download**: validate SHA format (`^[a-f0-9]{64}$`) before constructing S3 key. Stream to `NamedTemporaryFile`, don't hold full PDF in memory.
+- **Stored text**: strip NUL bytes (0x00) before INSERT — PostgreSQL rejects them in TEXT columns. Same pattern as the parse worker's known fix.
+- **No new external access**: pdftotext is a local binary (`/usr/bin/pdftotext`), S3 access uses existing IAM role. No new network calls.
+- **Temp file cleanup:** `NamedTemporaryFile(delete=True)` ensures cleanup on normal exit, exception, or crash. No manual cleanup needed.
 
 ## 8. Failure & Error Scenarios
 
-- **pdftotext crashes/hangs on a PDF** → timeout after 30s, mark `text_source = 'pdftotext_failed'`, continue batch
+- **pdftotext crashes/hangs on a PDF** → subprocess timeout after 30s, mark `text_source = 'pdftotext_failed'`, continue batch
 - **S3 download fails** → retry once, then skip with error logged, continue batch
-- **pdftotext produces empty output on a multi-page PDF** → classify as `scanned`, not `pdftotext_failed`
-- **Extremely low fidelity score** (< 0.30 both directions) → flag for manual review but don't block
+- **pdftotext produces empty output on a multi-page PDF** → classify as `scanned`, not `pdftotext_failed` (the PDF has pages but no embedded text layer)
+- **pdftotext produces empty output on a zero-page PDF** → classify as `pdftotext_failed` (corrupt PDF)
+- **Extremely low fidelity score** (< 0.50 both directions) → classify as `pdftotext_failed`; flag for manual review but don't block the batch
 - **NUL bytes in output** → strip before INSERT (known issue from parse worker)
+- **pdftotext binary missing** → fail fast at command startup with clear error message ("poppler-utils not installed")
 
 ## 9. Traps to Avoid
 
@@ -161,10 +203,11 @@ After 0060 runs:
 - **Do NOT replace Docling tables** — pdftotext produces flat text with no table structure. Docling tables feed R2 matching in 0057 and must be preserved.
 - **Do NOT treat pdftotext as infallible** — 0.3% of corpus has broken-font issues where pdftotext ALSO fails. The `pdftotext_suspect` category exists.
 - **Do NOT run pdftotext on GPU instances** — it's CPU-only, runs on cloud2.
+- **Do NOT mix sources within a document** — a document is either fully pdftotext-sourced or fully Docling-sourced for grounding purposes. Mixing would make the `grounding_source` field ambiguous.
 
 ## 10. Open Questions (plan phase)
 
 - **Parallel S3 downloads** — how many concurrent downloads? (S3 rate limits, memory)
-- **Dashboard UX** — separate page or fold into the existing Faithfulness Gate page?
-- **Coverage threshold for certification** — 0.50 proposed; tune after seeing corpus-wide distribution
-- **Re-extraction trigger** — when Docling is upgraded, should pdftotext re-run? (Probably not — pdftotext is independent of Docling)
+- **Dashboard UX** — fold into the Faithfulness Gate page (preferred) or separate page?
+- **Coverage threshold tuning** — 0.50 proposed; tune after seeing corpus-wide distribution
+- **Re-extraction trigger** — when pdftotext is upgraded, should we re-run? (Probably yes, unlike Docling upgrades — pdftotext is the ground truth reference)

--- a/locard/specs/0060-parse-fidelity-verification.md
+++ b/locard/specs/0060-parse-fidelity-verification.md
@@ -1,7 +1,7 @@
 # Spec 0060 — Parse Fidelity Verification & pdftotext Repair
 
 - **Project:** 0060
-- **Status:** conceived (multi-agent review incorporated)
+- **Status:** conceived (multi-agent review + red-team incorporated)
 - **Depends on:** none (0057 consumes 0060's output via SourceTextProvider)
 - **Author:** Architect, 2026-05-30
 
@@ -97,10 +97,22 @@ A new `SourceTextProvider` implementation for 0057's faithfulness gate.
 
 **Scanned documents route to Tier B in 0057** (published with OCR label), not `unverified_pending`. This matches the 0057 spec §4.3: Tier B = scanned/image source, published WITH a label. `unverified_pending` is reserved for docs where 0060 hasn't run yet (pdftotext not extracted).
 
-**Borderline cases:**
+**Provider decision table (precise, covers every combination):**
+
+| pdftotext row | text_source | coverage ≥ 0.50 | Docling sections | Provider returns | 0057 tier eligibility |
+|---|---|---|---|---|---|
+| exists | text_native | yes | any | pdftotext text, `source="pdftotext-repaired"` | Tier A (certified) |
+| exists | text_native | no | exist | Docling text, `source="docling"` | `unverified_pending` |
+| exists | scanned | — | exist | Docling text, `source="docling"` | Tier B (OCR label) |
+| exists | scanned | — | missing | None | quarantine |
+| exists | pdftotext_failed | — | exist | Docling text, `source="docling"` | `unverified_pending` |
+| missing | NULL | — | exist | Docling text, `source="docling"` | `unverified_pending` |
+| missing | NULL | — | missing | None | quarantine |
+
+**Borderline cases (narrative):**
 - pdftotext exists but coverage < 0.50 in either direction → treat as `pdftotext_failed` (both parsers disagree so severely that neither is trustworthy alone); fall back to Docling; flag for manual review
 - pdftotext exists but Docling sections are missing → use pdftotext text directly; this document was never fully parsed by Docling but has a text layer
-- Docling exists but pdftotext row is missing → use Docling (0060 hasn't processed this doc yet); set `unverified_pending` until 0060 runs
+- Docling exists but pdftotext row is missing → use Docling (0060 hasn't processed this doc yet); `unverified_pending` until 0060 runs
 
 ### 4.4 Data model additions
 
@@ -177,24 +189,43 @@ After 0060 runs:
 - end-to-end rescue: a metric quarantined under Docling source verifies as Tier A under pdftotext source
 - end-to-end no-regression: a metric verified under Docling source remains verified under pdftotext source
 - borderline coverage (<0.50) → falls back to Docling, not pdftotext
+- malformed PDF handling (pdftotext timeout/crash → `pdftotext_failed`, batch continues)
+- `--force` re-extraction overwrites existing pdftotext row
+- `--force --version-mismatch` only re-extracts version-mismatched rows
+- audit log entry created for dashboard-triggered batch runs
 
 ## 7. Security & Abuse Considerations
 
-- **PDF input is untrusted**: pdftotext runs on externally-sourced PDFs. Use `subprocess.run()` with `timeout=30`, `shell=False`, bounded `stdout` capture (10MB cap via `subprocess.PIPE` + length check). No `shell=True`.
-- **Malformed PDFs causing runaway CPU/disk:** the 30s timeout covers CPU; the 10MB stdout cap covers memory; temp files use `delete=True` for disk. If a PDF causes pdftotext to write excessive temp files internally, the subprocess timeout kills it.
-- **S3 download**: validate SHA format (`^[a-f0-9]{64}$`) before constructing S3 key. Stream to `NamedTemporaryFile`, don't hold full PDF in memory.
+- **PDF input is untrusted**: pdftotext runs on externally-sourced PDFs. Use `subprocess.run()` with `timeout=30`, `shell=False`, bounded `stdout` capture (10MB cap via `subprocess.PIPE` + length check). No `shell=True`. Use the **absolute path** `/usr/bin/pdftotext` (not a bare `pdftotext` PATH lookup) to prevent path injection.
+- **Subprocess isolation (red-team CRITICAL — Codex):** pdftotext runs as a subprocess on cloud2 processing untrusted PDFs. Full container isolation is disproportionate for this single-operator system with no multi-tenant exposure. Mitigations: (a) `subprocess.run()` with `timeout=30` kills runaway processes; (b) `shell=False` prevents injection; (c) absolute binary path prevents PATH hijacking; (d) temp files in a dedicated subdirectory (`/tmp/pdftotext-0060/`) with `NamedTemporaryFile(delete=True)`; (e) set `TMPDIR` env var for the subprocess to the same isolated directory, bounding internal temp file writes; (f) `ulimit` on the subprocess is a plan-phase detail if needed. The operator runs this system; there is no untrusted user access to the dashboard.
+- **Malformed PDFs causing runaway CPU/disk:** the 30s timeout covers CPU; the 10MB stdout cap covers memory; the isolated `TMPDIR` bounds disk writes. If pdftotext writes excessive internal temp files, timeout kills it and `TMPDIR` is cleaned up.
+- **S3 download**: validate SHA format (`^[a-f0-9]{64}$`) before constructing S3 key. Stream to `NamedTemporaryFile`, don't hold full PDF in memory. S3 bucket has versioning enabled and IAM least-privilege access.
 - **Stored text**: strip NUL bytes (0x00) before INSERT — PostgreSQL rejects them in TEXT columns. Same pattern as the parse worker's known fix.
 - **No new external access**: pdftotext is a local binary (`/usr/bin/pdftotext`), S3 access uses existing IAM role. No new network calls.
-- **Temp file cleanup:** `NamedTemporaryFile(delete=True)` ensures cleanup on normal exit, exception, or crash. No manual cleanup needed.
+- **Temp file cleanup:** `NamedTemporaryFile(delete=True)` in the isolated `TMPDIR` ensures cleanup on normal exit, exception, or crash.
+- **Dashboard authorization (red-team HIGH — Gemini):** the dashboard is behind Tailscale VPN + Django login. Only the operator (`ron`) has access. The batch runner button uses the same `LoginRequiredMixin` + `_log_audit()` pattern as all other pipeline controls. No additional RBAC is needed for this single-operator system.
+- **stderr sanitization:** capture `stderr` from pdftotext but do NOT log raw stderr to user-facing surfaces. Log to the server log only, where it's available for debugging but not exposed.
+- **Version exposure (red-team HIGH — Gemini):** `pdftotext_version` in the DB is internal (not exposed via API or public surfaces). It serves reproducibility. Keep `poppler-utils` patched per standard system maintenance.
 
 ## 8. Failure & Error Scenarios
 
 - **pdftotext crashes/hangs on a PDF** → subprocess timeout after 30s, mark `text_source = 'pdftotext_failed'`, continue batch
 - **S3 download fails** → retry once, then skip with error logged, continue batch
-- **pdftotext produces empty output on a multi-page PDF** → classify as `scanned`, not `pdftotext_failed` (the PDF has pages but no embedded text layer)
+- **pdftotext produces empty output on a multi-page PDF** → classify as `scanned`, not `pdftotext_failed` (the PDF has pages but no embedded text layer). Page count determined from `lava_parse.documents.page_count` (set by Docling parse).
 - **pdftotext produces empty output on a zero-page PDF** → classify as `pdftotext_failed` (corrupt PDF)
+- **Whitespace-only output** → treated as empty (classify as `scanned` or `pdftotext_failed` per page count)
 - **Extremely low fidelity score** (< 0.50 both directions) → classify as `pdftotext_failed`; flag for manual review but don't block the batch
 - **NUL bytes in output** → strip before INSERT (known issue from parse worker)
+- **Encrypted/password-protected PDFs** → pdftotext returns empty or error; classify as `pdftotext_failed`
+
+### 8.1 Version invalidation & re-extraction (red-team HIGH — Codex)
+
+The batch runner's `--force` flag re-extracts documents even if a `lava_parse.pdftotext` row exists. Use cases:
+- **pdftotext upgrade:** `--force --version-mismatch` re-extracts only rows where `pdftotext_version` differs from the current binary version
+- **Known-bad document:** `--sha SHA --force` re-extracts a specific document
+- **Full re-extraction:** `--force` re-extracts all documents (operator decision, not automatic)
+
+The batch runner **always** stores the current `pdftotext_version` on write, so stale versions are detectable. No automatic invalidation — the operator decides when to re-extract. This matches the single-operator model.
 - **pdftotext binary missing** → fail fast at command startup with clear error message ("poppler-utils not installed")
 
 ## 9. Traps to Avoid


### PR DESCRIPTION
## Summary

- **pdftotext extraction module** — runs `/usr/bin/pdftotext -layout` with bounded output (10MB), 30s timeout, NUL-byte stripping, and scanned-vs-text-native classification
- **Fidelity scoring** — bidirectional word-set coverage (Docling vs pdftotext) per document; classifies `text_native | scanned | pdftotext_failed`
- **PdftextSourceProvider** — returns certified pdftotext text for Tier A grounding when coverage ≥ 0.50; falls back to Docling for scanned/uncertified docs with appropriate tier hints
- **Backfill batch runner** — `manage.py extract_pdftotext` with `--force`, `--version-mismatch`, `--sha`, `--limit`, `--run-tag`; resumable, atomic per-document
- **Crawler inline hooks** — pdftotext extraction at crawl time (sync + async), best-effort / never blocks crawl
- **Dashboard integration** — pdftotext stats card, backfill button with progress polling, source provider dropdown on verify form
- **Migration SQL** — new `lava_parse.pdftotext` table + 3 columns on `lava_parse.documents` (operator-run)
- **Updated tier logic** — `_assign_tier` uses `tier_hint` from provider; certified pdftotext → Tier A, scanned → Tier B, uncertified → `unverified_pending`

## Files Changed

### New files (7)
- `lavandula/faithfulness/pdftotext_extract.py` — Phase 1 extractor
- `lavandula/faithfulness/fidelity.py` — Phase 2 scoring
- `lavandula/migrations/parse/0060_pdftotext.sql` — Phase 3 DDL
- `lavandula/dashboard/pipeline/management/commands/extract_pdftotext.py` — Phase 5 batch runner
- `lavandula/faithfulness/tests/test_pdftotext_extract.py` — extractor tests
- `lavandula/faithfulness/tests/test_fidelity.py` — fidelity tests
- `lavandula/faithfulness/tests/test_pdftotext_provider.py` — provider + decision table tests

### Modified files (9)
- `lavandula/faithfulness/source_provider.py` — added `tier_hint` to `SourceText`, added `PdftextSourceProvider`
- `lavandula/faithfulness/gate_runner.py` — updated `_assign_tier` to use `tier_hint`
- `lavandula/reports/crawler.py` — inline pdftotext hook + `_store_pdftotext_inline` helper
- `lavandula/reports/async_crawler.py` — async inline pdftotext hook + `_run_pdftotext_inline` helper
- `lavandula/dashboard/pipeline/views.py` — pdftotext backfill views, stats, provider toggle
- `lavandula/dashboard/pipeline/urls.py` — 2 new URL patterns
- `lavandula/dashboard/pipeline/templates/pipeline/faithfulness.html` — pdftotext section + re-verify dropdown
- `lavandula/faithfulness/tests/test_gate_runner.py` — updated for tier_hint semantics
- `lavandula/faithfulness/tests/test_regression_fixtures.py` — updated pdftotext tier tests

## Test plan

- [x] 163 tests pass (`pytest lavandula/faithfulness/tests/ -v`)
- [x] Extractor: text-native PDF, empty PDF → scanned, NUL-byte stripping, timeout handling, oversized output kill
- [x] Fidelity: word_set tokenization, coverage computation, known fixture, classify_text_source boundary cases
- [x] Provider: all 7 decision-table rows from spec §4.3, certification at boundary, Decimal from DB
- [x] Tier hint: override, ungrounded override, backward compat with DoclingSourceProvider
- [x] Regression fixtures: existing tests updated and passing
- [ ] Operator: apply migration SQL to RDS
- [ ] Operator: run `manage.py extract_pdftotext` on corpus
- [ ] Operator: re-verify with pdftotext provider on p20-v1, confirm ≥ 95% Tier A

🤖 Generated with [Claude Code](https://claude.com/claude-code)